### PR TITLE
fix: use result.error.issues instead of deprecated .errors (Zod v4)

### DIFF
--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -89,7 +89,7 @@ const UserService = {
         const result = registerSchema.safeParse(data);
 
         if (!result.success) {
-            const errors = result.error.errors.reduce((acc, error) => {
+            const errors = result.error.issues.reduce((acc, error) => {
                 const path = error.path[0] as string;
                 if (!acc[path]) {
                     acc[path] = [];


### PR DESCRIPTION
Zod renamed ZodError.errors to ZodError.issues. Build was failing with: Property 'errors' does not exist on type 'ZodError'.