### PR TITLE
feat: UX improvements batch

### DIFF
--- a/src/app/(auth)/profile/page.tsx
+++ b/src/app/(auth)/profile/page.tsx
@@ -22,6 +22,7 @@ const Profile: React.FC = () => {
     const [user, setUser] = useState<UserDTO | null>(null);
     const [priceZone, setPriceZone] = useState<string>('NO2');
     const [priceZoneSaving, setPriceZoneSaving] = useState(false);
+    const [profileLoading, setProfileLoading] = useState(true);
     const [isButtonDisabled, setIsButtonDisabled] = useState(false);
     const [countdown, setCountdown] = useState(0);
     const [verificationCode, setVerificationCode] = useState('');
@@ -53,7 +54,7 @@ const Profile: React.FC = () => {
 
     useEffect(() => {
         if (!isAuthenticated) { router.push('/login'); return; }
-        UserService.getUserProfile().then(u => { setUser(u); setPriceZone(u.priceZone ?? 'NO2'); }).catch(console.error);
+        UserService.getUserProfile().then(u => { setUser(u); setPriceZone(u.priceZone ?? 'NO2'); }).catch(console.error).finally(() => setProfileLoading(false));
         setSensorsLoading(true);
         refreshSensors().catch(console.error).finally(() => setSensorsLoading(false));
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -327,17 +328,28 @@ const Profile: React.FC = () => {
                             <p className="text-xs text-gray-500 mt-0.5">Used on the Electricity page. Norway price zones NO1–NO5.</p>
                         </div>
                         <div className="flex items-center gap-2">
-                            <select
-                                value={priceZone}
-                                onChange={e => handlePriceZoneChange(e.target.value)}
-                                disabled={priceZoneSaving}
-                                className="bg-gray-900/70 border border-gray-700/60 rounded-xl text-gray-200 text-sm px-3 py-2 focus:outline-none focus:border-sky-500 transition-colors disabled:opacity-50"
-                            >
-                                {['NO1', 'NO2', 'NO3', 'NO4', 'NO5'].map(z => (
-                                    <option key={z} value={z}>{z}</option>
-                                ))}
-                            </select>
-                            {priceZoneSaving && <span className="text-xs text-gray-500">Saving…</span>}
+                            {profileLoading ? (
+                                <div className="w-8 h-8 flex items-center justify-center">
+                                    <svg className="animate-spin h-4 w-4 text-sky-500" viewBox="0 0 24 24" fill="none">
+                                        <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                                        <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+                                    </svg>
+                                </div>
+                            ) : (
+                                <>
+                                    <select
+                                        value={priceZone}
+                                        onChange={e => handlePriceZoneChange(e.target.value)}
+                                        disabled={priceZoneSaving}
+                                        className="bg-gray-900/70 border border-gray-700/60 rounded-xl text-gray-200 text-sm px-3 py-2 focus:outline-none focus:border-sky-500 transition-colors disabled:opacity-50"
+                                    >
+                                        {['NO1', 'NO2', 'NO3', 'NO4', 'NO5'].map(z => (
+                                            <option key={z} value={z}>{z}</option>
+                                        ))}
+                                    </select>
+                                    {priceZoneSaving && <span className="text-xs text-gray-500">Saving…</span>}
+                                </>
+                            )}
                         </div>
                     </div>
                 </Section>

--- a/src/app/(auth)/profile/page.tsx
+++ b/src/app/(auth)/profile/page.tsx
@@ -319,6 +319,7 @@ const Profile: React.FC = () => {
                 </Section>
 
                 {/* Settings */}
+                <div id="settings">
                 <Section title="Settings">
                     <div className="flex items-center justify-between">
                         <div>
@@ -340,6 +341,7 @@ const Profile: React.FC = () => {
                         </div>
                     </div>
                 </Section>
+                </div>
             </div>
         </>
     );

--- a/src/app/(auth)/profile/page.tsx
+++ b/src/app/(auth)/profile/page.tsx
@@ -20,6 +20,8 @@ const Profile: React.FC = () => {
     const isAuthenticated = status === 'authenticated';
 
     const [user, setUser] = useState<UserDTO | null>(null);
+    const [priceZone, setPriceZone] = useState<string>('NO2');
+    const [priceZoneSaving, setPriceZoneSaving] = useState(false);
     const [isButtonDisabled, setIsButtonDisabled] = useState(false);
     const [countdown, setCountdown] = useState(0);
     const [verificationCode, setVerificationCode] = useState('');
@@ -51,7 +53,7 @@ const Profile: React.FC = () => {
 
     useEffect(() => {
         if (!isAuthenticated) { router.push('/login'); return; }
-        UserService.getUserProfile().then(setUser).catch(console.error);
+        UserService.getUserProfile().then(u => { setUser(u); setPriceZone(u.priceZone ?? 'NO2'); }).catch(console.error);
         setSensorsLoading(true);
         refreshSensors().catch(console.error).finally(() => setSensorsLoading(false));
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -77,6 +79,16 @@ const Profile: React.FC = () => {
         }
     };
 
+    const handlePriceZoneChange = async (zone: string) => {
+        if (!user?.id) return;
+        setPriceZone(zone);
+        setPriceZoneSaving(true);
+        try {
+            await UserService.updatePreferences(user.id, zone);
+        } catch { /* silent fail — zone is still set locally */ }
+        finally { setPriceZoneSaving(false); }
+    };
+
     const handleConfirmEmail = async () => {
         if (!user) return;
         try {
@@ -91,7 +103,7 @@ const Profile: React.FC = () => {
     };
 
     const handleClaimSensor = async () => {
-        if (!claimCode.trim()) { setClaimMessage('Please enter a registration code.'); setClaimError(true); return; }
+        if (!claimCode.trim()) { setClaimMessage('Please enter a device code.'); setClaimError(true); return; }
         setClaimLoading(true);
         setClaimMessage(null);
         setClaimError(false);
@@ -152,7 +164,7 @@ const Profile: React.FC = () => {
             {confirmDeleteId !== null && confirmSensor && (
                 <ConfirmModal
                     title="Remove sensor"
-                    message={<>Are you sure you want to remove <span className="font-medium text-gray-100">{confirmSensor.customName ?? confirmSensor.defaultName}</span> from your account? You can re-add it later using the registration code.</>}
+                    message={<>Are you sure you want to remove <span className="font-medium text-gray-100">{confirmSensor.customName ?? confirmSensor.defaultName}</span> from your account? You can re-add it later using the device code.</>}
                     confirmLabel="Remove"
                     onConfirm={handleUnclaimSensor}
                     onCancel={() => setConfirmDeleteId(null)}
@@ -219,13 +231,13 @@ const Profile: React.FC = () => {
 
                 {/* Claim Sensor */}
                 <Section title="Add a device">
-                    <p className="text-sm text-gray-400 mb-3">Enter the registration code found on your device to add it to your account.</p>
+                    <p className="text-sm text-gray-400 mb-3">Enter the device code for your sensor to add it to your account.</p>
                     <div className="flex gap-2">
                         <input
                             type="text"
                             value={claimCode}
                             onChange={e => setClaimCode(e.target.value)}
-                            placeholder="Registration code"
+                            placeholder="Device code"
                             className={inputClass}
                             disabled={claimLoading}
                         />
@@ -287,7 +299,7 @@ const Profile: React.FC = () => {
                                             </div>
                                             <div className="space-y-0.5 mb-4">
                                                 <p className="text-xs text-gray-400">Type: {sensor.type}</p>
-                                                <p className="text-xs text-gray-500">Code: {sensor.registrationCode}</p>
+                                        <p className="text-xs text-gray-500">Device code: {sensor.registrationCode}</p>
                                                 {sensor.customName && <p className="text-xs text-gray-500">Default: {sensor.defaultName}</p>}
                                             </div>
                                             <button
@@ -304,6 +316,29 @@ const Profile: React.FC = () => {
                             ))}
                         </div>
                     )}
+                </Section>
+
+                {/* Settings */}
+                <Section title="Settings">
+                    <div className="flex items-center justify-between">
+                        <div>
+                            <p className="text-sm text-gray-100 font-medium">Electricity price zone</p>
+                            <p className="text-xs text-gray-500 mt-0.5">Used on the Electricity page. Norway price zones NO1–NO5.</p>
+                        </div>
+                        <div className="flex items-center gap-2">
+                            <select
+                                value={priceZone}
+                                onChange={e => handlePriceZoneChange(e.target.value)}
+                                disabled={priceZoneSaving}
+                                className="bg-gray-900/70 border border-gray-700/60 rounded-xl text-gray-200 text-sm px-3 py-2 focus:outline-none focus:border-sky-500 transition-colors disabled:opacity-50"
+                            >
+                                {['NO1', 'NO2', 'NO3', 'NO4', 'NO5'].map(z => (
+                                    <option key={z} value={z}>{z}</option>
+                                ))}
+                            </select>
+                            {priceZoneSaving && <span className="text-xs text-gray-500">Saving…</span>}
+                        </div>
+                    </div>
                 </Section>
             </div>
         </>

--- a/src/app/DeviceDashboard.tsx
+++ b/src/app/DeviceDashboard.tsx
@@ -106,11 +106,16 @@ const DeviceCard: React.FC<{ device: UnifiedDevice; onClick: () => void }> = ({ 
                 <div className={`w-10 h-10 rounded-xl flex items-center justify-center ${cfg.iconBg}`}>
                     <cfg.Icon className={`h-5 w-5 ${cfg.iconColor}`} />
                 </div>
-                <span className={`w-2 h-2 rounded-full mt-1.5 flex-shrink-0 ${
-                    device.isActive
-                        ? 'bg-green-400 shadow-[0_0_6px_2px_rgba(74,222,128,0.35)]'
-                        : 'bg-gray-600'
-                }`} />
+                <div className="flex items-center gap-1 mt-1.5 flex-shrink-0">
+                    <span className={`w-2 h-2 rounded-full ${
+                        device.isActive
+                            ? 'bg-green-400 shadow-[0_0_6px_2px_rgba(74,222,128,0.35)]'
+                            : 'bg-gray-600'
+                    }`} />
+                    <span className={`text-[10px] font-medium ${device.isActive ? 'text-green-400' : 'text-gray-600'}`}>
+                        {device.isActive ? 'Active' : 'Inactive'}
+                    </span>
+                </div>
             </div>
 
             {/* Name + type */}

--- a/src/app/DeviceDrawer.tsx
+++ b/src/app/DeviceDrawer.tsx
@@ -204,7 +204,9 @@ const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose }) => {
                                 </div>
                                 {health.chargesRecorded > 0 && (
                                     <div className="flex items-center justify-between text-sm">
-                                        <span className="text-gray-500">Charges recorded</span>
+                                        <span className="text-gray-500" title="Number of times the battery has been detected as charged based on voltage rise patterns">
+                                            Charge cycles detected
+                                        </span>
                                         <span className="text-gray-200 font-medium">{health.chargesRecorded}</span>
                                     </div>
                                 )}

--- a/src/app/SetupWizard.tsx
+++ b/src/app/SetupWizard.tsx
@@ -225,7 +225,7 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
                     <div className="space-y-5">
                         <div>
                             <h2 className="text-xl font-bold text-gray-100 mb-1">Add a sensor</h2>
-                            <p className="text-sm text-gray-400">Enter the registration code for your sensor.</p>
+                            <p className="text-sm text-gray-400">Enter the device code for your sensor.</p>
                         </div>
                         <div className="space-y-3">
                             <input

--- a/src/app/automations/page.tsx
+++ b/src/app/automations/page.tsx
@@ -228,9 +228,9 @@ const AutomationsPage: React.FC = () => {
                 </Select>
             </div>
             <div className="flex items-center gap-2 pt-1">
-                <button type="submit" className="gargeBtnActive gargeBtnSmall flex-1">Save</button>
-                <button type="button" className="gargeBtnDisabled gargeBtnSmall flex-1" onClick={cancelEdit}>Cancel</button>
-                <button type="button" className="gargeBtnWarning gargeBtnSmall" onClick={() => handleDelete(rule.id)}>Delete</button>
+                <button type="submit" className="flex-1 px-4 py-2 bg-sky-600 hover:bg-sky-500 active:bg-sky-700 text-white text-sm font-medium rounded-xl transition-all">Save</button>
+                <button type="button" className="flex-1 px-4 py-2 bg-gray-700 hover:bg-gray-600 text-gray-300 text-sm font-medium rounded-xl transition-all" onClick={cancelEdit}>Cancel</button>
+                <button type="button" className="px-4 py-2 bg-rose-600 hover:bg-rose-500 active:bg-rose-700 text-white text-sm font-medium rounded-xl transition-all" onClick={() => handleDelete(rule.id)}>Delete</button>
             </div>
         </form>
     );
@@ -245,7 +245,7 @@ const AutomationsPage: React.FC = () => {
                 <h1 className="text-2xl sm:text-3xl font-bold">Automations</h1>
                 <button
                     onClick={() => setFormOpen(o => !o)}
-                    className="flex items-center gap-1.5 gargeBtnActive gargeBtnSmall"
+                    className="flex items-center gap-1.5 px-4 py-2 bg-sky-600 hover:bg-sky-500 active:bg-sky-700 text-white text-sm font-medium rounded-xl transition-all"
                 >
                     <PlusIcon className="h-4 w-4" />
                     New Rule
@@ -297,8 +297,8 @@ const AutomationsPage: React.FC = () => {
                             </Select>
                         </div>
                         <div className="flex gap-2 pt-1">
-                            <button type="submit" className="gargeBtnActive gargeBtnSmall flex-1">Create</button>
-                            <button type="button" className="gargeBtnDisabled gargeBtnSmall" onClick={() => setFormOpen(false)}>Cancel</button>
+                            <button type="submit" className="flex-1 px-4 py-2 bg-sky-600 hover:bg-sky-500 active:bg-sky-700 text-white text-sm font-medium rounded-xl transition-all">Create</button>
+                            <button type="button" className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-gray-300 text-sm font-medium rounded-xl transition-all" onClick={() => setFormOpen(false)}>Cancel</button>
                         </div>
                     </form>
                 </div>

--- a/src/app/automations/page.tsx
+++ b/src/app/automations/page.tsx
@@ -7,8 +7,10 @@ import SensorService, { Sensor } from '@/services/sensorService';
 import { AutomationRuleDto } from '@/dto/Automation/AutomationRuleDto';
 import { CreateAutomationRuleDto } from '@/dto/Automation/CreateAutomationRuleDto';
 import { UpdateAutomationRuleDto } from '@/dto/Automation/UpdateAutomationRuleDto';
+import { unitForType } from '@/lib/typeUtils';
+import { formatDateTime } from '@/lib/dateUtils';
 import { AxiosError } from 'axios';
-import { PlusIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
+import { PlusIcon } from '@heroicons/react/24/outline';
 
 const initialForm: CreateAutomationRuleDto = {
     targetType: '',
@@ -18,6 +20,7 @@ const initialForm: CreateAutomationRuleDto = {
     condition: '==',
     threshold: 0,
     action: 'on',
+    isEnabled: true,
 };
 
 const conditionOptions = [
@@ -29,17 +32,18 @@ const conditionOptions = [
 ];
 
 const conditionSymbol: Record<string, string> = {
-    '==': '=',
-    '<':  '<',
-    '>':  '>',
-    '<=': '≤',
-    '>=': '≥',
+    '==': '=', '<': '<', '>': '>', '<=': '≤', '>=': '≥',
 };
 
 const actionOptions = [
     { label: 'Turn On',  value: 'on'  },
     { label: 'Turn Off', value: 'off' },
 ];
+
+const formatTriggered = (iso: string | null): string | null => {
+    if (!iso) return null;
+    return formatDateTime(iso);
+};
 
 // ── Field components ──────────────────────────────────────────────────────────
 const FieldLabel: React.FC<{ children: React.ReactNode }> = ({ children }) => (
@@ -133,12 +137,26 @@ const AutomationsPage: React.FC = () => {
         catch (e) { handleError(e, 'Failed to delete automation'); }
     };
 
+    const handleToggleEnabled = async (rule: AutomationRuleDto) => {
+        setError('');
+        try {
+            await AutomationService.updateRule(rule.id, {
+                targetType: rule.targetType, targetId: rule.targetId,
+                sensorType: rule.sensorType, sensorId: rule.sensorId,
+                condition: rule.condition, threshold: rule.threshold,
+                action: rule.action, isEnabled: !rule.isEnabled,
+            });
+            fetchRules();
+        } catch (e) { handleError(e, 'Failed to update automation'); }
+    };
+
     const startEdit = (rule: AutomationRuleDto) => {
         setEditingId(rule.id);
         setEditForm({
             targetType: rule.targetType, targetId: rule.targetId,
             sensorType: rule.sensorType, sensorId: rule.sensorId,
-            condition: rule.condition, threshold: rule.threshold, action: rule.action,
+            condition: rule.condition, threshold: rule.threshold,
+            action: rule.action, isEnabled: rule.isEnabled,
         });
     };
 
@@ -165,6 +183,9 @@ const AutomationsPage: React.FC = () => {
     };
 
     // ── Inline edit form ─────────────────────────────────────────────────────
+    const editSensorObj = sensors.find(s => s.id === editForm?.sensorId);
+    const editUnit = editSensorObj ? unitForType(editSensorObj.type) : '';
+
     const renderEditForm = (rule: AutomationRuleDto) => (
         <form onSubmit={handleUpdate} className="space-y-3 mt-3 pt-3 border-t border-gray-700/50">
             <div>
@@ -195,7 +216,7 @@ const AutomationsPage: React.FC = () => {
                     </Select>
                 </div>
                 <div>
-                    <FieldLabel>Threshold</FieldLabel>
+                    <FieldLabel>Threshold{editUnit ? ` (${editUnit})` : ''}</FieldLabel>
                     <NumberInput value={editForm!.threshold} step="0.1" required
                         onChange={e => setEditForm({ ...editForm!, threshold: Number(e.target.value) })} />
                 </div>
@@ -213,6 +234,10 @@ const AutomationsPage: React.FC = () => {
             </div>
         </form>
     );
+
+    // ── Threshold unit for create form ────────────────────────────────────────
+    const createSensorObj = sensors.find(s => s.id === form.sensorId);
+    const createUnit = createSensorObj ? unitForType(createSensorObj.type) : '';
 
     return (
         <div className="p-4 max-w-7xl mx-auto">
@@ -260,7 +285,7 @@ const AutomationsPage: React.FC = () => {
                                 </Select>
                             </div>
                             <div>
-                                <FieldLabel>Threshold</FieldLabel>
+                                <FieldLabel>Threshold{createUnit ? ` (${createUnit})` : ''}</FieldLabel>
                                 <NumberInput value={form.threshold} step="0.1" placeholder="0" required
                                     onChange={e => setForm({ ...form, threshold: Number(e.target.value) })} />
                             </div>
@@ -294,13 +319,20 @@ const AutomationsPage: React.FC = () => {
                         const sensorObj = sensors.find(s => s.id === rule.sensorId);
                         const isEditing = editingId === rule.id && editForm;
                         const sym = conditionSymbol[rule.condition] ?? rule.condition;
+                        const unit = sensorObj ? unitForType(sensorObj.type) : '';
+                        const triggered = formatTriggered(rule.lastTriggeredAt);
 
                         return (
-                            <div key={rule.id} className="bg-gray-800/60 border border-gray-700/40 rounded-2xl backdrop-blur-sm shadow-lg p-5 flex flex-col">
+                            <div
+                                key={rule.id}
+                                className={`bg-gray-800/60 border rounded-2xl backdrop-blur-sm shadow-lg p-5 flex flex-col transition-opacity ${
+                                    rule.isEnabled ? 'border-gray-700/40' : 'border-gray-700/20 opacity-60'
+                                }`}
+                            >
                                 {/* Rule summary */}
                                 <div className="flex items-start justify-between mb-3">
                                     <div className="flex-1 min-w-0">
-                                        <h3 className="text-base font-semibold text-gray-100 truncate">
+                                        <h3 className={`text-base font-semibold truncate ${rule.isEnabled ? 'text-gray-100' : 'text-gray-400'}`}>
                                             {switchObj?.name ?? `Switch ${rule.targetId}`}
                                         </h3>
                                         <span className={`inline-flex items-center text-xs font-medium mt-1 px-2 py-0.5 rounded-full ${
@@ -311,14 +343,28 @@ const AutomationsPage: React.FC = () => {
                                             Turn {rule.action}
                                         </span>
                                     </div>
-                                    {!isEditing && (
+                                    <div className="flex items-center gap-1 ml-2 flex-shrink-0">
+                                        {/* Enable/disable toggle */}
                                         <button
-                                            className="ml-2 flex-shrink-0 text-xs text-gray-500 hover:text-gray-200 transition-colors px-2 py-1 rounded-lg hover:bg-gray-700/50"
-                                            onClick={() => startEdit(rule)}
+                                            title={rule.isEnabled ? 'Disable rule' : 'Enable rule'}
+                                            onClick={() => handleToggleEnabled(rule)}
+                                            className={`relative w-9 h-5 rounded-full transition-colors focus:outline-none ${
+                                                rule.isEnabled ? 'bg-sky-600' : 'bg-gray-600'
+                                            }`}
                                         >
-                                            Edit
+                                            <span className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${
+                                                rule.isEnabled ? 'translate-x-4' : 'translate-x-0'
+                                            }`} />
                                         </button>
-                                    )}
+                                        {!isEditing && (
+                                            <button
+                                                className="text-xs text-gray-500 hover:text-gray-200 transition-colors px-2 py-1 rounded-lg hover:bg-gray-700/50"
+                                                onClick={() => startEdit(rule)}
+                                            >
+                                                Edit
+                                            </button>
+                                        )}
+                                    </div>
                                 </div>
 
                                 {/* Condition pill */}
@@ -328,8 +374,15 @@ const AutomationsPage: React.FC = () => {
                                         {sensorObj?.customName ?? sensorObj?.defaultName ?? `Sensor ${rule.sensorId}`}
                                     </span>{' '}
                                     <span className="text-sky-400 font-mono">{sym}</span>{' '}
-                                    <span className="text-white font-medium">{rule.threshold}</span>
+                                    <span className="text-white font-medium">{rule.threshold}{unit ? ` ${unit}` : ''}</span>
                                 </div>
+
+                                {/* Last triggered */}
+                                {triggered && (
+                                    <p className="mt-2 text-xs text-gray-500">
+                                        Last triggered: <span className="text-gray-400">{triggered}</span>
+                                    </p>
+                                )}
 
                                 {isEditing && renderEditForm(rule)}
                             </div>

--- a/src/app/electricity/page.tsx
+++ b/src/app/electricity/page.tsx
@@ -61,16 +61,16 @@ const ElectricityPage = () => {
     const [cache, setCache] = useState<Partial<Record<TabKey, { x: number; y: number }[]>>>({});
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
-    const [priceZone, setPriceZone] = useState<string>('NO2');
+    const [priceZone, setPriceZone] = useState<string | null>(null);
 
     useEffect(() => {
         UserService.getUserProfile().then(u => {
-            if (u.priceZone) setPriceZone(u.priceZone);
-        }).catch(() => {});
+            setPriceZone(u.priceZone || 'NO2');
+        }).catch(() => { setPriceZone('NO2'); });
     }, []);
 
     const loadTab = useCallback(async (tab: TabKey) => {
-        if (cache[tab]) return;
+        if (!priceZone || cache[tab]) return;
         setLoading(true);
         setError(null);
         try {
@@ -110,7 +110,12 @@ const ElectricityPage = () => {
                 {/* Header */}
                 <div className="px-5 pt-5 pb-3 flex items-start justify-between">
                     <div>
-                        <h2 className="text-base font-semibold text-gray-100">{priceZone} · NOK / kWh</h2>
+                        <h2 className="text-base font-semibold text-gray-100">
+                            {priceZone
+                                ? <>{priceZone} · NOK / kWh</>
+                                : <span className="inline-block w-24 h-4 bg-gray-700/60 rounded animate-pulse" />
+                            }
+                        </h2>
                         {currentPrice !== null && (
                             <p className="text-xs text-gray-500 mt-0.5">Current hour</p>
                         )}

--- a/src/app/electricity/page.tsx
+++ b/src/app/electricity/page.tsx
@@ -4,6 +4,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import ElectricityService from '@/services/electricityService';
 import UserService from '@/services/userService';
+import Link from 'next/link';
 import dynamic from 'next/dynamic';
 
 const TimeSeriesChart = dynamic(() => import('@/components/TimeSeriesChart'), { ssr: false });
@@ -113,7 +114,7 @@ const ElectricityPage = () => {
                         {currentPrice !== null && (
                             <p className="text-xs text-gray-500 mt-0.5">Current hour</p>
                         )}
-                        <p className="text-xs text-gray-600 mt-1">Norwegian price zone · change in Profile → Settings</p>
+                        <p className="text-xs text-gray-600 mt-1">Norwegian price zone · <Link href="/profile#settings" className="text-sky-500 hover:text-sky-400 transition-colors">change in Profile → Settings</Link></p>
                     </div>
                     {currentPrice !== null && (
                         <div className="text-right">

--- a/src/app/electricity/page.tsx
+++ b/src/app/electricity/page.tsx
@@ -3,6 +3,7 @@
 
 import React, { useState, useEffect, useCallback } from 'react';
 import ElectricityService from '@/services/electricityService';
+import UserService from '@/services/userService';
 import dynamic from 'next/dynamic';
 
 const TimeSeriesChart = dynamic(() => import('@/components/TimeSeriesChart'), { ssr: false });
@@ -38,10 +39,10 @@ const getDate = (type: string) => {
     return date;
 };
 
-const fetchTabData = async (frequency: string, dateType: string): Promise<{ x: number; y: number }[]> => {
+const fetchTabData = async (frequency: string, dateType: string, zone: string): Promise<{ x: number; y: number }[]> => {
     const tomorrow = getDate('tomorrow');
     const startDate = getDate(dateType);
-    const raw = await ElectricityService.getElectricityData(frequency, 'NO2', tomorrow.toISOString());
+    const raw = await ElectricityService.getElectricityData(frequency, zone, tomorrow.toISOString());
     return raw
         .filter((d: any) => {
             const ts = d.time.endsWith('Z') ? d.time : d.time + 'Z';
@@ -59,6 +60,13 @@ const ElectricityPage = () => {
     const [cache, setCache] = useState<Partial<Record<TabKey, { x: number; y: number }[]>>>({});
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
+    const [priceZone, setPriceZone] = useState<string>('NO2');
+
+    useEffect(() => {
+        UserService.getUserProfile().then(u => {
+            if (u.priceZone) setPriceZone(u.priceZone);
+        }).catch(() => {});
+    }, []);
 
     const loadTab = useCallback(async (tab: TabKey) => {
         if (cache[tab]) return;
@@ -66,14 +74,18 @@ const ElectricityPage = () => {
         setError(null);
         try {
             const { frequency, dateType } = TABS.find(t => t.key === tab)!;
-            const data = await fetchTabData(frequency, dateType);
+            const data = await fetchTabData(frequency, dateType, priceZone);
             setCache(prev => ({ ...prev, [tab]: data }));
         } catch {
             setError('Failed to fetch electricity data');
         } finally {
             setLoading(false);
         }
-    }, [cache]);
+    }, [cache, priceZone]);
+
+    useEffect(() => {
+        setCache({});
+    }, [priceZone]);
 
     useEffect(() => {
         loadTab(activeTab);
@@ -97,10 +109,11 @@ const ElectricityPage = () => {
                 {/* Header */}
                 <div className="px-5 pt-5 pb-3 flex items-start justify-between">
                     <div>
-                        <h2 className="text-base font-semibold text-gray-100">NO2 · NOK / kWh</h2>
+                        <h2 className="text-base font-semibold text-gray-100">{priceZone} · NOK / kWh</h2>
                         {currentPrice !== null && (
                             <p className="text-xs text-gray-500 mt-0.5">Current hour</p>
                         )}
+                        <p className="text-xs text-gray-600 mt-1">Norwegian price zone · change in Profile → Settings</p>
                     </div>
                     {currentPrice !== null && (
                         <div className="text-right">

--- a/src/dto/Automation/AutomationRuleDto.ts
+++ b/src/dto/Automation/AutomationRuleDto.ts
@@ -7,4 +7,6 @@ export interface AutomationRuleDto {
     condition: string;
     threshold: number;
     action: string;
+    isEnabled: boolean;
+    lastTriggeredAt: string | null;
 }

--- a/src/dto/Automation/CreateAutomationRuleDto.ts
+++ b/src/dto/Automation/CreateAutomationRuleDto.ts
@@ -6,4 +6,5 @@ export interface CreateAutomationRuleDto {
     condition: string;
     threshold: number;
     action: string;
+    isEnabled: boolean;
 }

--- a/src/dto/Automation/UpdateAutomationRuleDto.ts
+++ b/src/dto/Automation/UpdateAutomationRuleDto.ts
@@ -6,4 +6,5 @@ export interface UpdateAutomationRuleDto {
     condition: string;
     threshold: number;
     action: string;
+    isEnabled: boolean;
 }

--- a/src/dto/UserDTO.ts
+++ b/src/dto/UserDTO.ts
@@ -1,6 +1,8 @@
 export interface UserDTO {
+    id?: string;
     email: string;
     firstName: string;
     lastName: string;
     emailConfirmed: boolean;
+    priceZone: string;
 }

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -61,7 +61,7 @@ const UserService = {
                     Authorization: `Bearer ${session.accessToken}`,
                 },
             });
-            return response.data;
+            return { ...response.data, id: sub };
         } catch (error: unknown) {
             if (error instanceof AxiosError) {
                 throw new Error(error.response?.data.message || 'Failed to fetch user profile');
@@ -176,7 +176,20 @@ const UserService = {
                 throw new Error('An unknown error occurred');
             }
         }
-    }
+    },
+
+    async updatePreferences(userId: string, priceZone: string): Promise<UserDTO> {
+        try {
+            const response = await axiosInstance.put<UserDTO>(`/users/${userId}/preferences`, { priceZone });
+            return response.data;
+        } catch (error: unknown) {
+            if (error instanceof AxiosError) {
+                throw new Error(error.response?.data.message || 'Failed to update preferences');
+            } else {
+                throw new Error('An unknown error occurred');
+            }
+        }
+    },
 };
 
 export default UserService;


### PR DESCRIPTION
## Summary

### Automations
- Show unit in threshold label (e.g. Threshold (degC))
- Enable/disable toggle per rule
- Last triggered timestamp using nb-NO locale format
- Update DTOs with isEnabled and lastTriggeredAt

### Device Dashboard and Drawer
- Add Active/Inactive text label next to status dot
- Rename Charges recorded to Charge cycles detected with tooltip

### Setup Wizard and Profile
- Rename registration code to device code throughout
- Add Settings section with electricity price zone selector (NO1-NO5, stored server-side)
- Loading spinner while profile is fetched (no flash of default value)

### Electricity Page
- Read price zone from user profile instead of hardcoding NO2
- Dynamic zone label with skeleton placeholder while loading
- Link to Profile Settings for changing zone

### User Service and DTOs
- Expose id from JWT sub in getUserProfile()
- Add updatePreferences() to save price zone server-side
- Add id and priceZone fields to UserDTO

### Commits
- bc709cb fix: hide electricity zone label until profile is loaded
- a09e05b fix: show loading spinner in settings until profile is fetched
- 008ceab feat: link electricity price zone hint to profile settings
- 34f09af feat: UX improvements batch