### PR TITLE
fix: stale sensor threshold uses 14d window

### DIFF
--- a/src/app/DeviceDashboard.tsx
+++ b/src/app/DeviceDashboard.tsx
@@ -160,7 +160,7 @@ const DeviceDashboard: React.FC = () => {
     const isStale = (d: UnifiedDevice): boolean => {
         if (d.kind === 'socket') return d.latestState === 'UNKNOWN';
         if (!d.latestTimestamp) return true;
-        return (Date.now() - new Date(d.latestTimestamp).getTime()) / 86_400_000 > 30;
+        return (Date.now() - new Date(d.latestTimestamp).getTime()) / 86_400_000 > 14;
     };
 
     const loadData = useCallback(async () => {
@@ -175,11 +175,18 @@ const DeviceDashboard: React.FC = () => {
 
             const displaySensors = allSensors.filter(s => s.type !== 'battery');
 
-            const [latestResp, healthResults, switchStates] = await Promise.all([
+            const [latestResp, staleResp, healthResults, switchStates] = await Promise.all([
                 displaySensors.length > 0
                     ? SensorService.getMultipleSensorsData(
                         displaySensors.map(s => s.id),
                         undefined, undefined, '1d', '30m', 1, 5000
+                      ).catch(() => ({ data: [], totalCount: 0 }))
+                    : Promise.resolve({ data: [], totalCount: 0 }),
+
+                displaySensors.length > 0
+                    ? SensorService.getMultipleSensorsData(
+                        displaySensors.map(s => s.id),
+                        undefined, undefined, '14d', '1d', 1, 5000
                       ).catch(() => ({ data: [], totalCount: 0 }))
                     : Promise.resolve({ data: [], totalCount: 0 }),
 
@@ -223,6 +230,17 @@ const DeviceDashboard: React.FC = () => {
                     latestMap[d.sensorId] = { value: Number(d.value), timestamp: d.timestamp };
                 }
             }
+
+            const staleMap: Record<number, string> = {};
+            for (const d of staleResp.data) {
+                const ex = staleMap[d.sensorId];
+                const ts = new Date(d.timestamp).getTime();
+                if (!ex || ts > new Date(ex).getTime()) {
+                    staleMap[d.sensorId] = d.timestamp;
+                }
+            }
+            // Merge: if 1d data exists use that timestamp, otherwise fall back to 14d staleMap
+
             const activeSensorIds = new Set(Object.keys(latestMap).map(Number));
 
             const healthMap: Record<string, BatteryHealthData> = {};
@@ -241,7 +259,7 @@ const DeviceDashboard: React.FC = () => {
                 type: s.type,
                 rawSensor: s,
                 latestValue: latestMap[s.id]?.value,
-                latestTimestamp: latestMap[s.id]?.timestamp,
+                latestTimestamp: latestMap[s.id]?.timestamp ?? staleMap[s.id],
                 batteryHealth: healthMap[s.name],
                 isActive: activeSensorIds.has(s.id),
             }));


### PR DESCRIPTION
## Summary

Sensors with data from the last 14 days were incorrectly showing under "No recent data" because the stale check relied on the 1-day data fetch used for displaying current values.

### Fix
- Added a second data fetch with a 14-day window (1d groupBy) used only for the stale timestamp
- latestTimestamp now falls back to the 14d result if no 1d data exists
- Lowered the isStale threshold from 30 days to 14 days to match

### Commits
- e95970f fix: use 14d window for stale sensor check instead of 1d data window