### PR TITLE
feat: socket self-claim, profile add-device for sockets, JWT cleanup

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+    images: {
+        qualities: [75, 100],
+    }
     /* config options here */
 };
 

--- a/src/app/(auth)/profile/page.tsx
+++ b/src/app/(auth)/profile/page.tsx
@@ -16,7 +16,6 @@ import Alert from '@/components/Alert';
 
 const Profile: React.FC = () => {
     const { status } = useSession();
-    const { update: updateSession } = useSession();
     const router = useRouter();
     const isAuthenticated = status === 'authenticated';
 
@@ -29,6 +28,7 @@ const Profile: React.FC = () => {
     const [verificationCode, setVerificationCode] = useState('');
     const [sensors, setSensors] = useState<Sensor[]>([]);
     const [claimCode, setClaimCode] = useState('');
+    const [claimType, setClaimType] = useState<'sensor' | 'socket'>('sensor');
     const [claimLoading, setClaimLoading] = useState(false);
     const [emailMessage, setEmailMessage] = useState<string | null>(null);
     const [emailError, setEmailError] = useState(false);
@@ -47,6 +47,7 @@ const Profile: React.FC = () => {
     const [newSwitchName, setNewSwitchName] = useState('');
     const [switchEditLoading, setSwitchEditLoading] = useState(false);
     const [switchEditError, setSwitchEditError] = useState<string | null>(null);
+    const [confirmDeleteSwitchId, setConfirmDeleteSwitchId] = useState<number | null>(null);
 
     function sortSensorsByName(sensors: Sensor[]): Sensor[] {
         return [...sensors].sort((a, b) =>
@@ -120,20 +121,25 @@ const Profile: React.FC = () => {
         }
     };
 
-    const handleClaimSensor = async () => {
+    const handleClaimDevice = async () => {
         if (!claimCode.trim()) { setClaimMessage('Please enter a device code.'); setClaimError(true); return; }
         setClaimLoading(true);
         setClaimMessage(null);
         setClaimError(false);
         try {
-            await SensorService.claimSensor(claimCode.trim());
-            setClaimMessage('Sensor added successfully!');
+            if (claimType === 'sensor') {
+                await SensorService.claimSensor(claimCode.trim());
+                setClaimMessage('Sensor added successfully!');
+                await refreshSensors();
+            } else {
+                await SwitchService.claimSwitch(claimCode.trim());
+                setClaimMessage('Socket added successfully!');
+                await refreshSwitches();
+            }
             setClaimError(false);
             setClaimCode('');
-            await updateSession();
-            await refreshSensors();
         } catch (error: unknown) {
-            setClaimMessage(error instanceof Error ? error.message : 'Failed to add sensor.');
+            setClaimMessage(error instanceof Error ? error.message : `Failed to add ${claimType}.`);
             setClaimError(true);
         } finally {
             setClaimLoading(false);
@@ -145,6 +151,13 @@ const Profile: React.FC = () => {
         await SensorService.unclaimSensor(confirmDeleteId);
         setConfirmDeleteId(null);
         await refreshSensors();
+    };
+
+    const handleUnclaimSwitch = async () => {
+        if (confirmDeleteSwitchId === null) return;
+        await SwitchService.unclaimSwitch(confirmDeleteSwitchId);
+        setConfirmDeleteSwitchId(null);
+        await refreshSwitches();
     };
 
     const startEditing = (sensor: Sensor) => {
@@ -202,6 +215,7 @@ const Profile: React.FC = () => {
     };
 
     const confirmSensor = sensors.find(s => s.id === confirmDeleteId);
+    const confirmSwitch = switches.find(sw => sw.id === confirmDeleteSwitchId);
     const isUserLoading = status === 'loading' || !user;
 
     return (
@@ -213,6 +227,15 @@ const Profile: React.FC = () => {
                     confirmLabel="Remove"
                     onConfirm={handleUnclaimSensor}
                     onCancel={() => setConfirmDeleteId(null)}
+                />
+            )}
+            {confirmDeleteSwitchId !== null && confirmSwitch && (
+                <ConfirmModal
+                    title="Remove socket"
+                    message={<>Are you sure you want to remove <span className="font-medium text-gray-100">{confirmSwitch.customName ?? confirmSwitch.name}</span> from your account? You can re-add it later using the device code.</>}
+                    confirmLabel="Remove"
+                    onConfirm={handleUnclaimSwitch}
+                    onCancel={() => setConfirmDeleteSwitchId(null)}
                 />
             )}
 
@@ -274,20 +297,48 @@ const Profile: React.FC = () => {
                     )}
                 </Section>
 
-                {/* Claim Sensor */}
+                {/* Claim Device */}
                 <Section title="Add a device">
-                    <p className="text-sm text-gray-400 mb-3">Enter the device code for your sensor to add it to your account.</p>
+                    <p className="text-sm text-gray-400 mb-3">Enter the device code to add a sensor or socket to your account.</p>
+
+                    {/* Type toggle */}
+                    <div className="flex gap-2 p-1 bg-gray-800/60 rounded-xl mb-3">
+                        <button
+                            type="button"
+                            onClick={() => { setClaimType('sensor'); setClaimCode(''); setClaimMessage(null); }}
+                            className={`flex-1 py-2 rounded-lg text-sm font-medium transition-all ${
+                                claimType === 'sensor'
+                                    ? 'bg-sky-600 text-white shadow'
+                                    : 'text-gray-400 hover:text-gray-200'
+                            }`}
+                        >
+                            🌡️ Sensor
+                        </button>
+                        <button
+                            type="button"
+                            onClick={() => { setClaimType('socket'); setClaimCode(''); setClaimMessage(null); }}
+                            className={`flex-1 py-2 rounded-lg text-sm font-medium transition-all ${
+                                claimType === 'socket'
+                                    ? 'bg-sky-600 text-white shadow'
+                                    : 'text-gray-400 hover:text-gray-200'
+                            }`}
+                        >
+                            🔌 Socket
+                        </button>
+                    </div>
+
                     <div className="flex gap-2">
                         <input
                             type="text"
                             value={claimCode}
-                            onChange={e => setClaimCode(e.target.value)}
+                            onChange={e => setClaimCode(e.target.value.toUpperCase())}
+                            onKeyDown={e => e.key === 'Enter' && handleClaimDevice()}
                             placeholder="Device code"
                             className={inputClass}
                             disabled={claimLoading}
                         />
                         <button
-                            onClick={handleClaimSensor}
+                            onClick={handleClaimDevice}
                             className="px-4 py-2.5 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded-xl transition-all whitespace-nowrap"
                             disabled={claimLoading}
                         >
@@ -395,18 +446,29 @@ const Profile: React.FC = () => {
                                             </div>
                                         </div>
                                     ) : (
-                                        <div className="flex items-start justify-between gap-2">
-                                            <div>
-                                                <span className="text-sm font-semibold text-gray-100 leading-tight block">
+                                        <>
+                                            <div className="flex items-start justify-between gap-2 mb-2">
+                                                <span className="text-sm font-semibold text-gray-100 leading-tight">
                                                     {sw.customName ?? sw.name}
                                                 </span>
-                                                <p className="text-xs text-gray-400 mt-0.5">Type: {sw.type}</p>
+                                                <button onClick={() => startEditingSwitch(sw)} className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-gray-700/60 transition-all flex-shrink-0" title="Rename">
+                                                    <PencilIcon className="h-3.5 w-3.5" />
+                                                </button>
+                                            </div>
+                                            <div className="space-y-0.5 mb-4">
+                                                <p className="text-xs text-gray-400">Type: {sw.type}</p>
+                                                {sw.registrationCode && <p className="text-xs text-gray-500">Device code: {sw.registrationCode}</p>}
                                                 {sw.customName && <p className="text-xs text-gray-500">Default: {sw.name}</p>}
                                             </div>
-                                            <button onClick={() => startEditingSwitch(sw)} className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-gray-700/60 transition-all flex-shrink-0" title="Rename">
-                                                <PencilIcon className="h-3.5 w-3.5" />
+                                            <button
+                                                onClick={() => setConfirmDeleteSwitchId(sw.id)}
+                                                className="flex items-center gap-1.5 text-xs text-gray-600 hover:text-red-400 transition-colors"
+                                                title="Remove from account"
+                                            >
+                                                <TrashIcon className="h-3.5 w-3.5" />
+                                                Remove from account
                                             </button>
-                                        </div>
+                                        </>
                                     )}
                                 </div>
                             ))}

--- a/src/app/(auth)/profile/page.tsx
+++ b/src/app/(auth)/profile/page.tsx
@@ -6,6 +6,7 @@ import { useSession } from 'next-auth/react';
 import UserService from '@/services/userService';
 import { UserDTO } from '@/dto/UserDTO';
 import SensorService, { Sensor } from '@/services/sensorService';
+import SwitchService, { Switch } from '@/services/switchService';
 import { PencilIcon, CheckIcon, XMarkIcon, TrashIcon } from '@heroicons/react/24/outline';
 import ConfirmModal from '@/components/ConfirmModal';
 import LoadingDots from '@/components/LoadingDots';
@@ -40,6 +41,13 @@ const Profile: React.FC = () => {
     const [sensorsLoading, setSensorsLoading] = useState(true);
     const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null);
 
+    const [switches, setSwitches] = useState<Switch[]>([]);
+    const [switchesLoading, setSwitchesLoading] = useState(true);
+    const [editingSwitchId, setEditingSwitchId] = useState<number | null>(null);
+    const [newSwitchName, setNewSwitchName] = useState('');
+    const [switchEditLoading, setSwitchEditLoading] = useState(false);
+    const [switchEditError, setSwitchEditError] = useState<string | null>(null);
+
     function sortSensorsByName(sensors: Sensor[]): Sensor[] {
         return [...sensors].sort((a, b) =>
             (a.customName ?? a.defaultName ?? '').toLowerCase()
@@ -52,11 +60,20 @@ const Profile: React.FC = () => {
         setSensors(sortSensorsByName(userSensors));
     };
 
+    const refreshSwitches = async () => {
+        const allSwitches = await SwitchService.getAllSwitches();
+        setSwitches([...allSwitches].sort((a, b) =>
+            (a.customName ?? a.name).toLowerCase().localeCompare((b.customName ?? b.name).toLowerCase())
+        ));
+    };
+
     useEffect(() => {
         if (!isAuthenticated) { router.push('/login'); return; }
         UserService.getUserProfile().then(u => { setUser(u); setPriceZone(u.priceZone ?? 'NO2'); }).catch(console.error).finally(() => setProfileLoading(false));
         setSensorsLoading(true);
         refreshSensors().catch(console.error).finally(() => setSensorsLoading(false));
+        setSwitchesLoading(true);
+        refreshSwitches().catch(console.error).finally(() => setSwitchesLoading(false));
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isAuthenticated, router]);
 
@@ -154,6 +171,33 @@ const Profile: React.FC = () => {
             setEditError(error instanceof Error ? error.message : 'Failed to update sensor name.');
         } finally {
             setEditLoading(false);
+        }
+    };
+
+    const startEditingSwitch = (sw: Switch) => {
+        setEditingSwitchId(sw.id);
+        setNewSwitchName(sw.customName ?? sw.name);
+        setSwitchEditError(null);
+    };
+
+    const cancelEditingSwitch = () => { setEditingSwitchId(null); setNewSwitchName(''); setSwitchEditError(null); };
+
+    const handleSaveSwitchName = async (switchId: number) => {
+        if (!newSwitchName.trim() || newSwitchName.length > 50) {
+            setSwitchEditError('Name is required and must be at most 50 characters.');
+            return;
+        }
+        setSwitchEditLoading(true);
+        setSwitchEditError(null);
+        try {
+            await SwitchService.updateCustomName(switchId, newSwitchName.trim());
+            await refreshSwitches();
+            setEditingSwitchId(null);
+            setNewSwitchName('');
+        } catch (error: unknown) {
+            setSwitchEditError(error instanceof Error ? error.message : 'Failed to update socket name.');
+        } finally {
+            setSwitchEditLoading(false);
         }
     };
 
@@ -312,6 +356,57 @@ const Profile: React.FC = () => {
                                                 Remove from account
                                             </button>
                                         </>
+                                    )}
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                </Section>
+
+                {/* Sockets */}
+                <Section title="Your sockets">
+                    {switchesLoading ? <LoadingDots /> : !switches.length ? (
+                        <p className="text-sm text-gray-500">No sockets found.</p>
+                    ) : (
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                            {switches.map(sw => (
+                                <div key={sw.id} className="bg-gray-900/50 border border-gray-700/40 rounded-xl p-4">
+                                    {editingSwitchId === sw.id ? (
+                                        <div className="space-y-2">
+                                            <input
+                                                type="text"
+                                                value={newSwitchName}
+                                                onChange={e => setNewSwitchName(e.target.value)}
+                                                className={inputClass}
+                                                maxLength={50}
+                                                disabled={switchEditLoading}
+                                                autoFocus
+                                            />
+                                            {switchEditError && <p className="text-xs text-red-400">{switchEditError}</p>}
+                                            <div className="flex gap-2">
+                                                <button onClick={() => handleSaveSwitchName(sw.id)} disabled={switchEditLoading} className="flex items-center gap-1.5 px-3 py-1.5 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 text-white text-xs font-medium rounded-lg transition-all">
+                                                    <CheckIcon className="h-3.5 w-3.5" />
+                                                    {switchEditLoading ? 'Saving…' : 'Save'}
+                                                </button>
+                                                <button onClick={cancelEditingSwitch} disabled={switchEditLoading} className="flex items-center gap-1.5 px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-300 text-xs font-medium rounded-lg transition-all">
+                                                    <XMarkIcon className="h-3.5 w-3.5" />
+                                                    Cancel
+                                                </button>
+                                            </div>
+                                        </div>
+                                    ) : (
+                                        <div className="flex items-start justify-between gap-2">
+                                            <div>
+                                                <span className="text-sm font-semibold text-gray-100 leading-tight block">
+                                                    {sw.customName ?? sw.name}
+                                                </span>
+                                                <p className="text-xs text-gray-400 mt-0.5">Type: {sw.type}</p>
+                                                {sw.customName && <p className="text-xs text-gray-500">Default: {sw.name}</p>}
+                                            </div>
+                                            <button onClick={() => startEditingSwitch(sw)} className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-gray-700/60 transition-all flex-shrink-0" title="Rename">
+                                                <PencilIcon className="h-3.5 w-3.5" />
+                                            </button>
+                                        </div>
                                     )}
                                 </div>
                             ))}

--- a/src/app/(auth)/profile/page.tsx
+++ b/src/app/(auth)/profile/page.tsx
@@ -333,7 +333,7 @@ const Profile: React.FC = () => {
                             value={claimCode}
                             onChange={e => setClaimCode(e.target.value.toUpperCase())}
                             onKeyDown={e => e.key === 'Enter' && handleClaimDevice()}
-                            placeholder="Device code"
+                            placeholder="e.g. A1B2C3D4E5"
                             className={inputClass}
                             disabled={claimLoading}
                         />

--- a/src/app/DeviceDashboard.tsx
+++ b/src/app/DeviceDashboard.tsx
@@ -160,7 +160,7 @@ const DeviceDashboard: React.FC = () => {
     const isStale = (d: UnifiedDevice): boolean => {
         if (d.kind === 'socket') return d.latestState === 'UNKNOWN';
         if (!d.latestTimestamp) return true;
-        return (Date.now() - new Date(d.latestTimestamp).getTime()) / 86_400_000 > 30;
+        return (Date.now() - new Date(d.latestTimestamp).getTime()) / 86_400_000 > 14;
     };
 
     const loadData = useCallback(async () => {
@@ -175,11 +175,18 @@ const DeviceDashboard: React.FC = () => {
 
             const displaySensors = allSensors.filter(s => s.type !== 'battery');
 
-            const [latestResp, healthResults, switchStates] = await Promise.all([
+            const [latestResp, staleResp, healthResults, switchStates] = await Promise.all([
                 displaySensors.length > 0
                     ? SensorService.getMultipleSensorsData(
                         displaySensors.map(s => s.id),
                         undefined, undefined, '1d', '30m', 1, 5000
+                      ).catch(() => ({ data: [], totalCount: 0 }))
+                    : Promise.resolve({ data: [], totalCount: 0 }),
+
+                displaySensors.length > 0
+                    ? SensorService.getMultipleSensorsData(
+                        displaySensors.map(s => s.id),
+                        undefined, undefined, '14d', '1d', 1, 5000
                       ).catch(() => ({ data: [], totalCount: 0 }))
                     : Promise.resolve({ data: [], totalCount: 0 }),
 
@@ -223,6 +230,17 @@ const DeviceDashboard: React.FC = () => {
                     latestMap[d.sensorId] = { value: Number(d.value), timestamp: d.timestamp };
                 }
             }
+
+            const staleMap: Record<number, string> = {};
+            for (const d of staleResp.data) {
+                const ex = staleMap[d.sensorId];
+                const ts = new Date(d.timestamp).getTime();
+                if (!ex || ts > new Date(ex).getTime()) {
+                    staleMap[d.sensorId] = d.timestamp;
+                }
+            }
+            // Merge: if 1d data exists use that timestamp, otherwise fall back to 14d staleMap
+
             const activeSensorIds = new Set(Object.keys(latestMap).map(Number));
 
             const healthMap: Record<string, BatteryHealthData> = {};
@@ -241,7 +259,7 @@ const DeviceDashboard: React.FC = () => {
                 type: s.type,
                 rawSensor: s,
                 latestValue: latestMap[s.id]?.value,
-                latestTimestamp: latestMap[s.id]?.timestamp,
+                latestTimestamp: latestMap[s.id]?.timestamp ?? staleMap[s.id],
                 batteryHealth: healthMap[s.name],
                 isActive: activeSensorIds.has(s.id),
             }));

--- a/src/app/DeviceDashboard.tsx
+++ b/src/app/DeviceDashboard.tsx
@@ -14,6 +14,9 @@ import ConfirmModal from '@/components/ConfirmModal';
 import { groupEmoji } from '@/lib/groupIcons';
 import CollapsibleSection from '@/components/CollapsibleSection';
 
+// ── Type sort order for group cards ───────────────────────────────────────────
+const TYPE_ORDER: Record<string, number> = { voltage: 0, temperature: 1, humidity: 2, socket: 3 };
+
 // ── Custom dropdown ────────────────────────────────────────────────────────────
 interface SelectOption { value: string; label: string }
 interface CustomSelectProps {
@@ -267,7 +270,7 @@ const DeviceDashboard: React.FC = () => {
             const socketDevices: UnifiedDevice[] = allSwitches.map(sw => ({
                 kind: 'socket' as const,
                 id: sw.id,
-                displayName: sw.name,
+                displayName: sw.customName ?? sw.name,
                 type: 'socket',
                 rawSwitch: sw,
                 latestState: switchStateMap[sw.id] ?? 'UNKNOWN',
@@ -385,9 +388,23 @@ const DeviceDashboard: React.FC = () => {
                         <h2 className="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Groups</h2>
                         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
                             {groups.map(group => {
-                                const groupDevices = devices.filter(d => d.kind === 'sensor' && group.sensorIds.includes(d.id));
+                                const groupDevices = devices
+                                    .filter(d =>
+                                        (d.kind === 'sensor' && group.sensorIds.includes(d.id)) ||
+                                        (d.kind === 'socket' && group.switchIds.includes(d.id))
+                                    )
+                                    .sort((a, b) =>
+                                        (TYPE_ORDER[a.type] ?? 99) - (TYPE_ORDER[b.type] ?? 99) ||
+                                        a.displayName.localeCompare(b.displayName)
+                                    );
                                 const emoji = groupEmoji(group.icon);
                                 const anyActive = groupDevices.some(d => d.isActive);
+                                const sensorCount = groupDevices.filter(d => d.kind === 'sensor').length;
+                                const socketCount = groupDevices.filter(d => d.kind === 'socket').length;
+                                const countLabel = [
+                                    sensorCount > 0 ? `${sensorCount} sensor${sensorCount !== 1 ? 's' : ''}` : '',
+                                    socketCount > 0 ? `${socketCount} socket${socketCount !== 1 ? 's' : ''}` : '',
+                                ].filter(Boolean).join(', ') || 'Empty';
                                 return (
                                     <div
                                         key={group.id}
@@ -399,7 +416,7 @@ const DeviceDashboard: React.FC = () => {
                                                 <span className="text-2xl">{emoji}</span>
                                                 <div>
                                                     <p className="font-semibold text-gray-100 text-sm">{group.name}</p>
-                                                    <p className="text-xs text-gray-500">{groupDevices.length} sensor{groupDevices.length !== 1 ? 's' : ''}</p>
+                                                    <p className="text-xs text-gray-500">{countLabel}</p>
                                                 </div>
                                             </div>
                                             <div className="flex items-center gap-1.5">
@@ -420,7 +437,7 @@ const DeviceDashboard: React.FC = () => {
 
                                         {/* Sensor readings inline */}
                                         {groupDevices.length === 0 ? (
-                                            <p className="text-xs text-gray-600 italic">No sensors assigned yet.</p>
+                                            <p className="text-xs text-gray-600 italic">No devices assigned yet.</p>
                                         ) : (
                                             <div className="flex flex-wrap gap-2">
                                                 {groupDevices.map(d => (
@@ -433,7 +450,8 @@ const DeviceDashboard: React.FC = () => {
                                                         <span className="text-xs text-gray-400">{
                                                             d.type === 'temperature' ? '🌡️' :
                                                             d.type === 'humidity'    ? '💧' :
-                                                            d.type === 'voltage'     ? '⚡' : '📡'
+                                                            d.type === 'voltage'     ? '⚡' :
+                                                            d.type === 'socket'      ? '🔌' : '📡'
                                                         }</span>
                                                         <span className="text-sm font-semibold text-gray-100 tabular-nums">{formatValue(d)}</span>
                                                     </button>
@@ -525,7 +543,7 @@ const DeviceDashboard: React.FC = () => {
                     <ConfirmModal
                         title="Delete group"
                         subtitle="This cannot be undone"
-                        message={<>Are you sure you want to delete <span className="font-medium text-gray-100">{icon} {deleteGroup.name}</span>? Your sensors won&apos;t be deleted, just removed from this group.</>}
+                        message={<>Are you sure you want to delete <span className="font-medium text-gray-100">{icon} {deleteGroup.name}</span>? Your devices won&apos;t be deleted, just removed from this group.</>}
                         confirmLabel="Delete"
                         onConfirm={async () => { await GroupService.deleteGroup(deleteGroup.id); setDeleteGroup(null); loadData(); }}
                         onCancel={() => setDeleteGroup(null)}

--- a/src/app/DeviceDashboard.tsx
+++ b/src/app/DeviceDashboard.tsx
@@ -513,7 +513,11 @@ const DeviceDashboard: React.FC = () => {
                                             ))}
                                         </div>
                                         {inactiveDevices.length > 0 && (
-                                            <CollapsibleSection label="No recent data" count={inactiveDevices.length}>
+                                            <CollapsibleSection
+                                                label="No recent data"
+                                                count={inactiveDevices.length}
+                                                defaultOpen={activeDevices.length === 0}
+                                            >
                                                 <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
                                                     {inactiveDevices.map(device => (
                                                         <DeviceCard

--- a/src/app/DeviceDrawer.tsx
+++ b/src/app/DeviceDrawer.tsx
@@ -2,12 +2,13 @@
 
 import React, { useCallback, useEffect, useState } from 'react';
 import dynamic from 'next/dynamic';
-import { XMarkIcon } from '@heroicons/react/24/outline';
+import { XMarkIcon, PencilIcon, CheckIcon } from '@heroicons/react/24/outline';
 import { TYPE_CONFIG as typeConfig, DEFAULT_TYPE as defaultType, BATTERY_STATUS_CONFIG as statusConfig } from '@/lib/typeConfig';
 import { unitForType, typeLabel } from '@/lib/typeUtils';
 import { RANGE_OPTIONS, type RangeIndex } from '@/lib/constants';
 import LoadingDots from '@/components/LoadingDots';
 import SensorService, { SensorData, BatteryHealthData } from '@/services/sensorService';
+import SwitchService from '@/services/switchService';
 import { formatDateTime } from '@/lib/dateUtils';
 import type { UnifiedDevice } from './DeviceDashboard';
 
@@ -23,6 +24,11 @@ const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose }) => {
     const [loadingChart, setLoadingChart] = useState(false);
     const [activeRange, setActiveRange] = useState<RangeIndex>(2);
     const [visible, setVisible] = useState(false);
+
+    // Inline name editing (sensors + sockets)
+    const [editingName, setEditingName] = useState(false);
+    const [editName, setEditName] = useState(device.displayName);
+    const [savingName, setSavingName] = useState(false);
 
     useEffect(() => {
         const frame = requestAnimationFrame(() => setVisible(true));
@@ -89,6 +95,24 @@ const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose }) => {
         ? `${Number(device.latestValue).toFixed(device.type === 'voltage' ? 2 : 1)} ${unitForType(device.type)}`
         : null;
 
+    const handleSaveName = async () => {
+        if (!editName.trim()) return;
+        setSavingName(true);
+        try {
+            if (device.kind === 'sensor') {
+                await SensorService.updateCustomName(device.id, editName.trim());
+            } else {
+                await SwitchService.updateCustomName(device.id, editName.trim());
+            }
+            device.displayName = editName.trim();
+            setEditingName(false);
+        } catch {
+            // non-fatal
+        } finally {
+            setSavingName(false);
+        }
+    };
+
     return (
         <>
             {/* Backdrop */}
@@ -106,7 +130,40 @@ const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose }) => {
                         <Icon className={`h-5 w-5 ${iconColor}`} />
                     </div>
                     <div className="flex-1 min-w-0">
-                        <h2 className="font-semibold text-gray-100 truncate">{device.displayName}</h2>
+                        {(device.kind === 'socket' || device.kind === 'sensor') && editingName ? (
+                            <div className="flex items-center gap-2">
+                                <input
+                                    autoFocus
+                                    type="text"
+                                    value={editName}
+                                    onChange={e => setEditName(e.target.value)}
+                                    onKeyDown={e => {
+                                        if (e.key === 'Enter') handleSaveName();
+                                        if (e.key === 'Escape') setEditingName(false);
+                                    }}
+                                    className="flex-1 min-w-0 bg-gray-800/80 border border-gray-600/50 rounded-lg px-2 py-1 text-sm text-gray-100 focus:outline-none focus:border-sky-500/60"
+                                />
+                                <button
+                                    onClick={handleSaveName}
+                                    disabled={savingName}
+                                    className="p-1 rounded-lg text-sky-400 hover:text-sky-300 hover:bg-sky-500/10 transition-colors flex-shrink-0"
+                                >
+                                    <CheckIcon className="h-4 w-4" />
+                                </button>
+                            </div>
+                        ) : (
+                            <div className="flex items-center gap-1.5 min-w-0">
+                                <h2 className="font-semibold text-gray-100 truncate">{device.displayName}</h2>
+                                {(device.kind === 'socket' || device.kind === 'sensor') && (
+                                    <button
+                                        onClick={() => { setEditName(device.displayName); setEditingName(true); }}
+                                        className="p-0.5 rounded text-gray-600 hover:text-gray-400 transition-colors flex-shrink-0"
+                                    >
+                                        <PencilIcon className="h-3.5 w-3.5" />
+                                    </button>
+                                )}
+                            </div>
+                        )}
                         <p className="text-xs text-gray-500">{typeLabel(device.type)}</p>
                     </div>
                     <button

--- a/src/app/DeviceDrawer.tsx
+++ b/src/app/DeviceDrawer.tsx
@@ -8,7 +8,7 @@ import { unitForType, typeLabel } from '@/lib/typeUtils';
 import { RANGE_OPTIONS, type RangeIndex } from '@/lib/constants';
 import LoadingDots from '@/components/LoadingDots';
 import SensorService, { SensorData, BatteryHealthData } from '@/services/sensorService';
-import SwitchService from '@/services/switchService';
+import SwitchService, { SwitchData } from '@/services/switchService';
 import { formatDateTime } from '@/lib/dateUtils';
 import type { UnifiedDevice } from './DeviceDashboard';
 
@@ -19,11 +19,70 @@ interface DeviceDrawerProps {
     onClose: () => void;
 }
 
+// ── Socket timeline helpers ───────────────────────────────────────────────────
+
+interface Segment { start: number; end: number; on: boolean; }
+
+function buildSegments(events: SwitchData[], rangeStart: number, rangeEnd: number): Segment[] {
+    if (events.length === 0) return [];
+    const sorted = [...events].sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+    const segments: Segment[] = [];
+    for (let i = 0; i < sorted.length; i++) {
+        const start = Math.max(new Date(sorted[i].timestamp).getTime(), rangeStart);
+        const end = i + 1 < sorted.length
+            ? Math.min(new Date(sorted[i + 1].timestamp).getTime(), rangeEnd)
+            : rangeEnd;
+        if (end > start) {
+            segments.push({ start, end, on: (sorted[i].value || '').trim().toUpperCase() === 'ON' });
+        }
+    }
+    return segments;
+}
+
+function totalOnMs(segments: Segment[]): number {
+    return segments.filter(s => s.on).reduce((acc, s) => acc + (s.end - s.start), 0);
+}
+
+function formatDuration(ms: number): string {
+    const h = Math.floor(ms / 3_600_000);
+    const m = Math.floor((ms % 3_600_000) / 60_000);
+    if (h > 0) return `${h}h ${m}m`;
+    if (m > 0) return `${m}m`;
+    return '<1m';
+}
+
+const TimelineBar: React.FC<{ segments: Segment[]; rangeStart: number; rangeEnd: number }> = ({ segments, rangeStart, rangeEnd }) => {
+    const total = rangeEnd - rangeStart;
+    if (total <= 0) return null;
+    return (
+        <div className="relative h-8 rounded-xl overflow-hidden bg-gray-800/60 flex">
+            {segments.map((seg, i) => {
+                const left = ((seg.start - rangeStart) / total) * 100;
+                const width = ((seg.end - seg.start) / total) * 100;
+                return (
+                    <div
+                        key={i}
+                        title={`${seg.on ? 'ON' : 'OFF'} — ${formatDateTime(new Date(seg.start).toISOString())} → ${formatDateTime(new Date(seg.end).toISOString())}`}
+                        style={{ left: `${left}%`, width: `${width}%` }}
+                        className={`absolute top-0 h-full ${seg.on ? 'bg-green-500/70' : 'bg-gray-700/50'}`}
+                    />
+                );
+            })}
+        </div>
+    );
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose }) => {
     const [chartData, setChartData] = useState<{ x: number; y: number }[]>([]);
     const [loadingChart, setLoadingChart] = useState(false);
-    const [activeRange, setActiveRange] = useState<RangeIndex>(2);
+    const [activeRange, setActiveRange] = useState<RangeIndex>(0);
     const [visible, setVisible] = useState(false);
+
+    // Socket state
+    const [switchEvents, setSwitchEvents] = useState<SwitchData[]>([]);
+    const [loadingSwitch, setLoadingSwitch] = useState(false);
 
     // Inline name editing (sensors + sockets)
     const [editingName, setEditingName] = useState(false);
@@ -83,9 +142,24 @@ const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose }) => {
         }
     }, [device.id, device.kind]);
 
+    const fetchSwitchData = useCallback(async (rangeIdx: RangeIndex) => {
+        if (device.kind !== 'socket') return;
+        setLoadingSwitch(true);
+        const { timeRange } = RANGE_OPTIONS[rangeIdx];
+        try {
+            const data = await SwitchService.getSwitchData(device.id, timeRange);
+            setSwitchEvents(data);
+        } catch {
+            setSwitchEvents([]);
+        } finally {
+            setLoadingSwitch(false);
+        }
+    }, [device.id, device.kind]);
+
     useEffect(() => {
         if (device.kind === 'sensor') fetchChart(activeRange);
-    }, [device, activeRange, fetchChart]);
+        if (device.kind === 'socket') fetchSwitchData(activeRange);
+    }, [device, activeRange, fetchChart, fetchSwitchData]);
 
     const { Icon, iconBg, iconColor } = typeConfig[device.type.toLowerCase()] ?? defaultType;
     const health = device.batteryHealth as BatteryHealthData | undefined;
@@ -95,6 +169,15 @@ const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose }) => {
         ? `${Number(device.latestValue).toFixed(device.type === 'voltage' ? 2 : 1)} ${unitForType(device.type)}`
         : null;
 
+    // Socket computed values
+    const now = Date.now();
+    const rangeMs: Record<RangeIndex, number> = { 0: 86_400_000, 1: 7 * 86_400_000, 2: 30 * 86_400_000, 3: 365 * 86_400_000 };
+    const rangeStart = now - rangeMs[activeRange];
+    const segments = device.kind === 'socket' ? buildSegments(switchEvents, rangeStart, now) : [];
+    const onMs = totalOnMs(segments);
+    const lastEvent = switchEvents.length > 0
+        ? [...switchEvents].sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())[0]
+        : null;
     const handleSaveName = async () => {
         if (!editName.trim()) return;
         setSavingName(true);
@@ -206,34 +289,80 @@ const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose }) => {
                         </div>
                     )}
 
-                    {/* Sensor: range selector + chart */}
+                    {/* Range selector — both sensor and socket */}
+                    <div className="flex gap-1 bg-gray-800/60 rounded-xl p-1">
+                        {RANGE_OPTIONS.map((opt, idx) => (
+                            <button
+                                key={opt.label}
+                                onClick={() => setActiveRange(idx as RangeIndex)}
+                                className={`flex-1 text-sm py-1.5 rounded-lg font-medium transition-all duration-200 ${
+                                    activeRange === idx
+                                        ? 'bg-sky-600 text-white shadow-sm'
+                                        : 'text-gray-400 hover:text-gray-200'
+                                }`}
+                            >
+                                {opt.label}
+                            </button>
+                        ))}
+                    </div>
+
+                    {/* Sensor chart */}
                     {device.kind === 'sensor' && (
-                        <>
-                            <div className="flex gap-1 bg-gray-800/60 rounded-xl p-1">
-                                {RANGE_OPTIONS.map((opt, idx) => (
-                                    <button
-                                        key={opt.label}
-                                        onClick={() => setActiveRange(idx as RangeIndex)}
-                                        className={`flex-1 text-sm py-1.5 rounded-lg font-medium transition-all duration-200 ${
-                                            activeRange === idx
-                                                ? 'bg-sky-600 text-white shadow-sm'
-                                                : 'text-gray-400 hover:text-gray-200'
-                                        }`}
-                                    >
-                                        {opt.label}
-                                    </button>
-                                ))}
+                        loadingChart ? (
+                            <LoadingDots />
+                        ) : chartData.length > 0 ? (
+                            <TimeSeriesChart title="" data={chartData} />
+                        ) : (
+                            <div className="h-48 flex items-center justify-center text-gray-500 text-sm">
+                                No data for this period
                             </div>
-                            {loadingChart ? (
-                                <LoadingDots />
-                            ) : chartData.length > 0 ? (
-                                <TimeSeriesChart title="" data={chartData} />
-                            ) : (
-                                <div className="h-48 flex items-center justify-center text-gray-500 text-sm">
-                                    No data for this period
+                        )
+                    )}
+
+                    {/* Socket timeline */}
+                    {device.kind === 'socket' && (
+                        loadingSwitch ? (
+                            <LoadingDots />
+                        ) : (
+                            <div className="space-y-4">
+                                {/* Timeline bar */}
+                                {segments.length > 0 ? (
+                                    <>
+                                        <TimelineBar segments={segments} rangeStart={rangeStart} rangeEnd={now} />
+                                        <div className="flex justify-between text-xs text-gray-600">
+                                            <span>{RANGE_OPTIONS[activeRange].label === 'Day' ? '24h ago' : RANGE_OPTIONS[activeRange].label === 'Week' ? '7d ago' : RANGE_OPTIONS[activeRange].label === 'Month' ? '30d ago' : '1y ago'}</span>
+                                            <span>Now</span>
+                                        </div>
+                                    </>
+                                ) : (
+                                    <div className="h-8 flex items-center justify-center text-gray-500 text-sm">
+                                        No activity this period
+                                    </div>
+                                )}
+
+                                {/* Stats */}
+                                <div className="bg-gray-800/60 border border-gray-700/40 rounded-2xl p-4 space-y-3">
+                                    <div className="flex items-center justify-between text-sm">
+                                        <span className="text-gray-500">Time on</span>
+                                        <span className="text-gray-200 font-medium">{onMs > 0 ? formatDuration(onMs) : '—'}</span>
+                                    </div>
+                                    <div className="flex items-center justify-between text-sm">
+                                        <span className="text-gray-500">Last state change</span>
+                                        <span className="text-gray-200 font-medium text-right">
+                                            {lastEvent ? formatDateTime(lastEvent.timestamp) : '—'}
+                                        </span>
+                                    </div>
+                                    {lastEvent && (
+                                        <div className="flex items-center justify-between text-sm">
+                                            <span className="text-gray-500">Changed to</span>
+                                            <span className={`font-medium ${(lastEvent.value || '').trim().toUpperCase() === 'ON' ? 'text-green-400' : 'text-red-400'}`}>
+                                                {(lastEvent.value || '').trim().toUpperCase()}
+                                            </span>
+                                        </div>
+                                    )}
                                 </div>
-                            )}
-                        </>
+                            </div>
+                        )
                     )}
 
                     {/* Battery health details */}

--- a/src/app/SetupWizard.tsx
+++ b/src/app/SetupWizard.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { XMarkIcon, ChevronRightIcon, CheckIcon } from '@heroicons/react/24/outline';
 import SensorService, { Sensor } from '@/services/sensorService';
+import SwitchService, { Switch } from '@/services/switchService';
 import GroupService, { Group } from '@/services/groupService';
 import { GROUP_ICONS as ICONS, groupEmoji } from '@/lib/groupIcons';
 import { typeEmoji } from '@/lib/typeUtils';
@@ -84,10 +85,12 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
     const [assignError, setAssignError] = useState('');
 
     const [allSensors, setAllSensors]           = useState<Sensor[]>([]);
+    const [allSwitches, setAllSwitches]         = useState<Switch[]>([]);
     const [sensorSearch, setSensorSearch]       = useState('');
     const [selectedSensorIds, setSelectedSensorIds] = useState<Set<number>>(
         prefillSensor ? new Set([prefillSensor.id]) : new Set()
     );
+    const [selectedSwitchIds, setSelectedSwitchIds] = useState<Set<number>>(new Set());
 
     const overlayRef = useRef<HTMLDivElement>(null);
 
@@ -100,22 +103,25 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
         return () => window.removeEventListener('keydown', handler);
     }, [onClose]);
 
-    // Load groups + all sensors when reaching step 2
+    // Load groups + all sensors + all switches when reaching step 2
     useEffect(() => {
         if (step === 2) {
             Promise.all([
                 GroupService.getAllGroups(),
                 SensorService.getAllSensors(),
-            ]).then(([fetchedGroups, fetchedSensors]) => {
+                SwitchService.getAllSwitches(),
+            ]).then(([fetchedGroups, fetchedSensors, fetchedSwitches]) => {
                 setGroups(fetchedGroups);
+                setAllSwitches(fetchedSwitches);
                 const accessible = fetchedSensors.filter(x => x.type !== 'battery');
 
-                // If managing an existing group, pre-check its current sensors
+                // If managing an existing group, pre-check its current sensors + switches
                 // and add ghost placeholders for any IDs not accessible in this environment
                 if (prefillGroupId) {
                     const existing = fetchedGroups.find(g => g.id === prefillGroupId);
                     if (existing) {
                         setSelectedSensorIds(new Set(existing.sensorIds));
+                        setSelectedSwitchIds(new Set(existing.switchIds));
                         const accessibleIds = new Set(accessible.map(s => s.id));
                         const ghosts: Sensor[] = existing.sensorIds
                             .filter(id => !accessibleIds.has(id))
@@ -181,6 +187,7 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
         try {
             let groupId: number;
             let originalSensorIds: Set<number> = new Set();
+            let originalSwitchIds: Set<number> = new Set();
 
             if (selectedGroupId === 'new') {
                 if (!newGroupName.trim()) { setAssignError('Please enter a group name.'); setAssigning(false); return; }
@@ -190,14 +197,19 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
                 groupId = selectedGroupId;
                 const existing = groups.find(g => g.id === groupId);
                 originalSensorIds = new Set(existing?.sensorIds ?? []);
+                originalSwitchIds = new Set(existing?.switchIds ?? []);
             }
 
-            const toAdd    = [...selectedSensorIds].filter(id => !originalSensorIds.has(id));
-            const toRemove = [...originalSensorIds].filter(id => !selectedSensorIds.has(id));
+            const sensorsToAdd    = [...selectedSensorIds].filter(id => !originalSensorIds.has(id));
+            const sensorsToRemove = [...originalSensorIds].filter(id => !selectedSensorIds.has(id));
+            const switchesToAdd    = [...selectedSwitchIds].filter(id => !originalSwitchIds.has(id));
+            const switchesToRemove = [...originalSwitchIds].filter(id => !selectedSwitchIds.has(id));
 
             await Promise.all([
-                ...toAdd.map(id    => GroupService.addSensor(groupId, id)),
-                ...toRemove.map(id => GroupService.removeSensor(groupId, id)),
+                ...sensorsToAdd.map(id    => GroupService.addSensor(groupId, id)),
+                ...sensorsToRemove.map(id => GroupService.removeSensor(groupId, id)),
+                ...switchesToAdd.map(id    => GroupService.addSwitch(groupId, id)),
+                ...switchesToRemove.map(id => GroupService.removeSwitch(groupId, id)),
             ]);
             setStep(3);
         } catch {
@@ -283,6 +295,10 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
                     (s.customName ?? s.defaultName ?? s.name)
                         .toLowerCase().includes(sensorSearch.toLowerCase())
                 );
+                const filteredSwitches = allSwitches.filter(sw =>
+                    (sw.customName ?? sw.name)
+                        .toLowerCase().includes(sensorSearch.toLowerCase())
+                );
                 const toggleSensor = (id: number) => {
                     setSelectedSensorIds(prev => {
                         const next = new Set(prev);
@@ -290,12 +306,20 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
                         return next;
                     });
                 };
+                const toggleSwitch = (id: number) => {
+                    setSelectedSwitchIds(prev => {
+                        const next = new Set(prev);
+                        next.has(id) ? next.delete(id) : next.add(id);
+                        return next;
+                    });
+                };
+                const totalSelected = selectedSensorIds.size + selectedSwitchIds.size;
 
                 return (
                     <div className="space-y-4">
                         <div>
                             <h2 className="text-xl font-bold text-gray-100 mb-1">Assign to a group</h2>
-                            <p className="text-sm text-gray-400">Pick a group and the sensors to include.</p>
+                            <p className="text-sm text-gray-400">Pick a group and the devices to include.</p>
                         </div>
 
                         {/* Group picker */}
@@ -340,7 +364,7 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
                                     type="text"
                                     value={newGroupName}
                                     onChange={e => setNewGroupName(e.target.value)}
-                                    placeholder="Group name (e.g. Honda CB500)"
+                                    placeholder="Group name (e.g. Storage Room)"
                                     className="w-full px-3 py-2 bg-gray-900/60 border border-gray-700/40 rounded-lg text-gray-100 placeholder-gray-600 focus:outline-none focus:border-sky-600/50 text-sm"
                                 />
                                 <div className="grid grid-cols-4 gap-2">
@@ -363,7 +387,21 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
                             </div>
                         )}
 
-                        {/* Sensor picker */}
+                        {/* Device search */}
+                        <div className="relative">
+                            <svg className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-gray-500 pointer-events-none" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                                <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-4.35-4.35M17 11A6 6 0 1 1 5 11a6 6 0 0 1 12 0z" />
+                            </svg>
+                            <input
+                                type="text"
+                                value={sensorSearch}
+                                onChange={e => setSensorSearch(e.target.value)}
+                                placeholder="Search devices..."
+                                className="w-full pl-8 pr-3 py-2 bg-gray-800/60 border border-gray-700/40 rounded-xl text-sm text-gray-200 placeholder-gray-600 focus:outline-none focus:border-sky-600/50 transition-all"
+                            />
+                        </div>
+
+                        {/* Sensors section */}
                         <div className="space-y-2">
                             <p className="text-xs font-semibold text-gray-500 uppercase tracking-widest">
                                 Sensors
@@ -373,21 +411,9 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
                                     </span>
                                 )}
                             </p>
-                            <div className="relative">
-                                <svg className="absolute left-3 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-gray-500 pointer-events-none" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                                    <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-4.35-4.35M17 11A6 6 0 1 1 5 11a6 6 0 0 1 12 0z" />
-                                </svg>
-                                <input
-                                    type="text"
-                                    value={sensorSearch}
-                                    onChange={e => setSensorSearch(e.target.value)}
-                                    placeholder="Search sensors..."
-                                    className="w-full pl-8 pr-3 py-2 bg-gray-800/60 border border-gray-700/40 rounded-xl text-sm text-gray-200 placeholder-gray-600 focus:outline-none focus:border-sky-600/50 transition-all"
-                                />
-                            </div>
-                            <div className="space-y-1.5 max-h-44 overflow-y-auto pr-1">
+                            <div className="space-y-1.5 max-h-36 overflow-y-auto pr-1">
                                 {filteredSensors.length === 0 ? (
-                                    <p className="text-xs text-gray-600 italic py-2 text-center">No sensors found</p>
+                                    <p className="text-xs text-gray-600 italic py-1 text-center">No sensors found</p>
                                 ) : filteredSensors.map(s => {
                                     const name = s.customName ?? s.defaultName ?? s.name;
                                     const checked = selectedSensorIds.has(s.id);
@@ -419,6 +445,48 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
                             </div>
                         </div>
 
+                        {/* Sockets section */}
+                        {allSwitches.length > 0 && (
+                            <div className="space-y-2">
+                                <p className="text-xs font-semibold text-gray-500 uppercase tracking-widest">
+                                    Sockets
+                                    {selectedSwitchIds.size > 0 && (
+                                        <span className="ml-2 text-sky-400 normal-case font-normal tracking-normal">
+                                            {selectedSwitchIds.size} selected
+                                        </span>
+                                    )}
+                                </p>
+                                <div className="space-y-1.5 max-h-36 overflow-y-auto pr-1">
+                                    {filteredSwitches.length === 0 ? (
+                                        <p className="text-xs text-gray-600 italic py-1 text-center">No sockets found</p>
+                                    ) : filteredSwitches.map(sw => {
+                                        const name = sw.customName ?? sw.name;
+                                        const checked = selectedSwitchIds.has(sw.id);
+                                        return (
+                                            <button
+                                                key={sw.id}
+                                                type="button"
+                                                onClick={() => toggleSwitch(sw.id)}
+                                                className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-xl border text-left transition-all text-sm ${
+                                                    checked
+                                                        ? 'bg-sky-600/10 border-sky-500/30 text-sky-100'
+                                                        : 'bg-gray-800/30 border-gray-700/20 text-gray-400 hover:bg-gray-700/40 hover:text-gray-200 hover:border-gray-600/40'
+                                                }`}
+                                            >
+                                                <span className="text-base w-5 text-center flex-shrink-0">🔌</span>
+                                                <span className="flex-1 truncate font-medium">{name}</span>
+                                                <div className={`w-4 h-4 rounded-md border flex-shrink-0 flex items-center justify-center transition-all ${
+                                                    checked ? 'bg-sky-500 border-sky-500' : 'border-gray-600'
+                                                }`}>
+                                                    {checked && <CheckIcon className="h-3 w-3 text-white" />}
+                                                </div>
+                                            </button>
+                                        );
+                                    })}
+                                </div>
+                            </div>
+                        )}
+
                         {assignError && <p className="text-red-400 text-xs">{assignError}</p>}
 
                         <Btn
@@ -426,7 +494,7 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
                             loading={assigning}
                             disabled={selectedGroupId === null}
                         >
-                            {selectedGroupId === null ? 'Select a group' : `Save group${selectedSensorIds.size > 0 ? ` · ${selectedSensorIds.size} sensor${selectedSensorIds.size !== 1 ? 's' : ''}` : ''}`}
+                            {selectedGroupId === null ? 'Select a group' : `Save group${totalSelected > 0 ? ` · ${totalSelected} device${totalSelected !== 1 ? 's' : ''}` : ''}`}
                             <ChevronRightIcon className="h-4 w-4" />
                         </Btn>
                         <Btn variant="ghost" onClick={() => setStep(3)}>Skip</Btn>

--- a/src/app/SetupWizard.tsx
+++ b/src/app/SetupWizard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect, useRef, useState } from 'react';
+import { useSession } from 'next-auth/react';
 import { XMarkIcon, ChevronRightIcon, CheckIcon } from '@heroicons/react/24/outline';
 import SensorService, { Sensor } from '@/services/sensorService';
 import SwitchService, { Switch } from '@/services/switchService';
@@ -68,6 +69,7 @@ const Btn: React.FC<{
 // ── Main wizard ────────────────────────────────────────────────────────────────
 
 const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialStep, prefillGroupId, onComplete }) => {
+    const { update: updateSession } = useSession();
     const [step, setStep]               = useState(initialStep ?? (prefillSensor ? 1 : 0));
     const [regCode, setRegCode]         = useState('');
     const [claimError, setClaimError]   = useState('');
@@ -151,6 +153,8 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
         setClaimError('');
         try {
             await SensorService.claimSensor(regCode.trim());
+            // Force a session/token refresh so the new sensor role is included in the JWT
+            await updateSession();
             // Fetch updated sensor list to find the newly claimed one
             const all = await SensorService.getAllSensors();
             const found = all.find(s => s.registrationCode === regCode.trim());

--- a/src/app/SetupWizard.tsx
+++ b/src/app/SetupWizard.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { useEffect, useRef, useState } from 'react';
-import { useSession } from 'next-auth/react';
 import { XMarkIcon, ChevronRightIcon, CheckIcon } from '@heroicons/react/24/outline';
 import SensorService, { Sensor } from '@/services/sensorService';
 import SwitchService, { Switch } from '@/services/switchService';
@@ -69,7 +68,6 @@ const Btn: React.FC<{
 // ── Main wizard ────────────────────────────────────────────────────────────────
 
 const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialStep, prefillGroupId, onComplete }) => {
-    const { update: updateSession } = useSession();
     const [step, setStep]               = useState(initialStep ?? (prefillSensor ? 1 : 0));
     const [regCode, setRegCode]         = useState('');
     const [claimError, setClaimError]   = useState('');
@@ -153,8 +151,6 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
         setClaimError('');
         try {
             await SensorService.claimSensor(regCode.trim());
-            // Force a session/token refresh so the new sensor role is included in the JWT
-            await updateSession();
             // Fetch updated sensor list to find the newly claimed one
             const all = await SensorService.getAllSensors();
             const found = all.find(s => s.registrationCode === regCode.trim());

--- a/src/app/SetupWizard.tsx
+++ b/src/app/SetupWizard.tsx
@@ -329,7 +329,15 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
                                     <button
                                         key={g.id}
                                         type="button"
-                                        onClick={() => setSelectedGroupId(g.id)}
+                                        onClick={() => {
+                                            setSelectedGroupId(g.id);
+                                            // Seed selection with this group's current members + any already-claimed sensor
+                                            setSelectedSensorIds(new Set([
+                                                ...g.sensorIds,
+                                                ...(claimedSensor ? [claimedSensor.id] : []),
+                                            ]));
+                                            setSelectedSwitchIds(new Set(g.switchIds));
+                                        }}
                                         className={`w-full flex items-center gap-3 px-4 py-2.5 rounded-xl border text-left transition-all text-sm ${
                                             selectedGroupId === g.id
                                                 ? 'bg-sky-600/15 border-sky-500/40 text-sky-200'
@@ -344,7 +352,12 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
                             })}
                             <button
                                 type="button"
-                                onClick={() => setSelectedGroupId('new')}
+                                onClick={() => {
+                                    setSelectedGroupId('new');
+                                    // Reset to just the newly claimed sensor (if any)
+                                    setSelectedSensorIds(new Set(claimedSensor ? [claimedSensor.id] : []));
+                                    setSelectedSwitchIds(new Set());
+                                }}
                                 className={`w-full flex items-center gap-3 px-4 py-2.5 rounded-xl border text-left transition-all text-sm ${
                                     selectedGroupId === 'new'
                                         ? 'bg-sky-600/15 border-sky-500/40 text-sky-200'

--- a/src/app/SetupWizard.tsx
+++ b/src/app/SetupWizard.tsx
@@ -69,10 +69,12 @@ const Btn: React.FC<{
 
 const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialStep, prefillGroupId, onComplete }) => {
     const [step, setStep]               = useState(initialStep ?? (prefillSensor ? 1 : 0));
+    const [claimType, setClaimType]     = useState<'sensor' | 'socket'>('sensor');
     const [regCode, setRegCode]         = useState('');
     const [claimError, setClaimError]   = useState('');
     const [claiming, setClaiming]       = useState(false);
     const [claimedSensor, setClaimedSensor] = useState<Sensor | null>(prefillSensor ?? null);
+    const [claimedSwitch, setClaimedSwitch] = useState<Switch | null>(null);
 
     const [customName, setCustomName]   = useState(prefillSensor?.customName ?? prefillSensor?.defaultName ?? '');
     const [saving, setSaving]           = useState(false);
@@ -144,22 +146,30 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
         }
     }, [step, prefillGroupId]);
 
-    // Step 0: Claim sensor
+    // Step 0: Claim sensor or switch
     const handleClaim = async () => {
         if (!regCode.trim()) return;
         setClaiming(true);
         setClaimError('');
         try {
-            await SensorService.claimSensor(regCode.trim());
-            // Fetch updated sensor list to find the newly claimed one
-            const all = await SensorService.getAllSensors();
-            const found = all.find(s => s.registrationCode === regCode.trim());
-            setClaimedSensor(found ?? null);
-            setCustomName(found?.customName ?? found?.defaultName ?? found?.name ?? '');
-            if (found) setSelectedSensorIds(new Set([found.id]));
+            if (claimType === 'sensor') {
+                await SensorService.claimSensor(regCode.trim());
+                const all = await SensorService.getAllSensors();
+                const found = all.find(s => s.registrationCode === regCode.trim());
+                setClaimedSensor(found ?? null);
+                setCustomName(found?.customName ?? found?.defaultName ?? found?.name ?? '');
+                if (found) setSelectedSensorIds(new Set([found.id]));
+            } else {
+                const { switchId } = await SwitchService.claimSwitch(regCode.trim());
+                const all = await SwitchService.getAllSwitches();
+                const found = all.find(sw => sw.id === switchId);
+                setClaimedSwitch(found ?? null);
+                setCustomName(found?.customName ?? found?.name ?? '');
+                if (found) setSelectedSwitchIds(new Set([found.id]));
+            }
             setStep(1);
         } catch (e: unknown) {
-            setClaimError(e instanceof Error ? e.message : 'Failed to claim sensor.');
+            setClaimError(e instanceof Error ? e.message : `Failed to claim ${claimType}.`);
         } finally {
             setClaiming(false);
         }
@@ -167,10 +177,13 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
 
     // Step 1: Save name
     const handleSaveName = async () => {
-        if (!claimedSensor) { setStep(2); return; }
         setSaving(true);
         try {
-            await SensorService.updateCustomName(claimedSensor.id, customName.trim() || claimedSensor.defaultName);
+            if (claimedSensor) {
+                await SensorService.updateCustomName(claimedSensor.id, customName.trim() || claimedSensor.defaultName);
+            } else if (claimedSwitch) {
+                await SwitchService.updateCustomName(claimedSwitch.id, customName.trim() || claimedSwitch.name);
+            }
             setStep(2);
         } catch {
             setStep(2); // non-fatal — proceed anyway
@@ -236,9 +249,38 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
                 return (
                     <div className="space-y-5">
                         <div>
-                            <h2 className="text-xl font-bold text-gray-100 mb-1">Add a sensor</h2>
-                            <p className="text-sm text-gray-400">Enter the device code for your sensor.</p>
+                            <h2 className="text-xl font-bold text-gray-100 mb-1">
+                                Add a {claimType === 'sensor' ? 'sensor' : 'socket'}
+                            </h2>
+                            <p className="text-sm text-gray-400">Enter the device code found on your device.</p>
                         </div>
+
+                        {/* Type toggle */}
+                        <div className="flex gap-2 p-1 bg-gray-800/60 rounded-xl">
+                            <button
+                                type="button"
+                                onClick={() => { setClaimType('sensor'); setRegCode(''); setClaimError(''); }}
+                                className={`flex-1 py-2 rounded-lg text-sm font-medium transition-all ${
+                                    claimType === 'sensor'
+                                        ? 'bg-sky-600 text-white shadow'
+                                        : 'text-gray-400 hover:text-gray-200'
+                                }`}
+                            >
+                                🌡️ Sensor
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => { setClaimType('socket'); setRegCode(''); setClaimError(''); }}
+                                className={`flex-1 py-2 rounded-lg text-sm font-medium transition-all ${
+                                    claimType === 'socket'
+                                        ? 'bg-sky-600 text-white shadow'
+                                        : 'text-gray-400 hover:text-gray-200'
+                                }`}
+                            >
+                                🔌 Socket
+                            </button>
+                        </div>
+
                         <div className="space-y-3">
                             <input
                                 type="text"
@@ -253,7 +295,7 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
                             {claimError && <p className="text-red-400 text-xs">{claimError}</p>}
                         </div>
                         <Btn onClick={handleClaim} loading={claiming} disabled={!regCode.trim()}>
-                            Claim sensor
+                            Claim {claimType === 'sensor' ? 'sensor' : 'socket'}
                             <ChevronRightIcon className="h-4 w-4" />
                         </Btn>
                         <Btn variant="ghost" onClick={() => setStep(2)}>
@@ -266,10 +308,17 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
                 return (
                     <div className="space-y-5">
                         <div>
-                            <h2 className="text-xl font-bold text-gray-100 mb-1">Name your sensor</h2>
+                            <h2 className="text-xl font-bold text-gray-100 mb-1">
+                                Name your {claimedSwitch ? 'socket' : 'sensor'}
+                            </h2>
                             {claimedSensor && (
                                 <span className="inline-block mt-1 text-xs bg-sky-500/15 text-sky-300 border border-sky-500/20 rounded-full px-2.5 py-0.5">
                                     {typeLabel(claimedSensor.type)}
+                                </span>
+                            )}
+                            {claimedSwitch && (
+                                <span className="inline-block mt-1 text-xs bg-sky-500/15 text-sky-300 border border-sky-500/20 rounded-full px-2.5 py-0.5">
+                                    🔌 Socket
                                 </span>
                             )}
                         </div>
@@ -279,7 +328,7 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
                             value={customName}
                             onChange={e => setCustomName(e.target.value)}
                             onKeyDown={e => e.key === 'Enter' && handleSaveName()}
-                            placeholder="e.g. Honda CB500 Battery"
+                            placeholder={claimedSwitch ? 'e.g. Storage Heater 1' : 'e.g. Honda CB500 Battery'}
                             className="w-full px-4 py-3 bg-gray-800/60 border border-gray-700/40 rounded-xl text-gray-100 placeholder-gray-500 focus:outline-none focus:border-sky-600/50 text-sm transition-all"
                         />
                         <Btn onClick={handleSaveName} loading={saving}>
@@ -331,12 +380,15 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
                                         type="button"
                                         onClick={() => {
                                             setSelectedGroupId(g.id);
-                                            // Seed selection with this group's current members + any already-claimed sensor
+                                            // Seed selection with this group's current members + any already-claimed device
                                             setSelectedSensorIds(new Set([
                                                 ...g.sensorIds,
                                                 ...(claimedSensor ? [claimedSensor.id] : []),
                                             ]));
-                                            setSelectedSwitchIds(new Set(g.switchIds));
+                                            setSelectedSwitchIds(new Set([
+                                                ...g.switchIds,
+                                                ...(claimedSwitch ? [claimedSwitch.id] : []),
+                                            ]));
                                         }}
                                         className={`w-full flex items-center gap-3 px-4 py-2.5 rounded-xl border text-left transition-all text-sm ${
                                             selectedGroupId === g.id
@@ -354,9 +406,9 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
                                 type="button"
                                 onClick={() => {
                                     setSelectedGroupId('new');
-                                    // Reset to just the newly claimed sensor (if any)
+                                    // Reset to just the newly claimed device (if any)
                                     setSelectedSensorIds(new Set(claimedSensor ? [claimedSensor.id] : []));
-                                    setSelectedSwitchIds(new Set());
+                                    setSelectedSwitchIds(new Set(claimedSwitch ? [claimedSwitch.id] : []));
                                 }}
                                 className={`w-full flex items-center gap-3 px-4 py-2.5 rounded-xl border text-left transition-all text-sm ${
                                     selectedGroupId === 'new'
@@ -528,8 +580,13 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
                                     <span className="text-gray-200 font-medium">{customName || claimedSensor.defaultName}</span> is ready.
                                     {' '}Head to your dashboard to see live data.
                                 </p>
+                            ) : claimedSwitch ? (
+                                <p className="text-sm text-gray-400">
+                                    <span className="text-gray-200 font-medium">{customName || claimedSwitch.name}</span> is ready.
+                                    {' '}Head to your dashboard to control it.
+                                </p>
                             ) : (
-                                <p className="text-sm text-gray-400">Your group has been created. Add sensors to it anytime.</p>
+                                <p className="text-sm text-gray-400">Your group has been created. Add devices to it anytime.</p>
                             )}
                         </div>
                         <Btn onClick={() => { onComplete?.(); onClose(); }}>

--- a/src/app/footer.tsx
+++ b/src/app/footer.tsx
@@ -11,7 +11,7 @@ export default function Footer() {
 
                 {/* Brand */}
                 <div className="flex items-center gap-2.5">
-                    <Image src="/garge-icon-large.png" height={32} width={0} style={{ width: 'auto' }} alt="Garge" />
+                    <Image src="/garge-icon-large.png" height={32} width={32} quality={75} style={{ width: 'auto' }} alt="Garge" />
                     <span className="text-sm font-semibold text-gray-300">Garge</span>
                 </div>
 

--- a/src/app/navbar.tsx
+++ b/src/app/navbar.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
 import { signOut, useSession } from 'next-auth/react';
-import { ArrowRightOnRectangleIcon } from '@heroicons/react/24/outline';
+import { ArrowRightStartOnRectangleIcon } from '@heroicons/react/24/outline';
 
 export default function Navbar() {
     const { data: session, status } = useSession();
@@ -15,7 +15,7 @@ export default function Navbar() {
             <div className="px-4 sm:px-6 py-3 flex items-center justify-between max-w-7xl mx-auto">
 
                 <Link href="/" className="flex items-center gap-2.5">
-                    <Image src="/garge-icon-large.png" height={36} width={0} style={{ width: 'auto' }} alt="Garge" priority />
+                    <Image src="/garge-icon-large.png" height={32} width={32} quality={75} style={{ width: 'auto' }} alt="Garge" priority/>
                     <span className="text-sm font-semibold text-gray-100 tracking-wide hidden sm:block">Garge</span>
                 </Link>
 
@@ -33,7 +33,7 @@ export default function Navbar() {
                                 title="Logout"
                                 className="flex items-center gap-1.5 px-3 py-1.5 rounded-xl text-sm font-medium text-gray-300 hover:text-white hover:bg-gray-700/60 transition-all"
                             >
-                                <ArrowRightOnRectangleIcon className="h-4 w-4" />
+                                <ArrowRightStartOnRectangleIcon className="h-4 w-4" />
                                 <span className="hidden sm:block">Logout</span>
                             </button>
                         </>

--- a/src/components/CollapsibleSection.tsx
+++ b/src/components/CollapsibleSection.tsx
@@ -6,10 +6,11 @@ interface CollapsibleSectionProps {
     count: number;
     children: React.ReactNode;
     className?: string;
+    defaultOpen?: boolean;
 }
 
-const CollapsibleSection: React.FC<CollapsibleSectionProps> = ({ label, count, children, className = '' }) => {
-    const [open, setOpen] = useState(false);
+const CollapsibleSection: React.FC<CollapsibleSectionProps> = ({ label, count, children, className = '', defaultOpen = false }) => {
+    const [open, setOpen] = useState(defaultOpen);
     return (
         <div className={`mt-8 ${className}`}>
             <button

--- a/src/services/groupService.ts
+++ b/src/services/groupService.ts
@@ -5,6 +5,7 @@ export interface Group {
   name: string;
   icon: string | null;
   sensorIds: number[];
+  switchIds: number[];
 }
 
 const GroupService = {
@@ -32,6 +33,14 @@ const GroupService = {
 
   async removeSensor(groupId: number, sensorId: number): Promise<void> {
     await axiosInstance.delete(`/groups/${groupId}/sensors/${sensorId}`);
+  },
+
+  async addSwitch(groupId: number, switchId: number): Promise<void> {
+    await axiosInstance.post(`/groups/${groupId}/switches/${switchId}`);
+  },
+
+  async removeSwitch(groupId: number, switchId: number): Promise<void> {
+    await axiosInstance.delete(`/groups/${groupId}/switches/${switchId}`);
   },
 };
 

--- a/src/services/switchService.ts
+++ b/src/services/switchService.ts
@@ -6,6 +6,7 @@ export interface Switch {
     name: string;
     type: string;
     role: string;
+    customName?: string;
 }
 
 export interface SwitchData {
@@ -121,6 +122,19 @@ const SwitchService = {
                 throw new Error(error.response?.data.message || 'Failed to fetch multiple switches data');
             } else {
                 console.error('Unknown Error:', error);
+                throw new Error('An unknown error occurred');
+            }
+        }
+    },
+
+    async updateCustomName(switchId: number, customName: string): Promise<Switch> {
+        try {
+            const response = await axiosInstance.patch<Switch>(`/switches/${switchId}/custom-name`, { customName });
+            return response.data;
+        } catch (error: unknown) {
+            if (error instanceof AxiosError) {
+                throw new Error(error.response?.data.message || 'Failed to update switch name');
+            } else {
                 throw new Error('An unknown error occurred');
             }
         }

--- a/src/services/switchService.ts
+++ b/src/services/switchService.ts
@@ -7,6 +7,7 @@ export interface Switch {
     type: string;
     role: string;
     customName?: string;
+    registrationCode?: string;
 }
 
 export interface SwitchData {
@@ -134,6 +135,31 @@ const SwitchService = {
         } catch (error: unknown) {
             if (error instanceof AxiosError) {
                 throw new Error(error.response?.data.message || 'Failed to update switch name');
+            } else {
+                throw new Error('An unknown error occurred');
+            }
+        }
+    },
+
+    async claimSwitch(registrationCode: string): Promise<{ switchId: number; registrationCode: string }> {
+        try {
+            const response = await axiosInstance.post<{ switchId: number; registrationCode: string }>('/switches/claim', { registrationCode });
+            return response.data;
+        } catch (error: unknown) {
+            if (error instanceof AxiosError) {
+                throw new Error(error.response?.data.message || 'Failed to claim switch');
+            } else {
+                throw new Error('An unknown error occurred');
+            }
+        }
+    },
+
+    async unclaimSwitch(switchId: number): Promise<void> {
+        try {
+            await axiosInstance.delete(`/switches/${switchId}/claim`);
+        } catch (error: unknown) {
+            if (error instanceof AxiosError) {
+                throw new Error(error.response?.data.message || 'Failed to unclaim switch');
             } else {
                 throw new Error('An unknown error occurred');
             }


### PR DESCRIPTION
## Summary

Several frontend features and fixes built on top of the UserSensors/UserSwitches backend refactor.

### Socket self-claim in SetupWizard
- Step 0 now has a Sensor/Socket toggle
- Claiming a socket uses `SwitchService.claimSwitch()` (registration code flow)
- Steps 1–3 adapt to the claimed device type

### Profile page improvements
- "Add a device" section now supports both sensors and sockets (toggle + unified handler)
- Removed stale `updateSession()` JWT workaround (access is now DB-driven server-side)
- Sockets section: added device code display and "Remove from account" with confirm modal

### Bug fixes
- Wizard: clicking an existing group no longer unassigns current members
- Newly claimed sensor immediately visible (no JWT refresh needed)

### Other
- Removed `updateSession` from SetupWizard after backend migration
- Consistent `e.g. A1B2C3D4E5` placeholder in profile page device code input
