### PR TITLE
fix(electricity): mobile-friendly chart with line on small screens

### DIFF
--- a/src/app/(protected)/electricity/page.tsx
+++ b/src/app/(protected)/electricity/page.tsx
@@ -20,7 +20,7 @@ const LoadingDots = () => (
 );
 
 const TABS = [
-    { label: 'Today', key: 'today',  frequency: 'HOURLY',  dateType: 'today',           chartType: 'line' as const },
+    { label: 'Today', key: 'today',  frequency: 'HOURLY',  dateType: 'today',           chartType: 'bar'  as const },
     { label: 'Week',  key: 'week',   frequency: 'DAILY',   dateType: 'last7Days',        chartType: 'bar'  as const },
     { label: 'Month', key: 'month',  frequency: 'DAILY',   dateType: 'firstDayOfMonth',  chartType: 'bar'  as const },
     { label: 'Year',  key: 'year',   frequency: 'MONTHLY', dateType: 'firstDayOfYear',   chartType: 'bar'  as const },

--- a/src/app/(protected)/electricity/page.tsx
+++ b/src/app/(protected)/electricity/page.tsx
@@ -20,10 +20,10 @@ const LoadingDots = () => (
 );
 
 const TABS = [
-    { label: 'Today', key: 'today',  frequency: 'HOURLY',  dateType: 'today'          },
-    { label: 'Week',  key: 'week',   frequency: 'DAILY',   dateType: 'last7Days'      },
-    { label: 'Month', key: 'month',  frequency: 'DAILY',   dateType: 'firstDayOfMonth' },
-    { label: 'Year',  key: 'year',   frequency: 'MONTHLY', dateType: 'firstDayOfYear' },
+    { label: 'Today', key: 'today',  frequency: 'HOURLY',  dateType: 'today',           chartType: 'line' as const },
+    { label: 'Week',  key: 'week',   frequency: 'DAILY',   dateType: 'last7Days',        chartType: 'bar'  as const },
+    { label: 'Month', key: 'month',  frequency: 'DAILY',   dateType: 'firstDayOfMonth',  chartType: 'bar'  as const },
+    { label: 'Year',  key: 'year',   frequency: 'MONTHLY', dateType: 'firstDayOfYear',   chartType: 'bar'  as const },
 ] as const;
 
 type TabKey = typeof TABS[number]['key'];
@@ -157,7 +157,7 @@ const ElectricityPage = () => {
                     ) : error ? (
                         <div className="h-[300px] flex items-center justify-center text-red-400 text-sm">{error}</div>
                     ) : data.length > 0 ? (
-                        <TimeSeriesChart title="" data={data} chartType="bar" />
+                        <TimeSeriesChart title="" data={data} chartType={TABS.find(t => t.key === activeTab)!.chartType} />
                     ) : (
                         <div className="h-[300px] flex items-center justify-center text-gray-500 text-sm">
                             No data available

--- a/src/components/TimeSeriesChart.tsx
+++ b/src/components/TimeSeriesChart.tsx
@@ -8,9 +8,6 @@ interface TimeSeriesChartProps {
     chartType?: 'line' | 'bar';
 }
 
-// Minimum pixels per bar to keep bars readable on mobile
-const MIN_BAR_WIDTH_PX = 24;
-
 const TimeSeriesChart: React.FC<TimeSeriesChartProps> = ({ title, data, chartType = 'line' }) => {
     const series = useMemo(() => [
         {
@@ -18,14 +15,6 @@ const TimeSeriesChart: React.FC<TimeSeriesChartProps> = ({ title, data, chartTyp
             data: data
         }
     ], [title, data]);
-
-    // Compute a minimum chart width so bars never get thinner than MIN_BAR_WIDTH_PX.
-    // ApexCharts will make the plot area scrollable horizontally when the viewport
-    // is narrower than this value.
-    const minScrollWidth = useMemo(() => {
-        if (chartType !== 'bar' || data.length <= 10) return undefined;
-        return data.length * MIN_BAR_WIDTH_PX;
-    }, [chartType, data.length]);
 
     const options: ApexOptions = useMemo(() => ({
         chart: {
@@ -45,14 +34,7 @@ const TimeSeriesChart: React.FC<TimeSeriesChartProps> = ({ title, data, chartTyp
                     zoomout: true
                 }
             },
-            foreColor: '#f0f0f0',
-            ...(minScrollWidth ? {
-                scrollablePlotArea: {
-                    minWidth: minScrollWidth,
-                    scrollWidth: minScrollWidth,
-                    offsetX: 0
-                }
-            } : {})
+            foreColor: '#f0f0f0'
         },
         plotOptions: {
             bar: {
@@ -74,10 +56,7 @@ const TimeSeriesChart: React.FC<TimeSeriesChartProps> = ({ title, data, chartTyp
                 style: {
                     colors: '#f0f0f0'
                 },
-                // Fewer x-axis labels on small screens to reduce crowding
-                hideOverlappingLabels: true,
-                rotate: -30,
-                rotateAlways: false,
+                hideOverlappingLabels: true
             }
         },
         yaxis: {
@@ -107,18 +86,14 @@ const TimeSeriesChart: React.FC<TimeSeriesChartProps> = ({ title, data, chartTyp
                 format: 'dd.MM.yyyy HH:mm:ss'
             }
         }
-    }), [title, chartType, minScrollWidth]);
+    }), [title, chartType]);
 
     if (!data || data.length === 0) {
         return null;
     }
 
     return (
-        <div className="overflow-x-auto w-full">
-            <div style={{ minWidth: minScrollWidth ?? '100%' }}>
-                <Chart options={options} series={series} type={chartType} height={350} />
-            </div>
-        </div>
+        <Chart options={options} series={series} type={chartType} height={350} />
     );
 };
 

--- a/src/components/TimeSeriesChart.tsx
+++ b/src/components/TimeSeriesChart.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState, useEffect } from 'react';
 import Chart from "react-apexcharts";
 import { ApexOptions } from 'apexcharts';
 
@@ -9,6 +9,18 @@ interface TimeSeriesChartProps {
 }
 
 const TimeSeriesChart: React.FC<TimeSeriesChartProps> = ({ title, data, chartType = 'line' }) => {
+    const [isMobile, setIsMobile] = useState(false);
+
+    useEffect(() => {
+        const check = () => setIsMobile(window.innerWidth < 640);
+        check();
+        window.addEventListener('resize', check);
+        return () => window.removeEventListener('resize', check);
+    }, []);
+
+    // On mobile, always use a line chart regardless of the requested type
+    const effectiveType = isMobile && chartType === 'bar' ? 'line' : chartType;
+
     const series = useMemo(() => [
         {
             name: title,
@@ -18,7 +30,7 @@ const TimeSeriesChart: React.FC<TimeSeriesChartProps> = ({ title, data, chartTyp
 
     const options: ApexOptions = useMemo(() => ({
         chart: {
-            type: chartType,
+            type: effectiveType,
             height: 350,
             animations: {
                 enabled: false
@@ -42,19 +54,6 @@ const TimeSeriesChart: React.FC<TimeSeriesChartProps> = ({ title, data, chartTyp
                 borderRadius: 2
             }
         },
-        responsive: [
-            {
-                breakpoint: 640,
-                options: {
-                    plotOptions: {
-                        bar: {
-                            columnWidth: '20%',
-                            borderRadius: 1
-                        }
-                    }
-                }
-            }
-        ],
         title: {
             text: title,
             align: 'left',
@@ -70,6 +69,9 @@ const TimeSeriesChart: React.FC<TimeSeriesChartProps> = ({ title, data, chartTyp
                     colors: '#f0f0f0'
                 },
                 hideOverlappingLabels: true
+            },
+            crosshairs: {
+                show: true
             }
         },
         yaxis: {
@@ -82,13 +84,21 @@ const TimeSeriesChart: React.FC<TimeSeriesChartProps> = ({ title, data, chartTyp
         },
         stroke: {
             curve: 'smooth',
-            width: 3
+            width: effectiveType === 'line' ? 3 : 0
+        },
+        markers: {
+            size: effectiveType === 'line' ? 0 : 0,
+            hover: {
+                size: effectiveType === 'line' ? 5 : 0
+            }
         },
         dataLabels: {
             enabled: false
         },
         tooltip: {
             theme: 'dark',
+            shared: true,
+            intersect: false,
             style: {
                 fontSize: '12px',
                 fontFamily: undefined,
@@ -96,17 +106,17 @@ const TimeSeriesChart: React.FC<TimeSeriesChartProps> = ({ title, data, chartTyp
                 color: '#f0f0f0'
             },
             x: {
-                format: 'dd.MM.yyyy HH:mm:ss'
+                format: 'dd.MM.yyyy HH:mm'
             }
         }
-    }), [title, chartType]);
+    }), [title, effectiveType]);
 
     if (!data || data.length === 0) {
         return null;
     }
 
     return (
-        <Chart options={options} series={series} type={chartType} height={350} />
+        <Chart options={options} series={series} type={effectiveType} height={350} />
     );
 };
 

--- a/src/components/TimeSeriesChart.tsx
+++ b/src/components/TimeSeriesChart.tsx
@@ -8,6 +8,9 @@ interface TimeSeriesChartProps {
     chartType?: 'line' | 'bar';
 }
 
+// Minimum pixels per bar to keep bars readable on mobile
+const MIN_BAR_WIDTH_PX = 24;
+
 const TimeSeriesChart: React.FC<TimeSeriesChartProps> = ({ title, data, chartType = 'line' }) => {
     const series = useMemo(() => [
         {
@@ -15,6 +18,14 @@ const TimeSeriesChart: React.FC<TimeSeriesChartProps> = ({ title, data, chartTyp
             data: data
         }
     ], [title, data]);
+
+    // Compute a minimum chart width so bars never get thinner than MIN_BAR_WIDTH_PX.
+    // ApexCharts will make the plot area scrollable horizontally when the viewport
+    // is narrower than this value.
+    const minScrollWidth = useMemo(() => {
+        if (chartType !== 'bar' || data.length <= 10) return undefined;
+        return data.length * MIN_BAR_WIDTH_PX;
+    }, [chartType, data.length]);
 
     const options: ApexOptions = useMemo(() => ({
         chart: {
@@ -34,7 +45,20 @@ const TimeSeriesChart: React.FC<TimeSeriesChartProps> = ({ title, data, chartTyp
                     zoomout: true
                 }
             },
-            foreColor: '#f0f0f0'
+            foreColor: '#f0f0f0',
+            ...(minScrollWidth ? {
+                scrollablePlotArea: {
+                    minWidth: minScrollWidth,
+                    scrollWidth: minScrollWidth,
+                    offsetX: 0
+                }
+            } : {})
+        },
+        plotOptions: {
+            bar: {
+                columnWidth: '70%',
+                borderRadius: 2
+            }
         },
         title: {
             text: title,
@@ -49,16 +73,14 @@ const TimeSeriesChart: React.FC<TimeSeriesChartProps> = ({ title, data, chartTyp
                 datetimeUTC: false,
                 style: {
                     colors: '#f0f0f0'
-                }
+                },
+                // Fewer x-axis labels on small screens to reduce crowding
+                hideOverlappingLabels: true,
+                rotate: -30,
+                rotateAlways: false,
             }
         },
         yaxis: {
-            //title: {
-            //    text: 'Value',
-            //    style: {
-            //        color: '#f0f0f0'
-            //    }
-            //},
             labels: {
                 style: {
                     colors: '#f0f0f0'
@@ -85,14 +107,18 @@ const TimeSeriesChart: React.FC<TimeSeriesChartProps> = ({ title, data, chartTyp
                 format: 'dd.MM.yyyy HH:mm:ss'
             }
         }
-    }), [title, chartType]);
+    }), [title, chartType, minScrollWidth]);
 
     if (!data || data.length === 0) {
         return null;
     }
 
     return (
-        <Chart options={options} series={series} type={chartType} height={350} />
+        <div className="overflow-x-auto w-full">
+            <div style={{ minWidth: minScrollWidth ?? '100%' }}>
+                <Chart options={options} series={series} type={chartType} height={350} />
+            </div>
+        </div>
     );
 };
 

--- a/src/components/TimeSeriesChart.tsx
+++ b/src/components/TimeSeriesChart.tsx
@@ -42,6 +42,19 @@ const TimeSeriesChart: React.FC<TimeSeriesChartProps> = ({ title, data, chartTyp
                 borderRadius: 2
             }
         },
+        responsive: [
+            {
+                breakpoint: 640,
+                options: {
+                    plotOptions: {
+                        bar: {
+                            columnWidth: '40%',
+                            borderRadius: 1
+                        }
+                    }
+                }
+            }
+        ],
         title: {
             text: title,
             align: 'left',

--- a/src/components/TimeSeriesChart.tsx
+++ b/src/components/TimeSeriesChart.tsx
@@ -116,7 +116,9 @@ const TimeSeriesChart: React.FC<TimeSeriesChartProps> = ({ title, data, chartTyp
     }
 
     return (
-        <Chart options={options} series={series} type={effectiveType} height={350} />
+        <div className="overflow-hidden w-full">
+            <Chart options={options} series={series} type={effectiveType} height={350} />
+        </div>
     );
 };
 

--- a/src/components/TimeSeriesChart.tsx
+++ b/src/components/TimeSeriesChart.tsx
@@ -48,7 +48,7 @@ const TimeSeriesChart: React.FC<TimeSeriesChartProps> = ({ title, data, chartTyp
                 options: {
                     plotOptions: {
                         bar: {
-                            columnWidth: '40%',
+                            columnWidth: '20%',
                             borderRadius: 1
                         }
                     }


### PR DESCRIPTION
## Mobile-friendly electricity chart

The electricity chart was hard to read on mobile — too many data points squished into a narrow bar chart.

### Changes
- **Mobile (< 640px)**: bar charts automatically switch to a smooth line chart with crosshair tooltip — tap anywhere to see the price for that point
- **Desktop**: bar charts unchanged (70% column width, rounded corners)
- Wrapped chart in `overflow-hidden` to prevent the tooltip from causing a horizontal scrollbar on the sidebar when hovering near the right edge
- Responsive to orientation changes (landscape portrait)
