### PR TITLE
feat: electricity stats, toast notifications, button locking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "react-datepicker": "^9.1.0",
         "react-devtools": "^6.1.5",
         "react-dom": "^19.2.4",
+        "sonner": "^2.0.7",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -7738,6 +7739,16 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react-datepicker": "^9.1.0",
     "react-devtools": "^6.1.5",
     "react-dom": "^19.2.4",
+    "sonner": "^2.0.7",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/src/app/(protected)/automations/page.tsx
+++ b/src/app/(protected)/automations/page.tsx
@@ -12,6 +12,7 @@ import { unitForType } from '@/lib/typeUtils';
 import { formatDateTime } from '@/lib/dateUtils';
 import { AxiosError } from 'axios';
 import { PlusIcon } from '@heroicons/react/24/outline';
+import { toast } from 'sonner';
 
 const PRICE_AREAS = ['NO1', 'NO2', 'NO3', 'NO4', 'NO5'];
 
@@ -230,13 +231,17 @@ const AutomationsPage: React.FC = () => {
             setForm(initialForm);
             setFormOpen(false);
             fetchRules();
-        } catch (e) { handleError(e, 'Failed to create automation'); }
+            toast.success('Automation created');
+        } catch (e) { handleError(e, 'Failed to create automation'); toast.error('Failed to create automation'); }
     };
 
     const handleDelete = async (id: number) => {
         setError('');
-        try { await AutomationService.deleteRule(id); fetchRules(); }
-        catch (e) { handleError(e, 'Failed to delete automation'); }
+        try {
+            await AutomationService.deleteRule(id);
+            fetchRules();
+            toast.success('Automation deleted');
+        } catch (e) { handleError(e, 'Failed to delete automation'); toast.error('Failed to delete automation'); }
     };
 
     const handleToggleEnabled = async (rule: AutomationRuleDto) => {
@@ -254,7 +259,8 @@ const AutomationsPage: React.FC = () => {
                 timerDurationHours: rule.timerDurationHours,
             });
             fetchRules();
-        } catch (e) { handleError(e, 'Failed to update automation'); }
+            toast.success(rule.isEnabled ? 'Automation disabled' : 'Automation enabled');
+        } catch (e) { handleError(e, 'Failed to update automation'); toast.error('Failed to update automation'); }
     };
 
     const startEdit = (rule: AutomationRuleDto) => {
@@ -282,7 +288,8 @@ const AutomationsPage: React.FC = () => {
             await AutomationService.updateRule(editingId, editForm);
             cancelEdit();
             fetchRules();
-        } catch (e) { handleError(e, 'Failed to update automation'); }
+            toast.success('Automation updated');
+        } catch (e) { handleError(e, 'Failed to update automation'); toast.error('Failed to update automation'); }
     };
 
     const handleTargetChange = (id: number) => {

--- a/src/app/(protected)/automations/page.tsx
+++ b/src/app/(protected)/automations/page.tsx
@@ -180,6 +180,7 @@ const AutomationsPage: React.FC = () => {
     const [error, setError] = useState<string>('');
     const [form, setForm] = useState<CreateAutomationRuleDto>(initialForm);
     const [formOpen, setFormOpen] = useState(false);
+    const [submitting, setSubmitting] = useState(false);
     const [editingId, setEditingId] = useState<number | null>(null);
     const [editForm, setEditForm] = useState<UpdateAutomationRuleDto | null>(null);
     const [switches, setSwitches] = useState<Switch[]>([]);
@@ -226,6 +227,7 @@ const AutomationsPage: React.FC = () => {
     const handleCreate = async (e: React.FormEvent) => {
         e.preventDefault();
         setError('');
+        setSubmitting(true);
         try {
             await AutomationService.createRule(form);
             setForm(initialForm);
@@ -233,6 +235,7 @@ const AutomationsPage: React.FC = () => {
             fetchRules();
             toast.success('Automation created');
         } catch (e) { handleError(e, 'Failed to create automation'); toast.error('Failed to create automation'); }
+        finally { setSubmitting(false); }
     };
 
     const handleDelete = async (id: number) => {
@@ -284,12 +287,14 @@ const AutomationsPage: React.FC = () => {
         e.preventDefault();
         if (!editingId || !editForm) return;
         setError('');
+        setSubmitting(true);
         try {
             await AutomationService.updateRule(editingId, editForm);
             cancelEdit();
             fetchRules();
             toast.success('Automation updated');
         } catch (e) { handleError(e, 'Failed to update automation'); toast.error('Failed to update automation'); }
+        finally { setSubmitting(false); }
     };
 
     const handleTargetChange = (id: number) => {
@@ -373,7 +378,7 @@ const AutomationsPage: React.FC = () => {
                 onChange={fields => setEditForm({ ...editForm!, ...fields })}
             />
             <div className="flex items-center gap-2 pt-1">
-                <button type="submit" className="flex-1 px-4 py-2 bg-sky-600 hover:bg-sky-500 active:bg-sky-700 text-white text-sm font-medium rounded-xl transition-all">Save</button>
+                <button type="submit" disabled={submitting} className="flex-1 px-4 py-2 bg-sky-600 hover:bg-sky-500 active:bg-sky-700 disabled:opacity-50 text-white text-sm font-medium rounded-xl transition-all">{submitting ? 'Saving…' : 'Save'}</button>
                 <button type="button" className="flex-1 px-4 py-2 bg-gray-700 hover:bg-gray-600 text-gray-300 text-sm font-medium rounded-xl transition-all" onClick={cancelEdit}>Cancel</button>
                 <button type="button" className="px-4 py-2 bg-rose-600 hover:bg-rose-500 active:bg-rose-700 text-white text-sm font-medium rounded-xl transition-all" onClick={() => handleDelete(rule.id)}>Delete</button>
             </div>
@@ -468,7 +473,7 @@ const AutomationsPage: React.FC = () => {
                             onChange={fields => setForm({ ...form, ...fields })}
                         />
                         <div className="flex gap-2 pt-1">
-                            <button type="submit" className="flex-1 px-4 py-2 bg-sky-600 hover:bg-sky-500 active:bg-sky-700 text-white text-sm font-medium rounded-xl transition-all">Create</button>
+                            <button type="submit" disabled={submitting} className="flex-1 px-4 py-2 bg-sky-600 hover:bg-sky-500 active:bg-sky-700 disabled:opacity-50 text-white text-sm font-medium rounded-xl transition-all">{submitting ? 'Creating…' : 'Create'}</button>
                             <button type="button" className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-gray-300 text-sm font-medium rounded-xl transition-all" onClick={() => setFormOpen(false)}>Cancel</button>
                         </div>
                     </form>

--- a/src/app/(protected)/electricity/page.tsx
+++ b/src/app/(protected)/electricity/page.tsx
@@ -163,13 +163,13 @@ const ElectricityPage = () => {
                 {stats && !loading && (
                     <div className="px-5 pb-3 flex gap-3">
                         {[
-                            { label: 'Min', value: stats.min, color: 'text-green-400' },
-                            { label: 'Avg', value: stats.avg, color: 'text-sky-400' },
-                            { label: 'Max', value: stats.max, color: 'text-red-400' },
-                        ].map(({ label, value, color }) => (
+                            { label: 'Min', value: stats.min },
+                            { label: 'Avg', value: stats.avg },
+                            { label: 'Max', value: stats.max },
+                        ].map(({ label, value }) => (
                             <div key={label} className="flex-1 bg-gray-900/50 rounded-xl px-3 py-2 text-center">
                                 <p className="text-[10px] text-gray-500 uppercase tracking-wide">{label}</p>
-                                <p className={`text-sm font-bold tabular-nums ${color}`}>{value.toFixed(2)}</p>
+                                <p className="text-sm font-bold tabular-nums text-gray-100">{value.toFixed(2)}</p>
                                 <p className="text-[10px] text-gray-600">kr</p>
                             </div>
                         ))}

--- a/src/app/(protected)/electricity/page.tsx
+++ b/src/app/(protected)/electricity/page.tsx
@@ -102,6 +102,15 @@ const ElectricityPage = () => {
         ).y;
     })();
 
+    const stats = (() => {
+        if (data.length === 0) return null;
+        const values = data.map(d => d.y);
+        const min = Math.min(...values);
+        const max = Math.max(...values);
+        const avg = values.reduce((s, v) => s + v, 0) / values.length;
+        return { min, max, avg };
+    })();
+
     return (
         <div className="p-4 max-w-7xl mx-auto">
             <h1 className="text-2xl sm:text-3xl font-bold mb-6">Electricity Prices</h1>
@@ -149,6 +158,23 @@ const ElectricityPage = () => {
                         ))}
                     </div>
                 </div>
+
+                {/* Stats bar */}
+                {stats && !loading && (
+                    <div className="px-5 pb-3 flex gap-3">
+                        {[
+                            { label: 'Min', value: stats.min, color: 'text-green-400' },
+                            { label: 'Avg', value: stats.avg, color: 'text-sky-400' },
+                            { label: 'Max', value: stats.max, color: 'text-red-400' },
+                        ].map(({ label, value, color }) => (
+                            <div key={label} className="flex-1 bg-gray-900/50 rounded-xl px-3 py-2 text-center">
+                                <p className="text-[10px] text-gray-500 uppercase tracking-wide">{label}</p>
+                                <p className={`text-sm font-bold tabular-nums ${color}`}>{value.toFixed(2)}</p>
+                                <p className="text-[10px] text-gray-600">kr</p>
+                            </div>
+                        ))}
+                    </div>
+                )}
 
                 {/* Chart */}
                 <div className="px-2 pb-4">

--- a/src/app/(protected)/profile/page.tsx
+++ b/src/app/(protected)/profile/page.tsx
@@ -13,6 +13,7 @@ import LoadingDots from '@/components/LoadingDots';
 import Section from '@/components/Section';
 import { inputClass } from '@/components/TextInput';
 import Alert from '@/components/Alert';
+import { toast } from 'sonner';
 
 const Profile: React.FC = () => {
     const { status } = useSession();
@@ -130,17 +131,21 @@ const Profile: React.FC = () => {
             if (claimType === 'sensor') {
                 await SensorService.claimSensor(claimCode.trim());
                 setClaimMessage('Sensor added successfully!');
+                toast.success('Sensor added');
                 await refreshSensors();
             } else {
                 await SwitchService.claimSwitch(claimCode.trim());
                 setClaimMessage('Socket added successfully!');
+                toast.success('Socket added');
                 await refreshSwitches();
             }
             setClaimError(false);
             setClaimCode('');
         } catch (error: unknown) {
-            setClaimMessage(error instanceof Error ? error.message : `Failed to add ${claimType}.`);
+            const msg = error instanceof Error ? error.message : `Failed to add ${claimType}.`;
+            setClaimMessage(msg);
             setClaimError(true);
+            toast.error(msg);
         } finally {
             setClaimLoading(false);
         }
@@ -151,6 +156,7 @@ const Profile: React.FC = () => {
         await SensorService.unclaimSensor(confirmDeleteId);
         setConfirmDeleteId(null);
         await refreshSensors();
+        toast.success('Sensor removed');
     };
 
     const handleUnclaimSwitch = async () => {
@@ -158,6 +164,7 @@ const Profile: React.FC = () => {
         await SwitchService.unclaimSwitch(confirmDeleteSwitchId);
         setConfirmDeleteSwitchId(null);
         await refreshSwitches();
+        toast.success('Socket removed');
     };
 
     const startEditing = (sensor: Sensor) => {
@@ -180,6 +187,7 @@ const Profile: React.FC = () => {
             await refreshSensors();
             setEditingSensorId(null);
             setNewCustomName('');
+            toast.success('Sensor renamed');
         } catch (error: unknown) {
             setEditError(error instanceof Error ? error.message : 'Failed to update sensor name.');
         } finally {
@@ -207,6 +215,7 @@ const Profile: React.FC = () => {
             await refreshSwitches();
             setEditingSwitchId(null);
             setNewSwitchName('');
+            toast.success('Socket renamed');
         } catch (error: unknown) {
             setSwitchEditError(error instanceof Error ? error.message : 'Failed to update socket name.');
         } finally {

--- a/src/app/DeviceDashboard.tsx
+++ b/src/app/DeviceDashboard.tsx
@@ -13,7 +13,6 @@ import SetupWizard from './SetupWizard';
 import ConfirmModal from '@/components/ConfirmModal';
 import { groupEmoji } from '@/lib/groupIcons';
 import CollapsibleSection from '@/components/CollapsibleSection';
-import { formatDateTime } from '@/lib/dateUtils';
 
 // ── Type sort order for group cards ───────────────────────────────────────────
 const TYPE_ORDER: Record<string, number> = { voltage: 0, temperature: 1, humidity: 2, socket: 3 };
@@ -94,7 +93,7 @@ function formatValue(device: UnifiedDevice): string {
     return formatSensorValue(device.type, device.latestValue);
 }
 
-const DeviceCard: React.FC<{ device: UnifiedDevice; onClick: () => void; showLastSeen?: boolean }> = ({ device, onClick, showLastSeen }) => {
+const DeviceCard: React.FC<{ device: UnifiedDevice; onClick: () => void }> = ({ device, onClick }) => {
     const cfg = TYPE_CONFIG[device.type.toLowerCase()] ?? DEFAULT_TYPE;
     const value = formatValue(device);
     const socketOn  = device.kind === 'socket' && device.latestState === 'ON';
@@ -126,9 +125,6 @@ const DeviceCard: React.FC<{ device: UnifiedDevice; onClick: () => void; showLas
             <div className="flex-1">
                 <p className="font-semibold text-gray-100 text-sm leading-snug line-clamp-2">{device.displayName}</p>
                 <p className="text-xs text-gray-500 mt-0.5">{cfg.label}</p>
-                {showLastSeen && device.latestTimestamp && (
-                    <p className="text-[10px] text-gray-600 mt-1">Last seen {formatDateTime(device.latestTimestamp)}</p>
-                )}
             </div>
 
             {/* Value */}
@@ -528,7 +524,6 @@ const DeviceDashboard: React.FC = () => {
                                                             key={`${device.kind}-${device.id}`}
                                                             device={device}
                                                             onClick={() => setSelected(device)}
-                                                            showLastSeen
                                                         />
                                                     ))}
                                                 </div>

--- a/src/app/DeviceDashboard.tsx
+++ b/src/app/DeviceDashboard.tsx
@@ -13,6 +13,7 @@ import SetupWizard from './SetupWizard';
 import ConfirmModal from '@/components/ConfirmModal';
 import { groupEmoji } from '@/lib/groupIcons';
 import CollapsibleSection from '@/components/CollapsibleSection';
+import { formatDateTime } from '@/lib/dateUtils';
 
 // ── Type sort order for group cards ───────────────────────────────────────────
 const TYPE_ORDER: Record<string, number> = { voltage: 0, temperature: 1, humidity: 2, socket: 3 };
@@ -93,7 +94,7 @@ function formatValue(device: UnifiedDevice): string {
     return formatSensorValue(device.type, device.latestValue);
 }
 
-const DeviceCard: React.FC<{ device: UnifiedDevice; onClick: () => void }> = ({ device, onClick }) => {
+const DeviceCard: React.FC<{ device: UnifiedDevice; onClick: () => void; showLastSeen?: boolean }> = ({ device, onClick, showLastSeen }) => {
     const cfg = TYPE_CONFIG[device.type.toLowerCase()] ?? DEFAULT_TYPE;
     const value = formatValue(device);
     const socketOn  = device.kind === 'socket' && device.latestState === 'ON';
@@ -125,6 +126,9 @@ const DeviceCard: React.FC<{ device: UnifiedDevice; onClick: () => void }> = ({ 
             <div className="flex-1">
                 <p className="font-semibold text-gray-100 text-sm leading-snug line-clamp-2">{device.displayName}</p>
                 <p className="text-xs text-gray-500 mt-0.5">{cfg.label}</p>
+                {showLastSeen && device.latestTimestamp && (
+                    <p className="text-[10px] text-gray-600 mt-1">Last seen {formatDateTime(device.latestTimestamp)}</p>
+                )}
             </div>
 
             {/* Value */}
@@ -524,6 +528,7 @@ const DeviceDashboard: React.FC = () => {
                                                             key={`${device.kind}-${device.id}`}
                                                             device={device}
                                                             onClick={() => setSelected(device)}
+                                                            showLastSeen
                                                         />
                                                     ))}
                                                 </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import Footer from './footer';
 import SessionProviderWrapper from './SessionProviderWrapper';
 import type { Metadata } from "next";
 import Script from 'next/script';
+import { Toaster } from 'sonner';
 
 export const metadata: Metadata = {
     title: 'Garge',
@@ -35,6 +36,7 @@ export default function Layout({
                         <Footer />
                         <FloatingNav />
                     </div>
+                    <Toaster position="bottom-center" theme="dark" richColors />
                 </SessionProviderWrapper>
             </body>
         </html>


### PR DESCRIPTION
## UX improvements

### Electricity stats bar
A Min / Avg / Max row of stat pills is shown between the tab selector and the chart, computed from the already-loaded data. Uses neutral gray text. Disappears while loading.

### Toast notifications
Installed sonner (lightweight, App Router compatible). Added <Toaster> to the root layout.

Toasts fire on:
- **Automations**: create, update, delete, enable/disable toggle
- **Profile**: claim device, unclaim device, rename sensor, rename socket

### Button locking
Create and Save buttons in the automations form are disabled and show a loading label while the request is in-flight, preventing double-submit.

### Chart overflow fix
Wrapped TimeSeriesChart in overflow-hidden to prevent chart tooltips from causing a horizontal scrollbar on the sidebar.

### Files changed
- src/app/layout.tsx — Toaster
- src/app/(protected)/electricity/page.tsx — stats bar
- src/app/(protected)/automations/page.tsx — toast calls, button locking
- src/app/(protected)/profile/page.tsx — toast calls
- src/components/TimeSeriesChart.tsx — overflow-hidden wrapper
