### PR TITLE
fix: humidity 1 decimal, rename char counter, unified timeline tooltip

### DIFF
--- a/src/app/(protected)/profile/page.tsx
+++ b/src/app/(protected)/profile/page.tsx
@@ -371,15 +371,18 @@ const Profile: React.FC = () => {
                                 <div key={sensor.id} className="bg-gray-900/50 border border-gray-700/40 rounded-xl p-4">
                                     {editingSensorId === sensor.id ? (
                                         <div className="space-y-2">
-                                            <input
-                                                type="text"
-                                                value={newCustomName}
-                                                onChange={e => setNewCustomName(e.target.value)}
-                                                className={inputClass}
-                                                maxLength={50}
-                                                disabled={editLoading}
-                                                autoFocus
-                                            />
+                                            <div className="relative">
+                                                <input
+                                                    type="text"
+                                                    value={newCustomName}
+                                                    onChange={e => setNewCustomName(e.target.value)}
+                                                    className={inputClass}
+                                                    maxLength={50}
+                                                    disabled={editLoading}
+                                                    autoFocus
+                                                />
+                                                <span className={`absolute right-2 top-1/2 -translate-y-1/2 text-[10px] tabular-nums pointer-events-none ${newCustomName.length >= 45 ? 'text-amber-400' : 'text-gray-600'}`}>{newCustomName.length}/50</span>
+                                            </div>
                                             {editError && <p className="text-xs text-red-400">{editError}</p>}
                                             <div className="flex gap-2">
                                                 <button onClick={() => handleSaveCustomName(sensor.id)} disabled={editLoading} className="flex items-center gap-1.5 px-3 py-1.5 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 text-white text-xs font-medium rounded-lg transition-all">
@@ -433,15 +436,18 @@ const Profile: React.FC = () => {
                                 <div key={sw.id} className="bg-gray-900/50 border border-gray-700/40 rounded-xl p-4">
                                     {editingSwitchId === sw.id ? (
                                         <div className="space-y-2">
-                                            <input
-                                                type="text"
-                                                value={newSwitchName}
-                                                onChange={e => setNewSwitchName(e.target.value)}
-                                                className={inputClass}
-                                                maxLength={50}
-                                                disabled={switchEditLoading}
-                                                autoFocus
-                                            />
+                                            <div className="relative">
+                                                <input
+                                                    type="text"
+                                                    value={newSwitchName}
+                                                    onChange={e => setNewSwitchName(e.target.value)}
+                                                    className={inputClass}
+                                                    maxLength={50}
+                                                    disabled={switchEditLoading}
+                                                    autoFocus
+                                                />
+                                                <span className={`absolute right-2 top-1/2 -translate-y-1/2 text-[10px] tabular-nums pointer-events-none ${newSwitchName.length >= 45 ? 'text-amber-400' : 'text-gray-600'}`}>{newSwitchName.length}/50</span>
+                                            </div>
                                             {switchEditError && <p className="text-xs text-red-400">{switchEditError}</p>}
                                             <div className="flex gap-2">
                                                 <button onClick={() => handleSaveSwitchName(sw.id)} disabled={switchEditLoading} className="flex items-center gap-1.5 px-3 py-1.5 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 text-white text-xs font-medium rounded-lg transition-all">

--- a/src/app/DeviceDrawer.tsx
+++ b/src/app/DeviceDrawer.tsx
@@ -53,21 +53,40 @@ function formatDuration(ms: number): string {
 
 const TimelineBar: React.FC<{ segments: Segment[]; rangeStart: number; rangeEnd: number }> = ({ segments, rangeStart, rangeEnd }) => {
     const total = rangeEnd - rangeStart;
+    const [activeIdx, setActiveIdx] = useState<number | null>(null);
     if (total <= 0) return null;
+
+    const active = activeIdx !== null ? segments[activeIdx] : null;
+
     return (
-        <div className="relative h-8 rounded-xl overflow-hidden bg-gray-800/60 flex">
-            {segments.map((seg, i) => {
-                const left = ((seg.start - rangeStart) / total) * 100;
-                const width = ((seg.end - seg.start) / total) * 100;
-                return (
-                    <div
-                        key={i}
-                        title={`${seg.on ? 'ON' : 'OFF'} — ${formatDateTime(new Date(seg.start).toISOString())} → ${formatDateTime(new Date(seg.end).toISOString())}`}
-                        style={{ left: `${left}%`, width: `${width}%` }}
-                        className={`absolute top-0 h-full ${seg.on ? 'bg-green-500/70' : 'bg-gray-700/50'}`}
-                    />
-                );
-            })}
+        <div>
+            <div className="relative h-8 rounded-xl overflow-hidden bg-gray-800/60 flex">
+                {segments.map((seg, i) => {
+                    const left = ((seg.start - rangeStart) / total) * 100;
+                    const width = ((seg.end - seg.start) / total) * 100;
+                    return (
+                        <div
+                            key={i}
+                            style={{ left: `${left}%`, width: `${width}%` }}
+                            className={`absolute top-0 h-full cursor-pointer ${seg.on ? 'bg-green-500/70' : 'bg-gray-700/50'}`}
+                            onMouseEnter={() => setActiveIdx(i)}
+                            onMouseLeave={() => setActiveIdx(null)}
+                            onClick={() => setActiveIdx(prev => prev === i ? null : i)}
+                        />
+                    );
+                })}
+            </div>
+            <div className="h-5 mt-1">
+                {active && (
+                    <p className="text-[11px] text-gray-400 tabular-nums">
+                        <span className={active.on ? 'text-green-400 font-medium' : 'text-gray-500 font-medium'}>{active.on ? 'ON' : 'OFF'}</span>
+                        {' — '}
+                        {formatDateTime(new Date(active.start).toISOString())}
+                        {' → '}
+                        {formatDateTime(new Date(active.end).toISOString())}
+                    </p>
+                )}
+            </div>
         </div>
     );
 };

--- a/src/lib/typeUtils.ts
+++ b/src/lib/typeUtils.ts
@@ -25,7 +25,7 @@ export function formatSensorValue(type: string, value: number | null | undefined
     if (value === undefined || value === null) return '—';
     const t = type.toLowerCase();
     if (t === 'temperature') return `${Number(value).toFixed(1)} °C`;
-    if (t === 'humidity')    return `${Number(value).toFixed(0)} %`;
+    if (t === 'humidity')    return `${Number(value).toFixed(1)} %`;
     if (t === 'voltage')     return `${Number(value).toFixed(2)} V`;
     return `${Number(value).toFixed(1)} ${unitForType(t)}`;
 }


### PR DESCRIPTION
## Changes

### Humidity 1 decimal
Humidity values now show 1 decimal place (e.g. `62.3 %`) consistent with temperature.

### Character counter on rename inputs
Both sensor and socket rename inputs now show a `X/50` counter overlaid at the right edge. Turns amber when 45+ characters are used. API enforces the same 50-char max.

### Unified socket timeline tooltip
Replaced the hover-only `title` attribute with an interactive approach that works on both desktop and mobile:
- **Desktop**: hover over a segment to see the label below the bar
- **Mobile**: tap a segment to show/hide the label
- Shows: `ON — 12:00 → 13:00` in a fixed-height row below the timeline
