### PR TITLE
fix(electricity): filter monthly chart to first-of-month entries only

### DIFF
--- a/src/app/(protected)/electricity/page.tsx
+++ b/src/app/(protected)/electricity/page.tsx
@@ -48,6 +48,8 @@ const fetchTabData = async (frequency: string, dateType: string, zone: string): 
         .filter((d: any) => {
             const ts = d.time.endsWith('Z') ? d.time : d.time + 'Z';
             const t = new Date(ts);
+            // MONTHLY entries always start on the 1st — any other UTC day is a bad row
+            if (frequency === 'MONTHLY' && t.getUTCDate() !== 1) return false;
             return t >= startDate && t < tomorrow;
         })
         .map((d: any) => {


### PR DESCRIPTION
Fix yearly electricity chart showing multiple bars per month.

The frontend filter for MONTHLY data now rejects any entry where the UTC day is not 1. Nord Pool MONTHLY deliveryStart values always fall on the 1st of the month, so any other UTC day is a bad row from a prior DB normalization issue.
