### PR TITLE
feat: GDPR compliance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [1.9.0](https://github.com/sondresjolyst/garge-app/compare/v1.8.2...v1.9.0) (2026-04-27)
+
+
+### Features
+
+* add activities to sensor sidebar ([#191](https://github.com/sondresjolyst/garge-app/issues/191)) ([5bc3b18](https://github.com/sondresjolyst/garge-app/commit/5bc3b18779920c02d88c3a92c172a4af37a66876))
+* admin page, activities section, and session roles ([#189](https://github.com/sondresjolyst/garge-app/issues/189)) ([b4108f5](https://github.com/sondresjolyst/garge-app/commit/b4108f505844f78297f2837f62a71316376ef4a7))
+* **sensor:** photo upload for device drawer ([#190](https://github.com/sondresjolyst/garge-app/issues/190)) ([c2cdfe7](https://github.com/sondresjolyst/garge-app/commit/c2cdfe76dff71ad2232f80eb5ba62e3cbdea9066))
+
 ## [1.8.2](https://github.com/sondresjolyst/garge-app/compare/v1.8.1...v1.8.2) (2026-04-19)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garge-app",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garge-app",
-      "version": "1.8.2",
+      "version": "1.9.0",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
         "apexcharts": "^4.5.0",
@@ -968,17 +968,6 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
-        "@jridgewell/trace-mapping": "^0.3.24"
-      }
-    },
-    "node_modules/@jridgewell/remapping": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
-      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garge-app",
-  "version": "1.8.2",
+  "version": "1.9.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -17,6 +17,7 @@ const Register: React.FC = () => {
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
     const [showPassword, setShowPassword] = useState(false);
+    const [agreedToTerms, setAgreedToTerms] = useState(false);
     const [errors, setErrors] = useState<{ userName?: string[]; firstName?: string[]; lastName?: string[]; email?: string[]; password?: string[] }>({});
     const [apiMessage, setApiMessage] = useState('');
     const [loading, setLoading] = useState(false);
@@ -111,10 +112,25 @@ const Register: React.FC = () => {
                             <Alert variant="error">{apiMessage}</Alert>
                         )}
 
+                        <label className="flex items-start gap-2.5 cursor-pointer">
+                            <input
+                                type="checkbox"
+                                checked={agreedToTerms}
+                                onChange={e => setAgreedToTerms(e.target.checked)}
+                                className="mt-0.5 h-4 w-4 rounded border-gray-600 bg-gray-800 text-sky-500 focus:ring-sky-500 focus:ring-offset-gray-900 flex-shrink-0"
+                            />
+                            <span className="text-xs text-gray-400 leading-relaxed">
+                                I have read and agree to the{' '}
+                                <Link href="/terms" className="text-sky-400 hover:text-sky-300 transition-colors">Terms of Service</Link>
+                                {' '}and{' '}
+                                <Link href="/privacy" className="text-sky-400 hover:text-sky-300 transition-colors">Privacy Policy</Link>
+                            </span>
+                        </label>
+
                         <button
                             className="w-full py-2.5 bg-sky-600 hover:bg-sky-500 active:bg-sky-700 disabled:opacity-50 disabled:cursor-not-allowed text-white font-medium rounded-xl transition-all text-sm"
                             type="submit"
-                            disabled={loading}
+                            disabled={loading || !agreedToTerms}
                         >
                             {loading ? 'Creating account…' : 'Create account'}
                         </button>

--- a/src/app/(protected)/profile/page.tsx
+++ b/src/app/(protected)/profile/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { useSession } from 'next-auth/react';
+import { useSession, signOut } from 'next-auth/react';
 import UserService from '@/services/userService';
 import { UserDTO } from '@/dto/UserDTO';
 import SensorService, { Sensor } from '@/services/sensorService';
@@ -49,6 +49,9 @@ const Profile: React.FC = () => {
     const [switchEditLoading, setSwitchEditLoading] = useState(false);
     const [switchEditError, setSwitchEditError] = useState<string | null>(null);
     const [confirmDeleteSwitchId, setConfirmDeleteSwitchId] = useState<number | null>(null);
+    const [showDeleteAccount, setShowDeleteAccount] = useState(false);
+    const [deleteAccountLoading, setDeleteAccountLoading] = useState(false);
+    const [exportLoading, setExportLoading] = useState(false);
 
     function sortSensorsByName(sensors: Sensor[]): Sensor[] {
         return [...sensors].sort((a, b) =>
@@ -223,12 +226,56 @@ const Profile: React.FC = () => {
         }
     };
 
+    const handleDeleteAccount = async () => {
+        if (!user?.id) return;
+        setDeleteAccountLoading(true);
+        try {
+            await UserService.deleteAccount(user.id);
+            await signOut({ callbackUrl: '/' });
+        } catch {
+            toast.error('Failed to delete account. Please try again.');
+            setDeleteAccountLoading(false);
+            setShowDeleteAccount(false);
+        }
+    };
+
+    const handleExportData = async () => {
+        if (!user?.id) return;
+        setExportLoading(true);
+        try {
+            const data = await UserService.exportData(user.id);
+            const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = 'garge-my-data.json';
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+            toast.success('Data downloaded');
+        } catch {
+            toast.error('Failed to export data. Please try again.');
+        } finally {
+            setExportLoading(false);
+        }
+    };
+
     const confirmSensor = sensors.find(s => s.id === confirmDeleteId);
     const confirmSwitch = switches.find(sw => sw.id === confirmDeleteSwitchId);
     const isUserLoading = status === 'loading' || !user;
 
     return (
         <>
+            {showDeleteAccount && (
+                <ConfirmModal
+                    title="Delete account"
+                    message={<>This will permanently delete your account and all associated personal data. <span className="font-medium text-red-400">This cannot be undone.</span></>}
+                    confirmLabel="Delete my account"
+                    onConfirm={handleDeleteAccount}
+                    onCancel={() => setShowDeleteAccount(false)}
+                />
+            )}
             {confirmDeleteId !== null && confirmSensor && (
                 <ConfirmModal
                     title="Remove sensor"
@@ -526,6 +573,39 @@ const Profile: React.FC = () => {
                     </div>
                 </Section>
                 </div>
+
+                {/* Your data */}
+                <Section title="Your data">
+                    <div className="space-y-4">
+                        <div className="flex items-center justify-between">
+                            <div>
+                                <p className="text-sm text-gray-100 font-medium">Download your data</p>
+                                <p className="text-xs text-gray-500 mt-0.5">Export your account and device data as JSON (GDPR Article 20).</p>
+                            </div>
+                            <button
+                                onClick={handleExportData}
+                                disabled={!user?.id || exportLoading}
+                                className="px-4 py-2 bg-gray-700 hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded-xl transition-all whitespace-nowrap"
+                            >
+                                {exportLoading ? 'Exporting…' : 'Download'}
+                            </button>
+                        </div>
+
+                        <div className="border-t border-gray-700/40 pt-4 flex items-center justify-between">
+                            <div>
+                                <p className="text-sm text-red-400 font-medium">Delete account</p>
+                                <p className="text-xs text-gray-500 mt-0.5">Permanently deletes your account and personal data.</p>
+                            </div>
+                            <button
+                                onClick={() => setShowDeleteAccount(true)}
+                                disabled={!user?.id || deleteAccountLoading}
+                                className="px-4 py-2 bg-red-600/20 hover:bg-red-600/30 border border-red-600/40 disabled:opacity-50 disabled:cursor-not-allowed text-red-400 text-sm font-medium rounded-xl transition-all whitespace-nowrap"
+                            >
+                                Delete account
+                            </button>
+                        </div>
+                    </div>
+                </Section>
             </div>
         </>
     );

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -27,17 +27,29 @@ export default function PrivacyPage() {
 
                 <section className="space-y-2">
                     <h2 className="text-base font-semibold text-gray-100">Data sharing</h2>
-                    <p>We do not sell, trade, or share your personal data with third parties, except where required by law.</p>
+                    <p>We do not sell or trade your personal data. We use the following third-party data processors:</p>
+                    <ul className="list-disc list-inside space-y-1">
+                        <li>
+                            <a href="https://www.brevo.com/legal/termsofuse/" target="_blank" rel="noopener noreferrer" className="text-sky-400 hover:text-sky-300">Brevo</a>
+                            {' '}— transactional email delivery (email confirmations, password resets). Your email address is shared with Brevo solely for this purpose.
+                        </li>
+                    </ul>
+                    <p>We may also disclose data when required by law.</p>
                 </section>
 
                 <section className="space-y-2">
                     <h2 className="text-base font-semibold text-gray-100">Data retention</h2>
-                    <p>Your data is retained for as long as your account is active. You may request deletion of your account and associated data by contacting us.</p>
+                    <p>Your data is retained for as long as your account is active. When you delete your account, all associated personal data is permanently removed. You can delete your account at any time from your <Link href="/profile" className="text-sky-400 hover:text-sky-300">profile page</Link>.</p>
                 </section>
 
                 <section className="space-y-2">
                     <h2 className="text-base font-semibold text-gray-100">Your rights</h2>
-                    <p>You have the right to access, correct, or delete your personal data. To exercise these rights, <Link href="/contact" className="text-sky-400 hover:text-sky-300">contact us</Link>.</p>
+                    <p>Under GDPR you have the right to:</p>
+                    <ul className="list-disc list-inside space-y-1">
+                        <li><span className="text-gray-300">Access &amp; portability</span> — download a copy of all your personal data in JSON format from your <Link href="/profile" className="text-sky-400 hover:text-sky-300">profile page</Link>.</li>
+                        <li><span className="text-gray-300">Erasure</span> — permanently delete your account and all associated data from your <Link href="/profile" className="text-sky-400 hover:text-sky-300">profile page</Link>.</li>
+                        <li><span className="text-gray-300">Correction</span> — to correct inaccurate data, <Link href="/contact" className="text-sky-400 hover:text-sky-300">contact us</Link>.</li>
+                    </ul>
                 </section>
 
                 <section className="space-y-2">

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -34,7 +34,7 @@ export default function TermsPage() {
 
                 <section className="space-y-2">
                     <h2 className="text-base font-semibold text-gray-100">6. Changes to terms</h2>
-                    <p>We may update these terms from time to time. Continued use of Garge after changes are posted constitutes acceptance.</p>
+                    <p>We may update these terms from time to time. We will notify you of material changes by email. Continued use of Garge after notification constitutes acceptance of the updated terms.</p>
                 </section>
 
                 <section className="space-y-2">

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -191,6 +191,31 @@ const UserService = {
             }
         }
     },
+
+    async deleteAccount(userId: string): Promise<void> {
+        try {
+            await axiosInstance.delete(`/users/${userId}/account`);
+        } catch (error: unknown) {
+            if (error instanceof AxiosError) {
+                throw new Error(error.response?.data.message || 'Failed to delete account');
+            } else {
+                throw new Error('An unknown error occurred');
+            }
+        }
+    },
+
+    async exportData(userId: string): Promise<unknown> {
+        try {
+            const response = await axiosInstance.get(`/users/${userId}/export`);
+            return response.data;
+        } catch (error: unknown) {
+            if (error instanceof AxiosError) {
+                throw new Error(error.response?.data.message || 'Failed to export data');
+            } else {
+                throw new Error('An unknown error occurred');
+            }
+        }
+    },
 };
 
 export default UserService;


### PR DESCRIPTION
## Summary
- Add terms/privacy policy consent checkbox on registration form (GDPR Article 13)
- Add Download my data button on profile page — exports full account data as JSON (GDPR Article 20)
- Add Delete account button on profile page with confirmation modal (GDPR Article 17)
- Update privacy policy: disclose Brevo as transactional email processor, update data retention and rights sections
- Update terms of service: replace silent acceptance with email notification of material changes

## Test plan
- [x] Register — confirm submit is disabled until checkbox is ticked, links to privacy and terms work
- [x] Profile page — confirm Download and Delete account buttons enable once profile loads
- [x] Download — confirm JSON file downloads with account, sensor and switch data
- [x] Delete account — confirm modal appears, account is deleted, user is signed out and redirected home