### PR TITLE
feat: design refresh — fonts, animations, scroll reveals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.10.0](https://github.com/sondresjolyst/garge-app/compare/v1.9.0...v1.10.0) (2026-04-29)
+
+
+### Features
+
+* GDPR compliance improvements ([#194](https://github.com/sondresjolyst/garge-app/issues/194)) ([55d5f2e](https://github.com/sondresjolyst/garge-app/commit/55d5f2eafe24a75295435cc16552bfb29dddaf8b))
+
 ## [1.9.0](https://github.com/sondresjolyst/garge-app/compare/v1.8.2...v1.9.0) (2026-04-27)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "garge-app",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "garge-app",
-      "version": "1.9.0",
+      "version": "1.10.0",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
         "apexcharts": "^4.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "garge-app",
-  "version": "1.9.0",
+  "version": "1.10.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -50,7 +50,7 @@ const Login: React.FC = () => {
                 </div>
 
                 <div className="bg-gray-800/60 backdrop-blur-xl border border-gray-700/40 rounded-2xl p-8 shadow-xl">
-                    <h1 className="text-xl font-semibold text-gray-100 mb-1">Welcome back</h1>
+                    <h1 className="text-xl font-display font-bold text-gray-100 mb-1">Welcome back</h1>
                     <p className="text-sm text-gray-400 mb-6">
                         No account?{' '}
                         <Link href="/register" className="text-sky-400 hover:text-sky-300 transition-colors">Create one</Link>

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -54,7 +54,7 @@ const Register: React.FC = () => {
                 </div>
 
                 <div className="bg-gray-800/60 backdrop-blur-xl border border-gray-700/40 rounded-2xl p-8 shadow-xl">
-                    <h1 className="text-xl font-semibold text-gray-100 mb-1">Create account</h1>
+                    <h1 className="text-xl font-display font-bold text-gray-100 mb-1">Create account</h1>
                     <p className="text-sm text-gray-400 mb-6">
                         Already have one?{' '}
                         <Link href="/login" className="text-sky-400 hover:text-sky-300 transition-colors">Sign in</Link>

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -54,7 +54,7 @@ const ResetPassword: React.FC = () => {
                 </div>
 
                 <div className="bg-gray-800/60 backdrop-blur-xl border border-gray-700/40 rounded-2xl p-8 shadow-xl">
-                    <h1 className="text-xl font-semibold text-gray-100 mb-1">Reset password</h1>
+                    <h1 className="text-xl font-display font-bold text-gray-100 mb-1">Reset password</h1>
                     <p className="text-sm text-gray-400 mb-6">
                         Remembered it?{' '}
                         <Link href="/login" className="text-sky-400 hover:text-sky-300 transition-colors">Sign in</Link>

--- a/src/app/(protected)/admin/page.tsx
+++ b/src/app/(protected)/admin/page.tsx
@@ -114,7 +114,7 @@ export default function AdminPage() {
 
     return (
         <div className="max-w-7xl mx-auto px-4 py-8 space-y-6 pb-32">
-            <h1 className="text-xl font-bold text-gray-100">Admin</h1>
+            <h1 className="text-xl font-display font-bold text-gray-100">Admin</h1>
 
             {loading && <LoadingDots height="h-32" />}
             {error && <p className="text-sm text-red-400">{error}</p>}
@@ -123,7 +123,7 @@ export default function AdminPage() {
                 <>
                     {/* Stats */}
                     <Section title="Overview">
-                        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 device-card-grid">
                             {([
                                 { label: 'Users', value: stats?.totalUsers, key: 'totalUsers' as StatKey },
                                 { label: 'Sensors', value: stats?.totalSensors, key: 'totalSensors' as StatKey },

--- a/src/app/(protected)/automations/page.tsx
+++ b/src/app/(protected)/automations/page.tsx
@@ -11,7 +11,15 @@ import { UpdateAutomationRuleDto } from '@/dto/Automation/UpdateAutomationRuleDt
 import { unitForType } from '@/lib/typeUtils';
 import { formatDateTime } from '@/lib/dateUtils';
 import { AxiosError } from 'axios';
-import { PlusIcon } from '@heroicons/react/24/outline';
+import ConfirmModal from '@/components/ConfirmModal';
+import {
+    PlusIcon,
+    XMarkIcon,
+    ClockIcon,
+    PencilSquareIcon,
+    TrashIcon,
+    BoltIcon,
+} from '@heroicons/react/24/outline';
 import { toast } from 'sonner';
 
 const PRICE_AREAS = ['NO1', 'NO2', 'NO3', 'NO4', 'NO5'];
@@ -28,15 +36,23 @@ const initialForm: CreateAutomationRuleDto = {
 };
 
 const conditionOptions = [
-    { label: 'Equals',               value: '==' },
-    { label: 'Less than',            value: '<'  },
-    { label: 'Greater than',         value: '>'  },
-    { label: 'Less than or equal',   value: '<=' },
-    { label: 'Greater than or equal',value: '>=' },
+    { label: 'Equals',                value: '==' },
+    { label: 'Less than',             value: '<'  },
+    { label: 'Greater than',          value: '>'  },
+    { label: 'Less than or equal',    value: '<=' },
+    { label: 'Greater than or equal', value: '>=' },
 ];
 
 const conditionSymbol: Record<string, string> = {
     '==': '=', '<': '<', '>': '>', '<=': '≤', '>=': '≥',
+};
+
+const conditionVerb: Record<string, string> = {
+    '==': 'equals',
+    '<':  'drops below',
+    '>':  'rises above',
+    '<=': 'is at most',
+    '>=': 'reaches',
 };
 
 const actionOptions = [
@@ -58,16 +74,17 @@ const formatTimerRemaining = (activatedAt: string, durationHours: number): strin
     return h > 0 ? `${h}h ${m}m remaining` : `${m}m remaining`;
 };
 
-// ── Field components ──────────────────────────────────────────────────────────
+// ── Shared field components ───────────────────────────────────────────────────
+
 const FieldLabel: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-    <label className="block text-xs font-medium text-gray-400 mb-1.5 uppercase tracking-wide">
+    <label className="block text-xs font-semibold text-gray-400 mb-1.5 uppercase tracking-wider">
         {children}
     </label>
 );
 
 const Select: React.FC<React.SelectHTMLAttributes<HTMLSelectElement>> = ({ className = '', ...props }) => (
     <select
-        className={`block w-full px-3 py-2 bg-gray-900/70 border border-gray-700/60 rounded-xl text-gray-200 text-sm focus:outline-none focus:border-sky-500 transition-colors ${className}`}
+        className={`block w-full px-3 py-2.5 bg-gray-800 border border-gray-600/60 rounded-lg text-gray-200 text-sm focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/30 transition-all ${className}`}
         {...props}
     />
 );
@@ -75,23 +92,35 @@ const Select: React.FC<React.SelectHTMLAttributes<HTMLSelectElement>> = ({ class
 const NumberInput: React.FC<React.InputHTMLAttributes<HTMLInputElement>> = ({ className = '', onFocus, ...props }) => (
     <input
         type="number"
-        className={`block w-full px-3 py-2 bg-gray-900/70 border border-gray-700/60 rounded-xl text-gray-200 text-sm focus:outline-none focus:border-sky-500 transition-colors ${className}`}
+        className={`block w-full px-3 py-2.5 bg-gray-800 border border-gray-600/60 rounded-lg text-gray-200 text-sm focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/30 transition-all ${className}`}
         onFocus={e => { e.currentTarget.select(); onFocus?.(e); }}
         {...props}
     />
 );
 
 const LoadingDots = () => (
-    <div className="h-40 flex items-center justify-center">
-        <div className="flex gap-1.5">
-            <span className="w-2 h-2 rounded-full bg-sky-500 animate-bounce [animation-delay:0ms]" />
-            <span className="w-2 h-2 rounded-full bg-sky-500 animate-bounce [animation-delay:150ms]" />
-            <span className="w-2 h-2 rounded-full bg-sky-500 animate-bounce [animation-delay:300ms]" />
+    <div className="h-60 flex items-center justify-center">
+        <div className="flex gap-2">
+            <span className="w-2.5 h-2.5 rounded-full bg-sky-500 animate-bounce [animation-delay:0ms]" />
+            <span className="w-2.5 h-2.5 rounded-full bg-sky-500 animate-bounce [animation-delay:150ms]" />
+            <span className="w-2.5 h-2.5 rounded-full bg-sky-500 animate-bounce [animation-delay:300ms]" />
         </div>
     </div>
 );
 
+const Toggle: React.FC<{ enabled: boolean; onClick: () => void; title?: string }> = ({ enabled, onClick, title }) => (
+    <button
+        type="button"
+        title={title}
+        onClick={onClick}
+        className={`relative inline-flex h-7 w-12 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2 focus:ring-offset-gray-900 ${enabled ? 'bg-sky-600' : 'bg-gray-600'}`}
+    >
+        <span className={`pointer-events-none inline-block h-6 w-6 transform rounded-full bg-white shadow-lg ring-0 transition-transform duration-200 ease-in-out ${enabled ? 'translate-x-5' : 'translate-x-0'}`} />
+    </button>
+);
+
 // ── Electricity price sub-form ────────────────────────────────────────────────
+
 interface PriceConditionFields {
     electricityPriceCondition?: string;
     electricityPriceThreshold?: number;
@@ -129,19 +158,16 @@ const PriceConditionForm: React.FC<PriceConditionFormProps> = ({ value, defaultA
     };
 
     return (
-        <div className="pt-2 border-t border-gray-700/40">
-            <div className="flex items-center gap-2 mb-2">
-                <button
-                    type="button"
-                    onClick={toggle}
-                    className={`relative w-9 h-5 rounded-full transition-colors focus:outline-none ${enabled ? 'bg-sky-600' : 'bg-gray-600'}`}
-                >
-                    <span className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${enabled ? 'translate-x-4' : 'translate-x-0'}`} />
-                </button>
-                <span className="text-xs text-gray-400 font-medium uppercase tracking-wide">Electricity price condition</span>
+        <div className="pt-4 border-t border-gray-700/60">
+            <div className="flex items-center justify-between mb-3">
+                <div>
+                    <p className="text-sm font-medium text-gray-300">Electricity price condition</p>
+                    <p className="text-xs text-gray-500 mt-0.5">Also check current electricity price</p>
+                </div>
+                <Toggle enabled={enabled} onClick={toggle} />
             </div>
             {enabled && (
-                <div className="space-y-2">
+                <div className="mt-3 p-3 bg-amber-500/5 border border-amber-500/20 rounded-lg space-y-3">
                     <div>
                         <FieldLabel>Combine with sensor condition using</FieldLabel>
                         <Select value={value.electricityPriceOperator ?? 'AND'} onChange={e => onChange({ ...value, electricityPriceOperator: e.target.value })}>
@@ -175,18 +201,20 @@ const PriceConditionForm: React.FC<PriceConditionFormProps> = ({ value, defaultA
 };
 
 // ── AutomationsPage ───────────────────────────────────────────────────────────
+
 const AutomationsPage: React.FC = () => {
-    const [rules, setRules] = useState<AutomationRuleDto[]>([]);
-    const [loading, setLoading] = useState(true);
-    const [error, setError] = useState<string>('');
-    const [form, setForm] = useState<CreateAutomationRuleDto>(initialForm);
-    const [formOpen, setFormOpen] = useState(false);
-    const [submitting, setSubmitting] = useState(false);
-    const [editingId, setEditingId] = useState<number | null>(null);
-    const [editForm, setEditForm] = useState<UpdateAutomationRuleDto | null>(null);
-    const [switches, setSwitches] = useState<Switch[]>([]);
-    const [sensors, setSensors] = useState<Sensor[]>([]);
+    const [rules, setRules]                   = useState<AutomationRuleDto[]>([]);
+    const [loading, setLoading]               = useState(true);
+    const [error, setError]                   = useState<string>('');
+    const [form, setForm]                     = useState<CreateAutomationRuleDto>(initialForm);
+    const [formOpen, setFormOpen]             = useState(false);
+    const [submitting, setSubmitting]         = useState(false);
+    const [editingId, setEditingId]           = useState<number | null>(null);
+    const [editForm, setEditForm]             = useState<UpdateAutomationRuleDto | null>(null);
+    const [switches, setSwitches]             = useState<Switch[]>([]);
+    const [sensors, setSensors]               = useState<Sensor[]>([]);
     const [defaultPriceArea, setDefaultPriceArea] = useState<string>('NO2');
+    const [deleteTargetId, setDeleteTargetId]     = useState<number | null>(null);
 
     useEffect(() => {
         Promise.all([fetchRules(), fetchSwitches(), fetchSensors(), fetchUserPriceZone()])
@@ -201,14 +229,14 @@ const AutomationsPage: React.FC = () => {
             .localeCompare((b.customName ?? b.defaultName ?? '').toLowerCase())
     );
 
-    const fetchRules   = () => AutomationService.getRules()
+    const fetchRules    = () => AutomationService.getRules()
         .then(data => setRules(Array.isArray(data) ? data : []))
         .catch(handleError);
     const fetchSwitches = async () => {
         try { setSwitches(await SwitchService.getAllSwitches()); }
         catch (e) { handleError(e, 'Failed to fetch switches'); }
     };
-    const fetchSensors = async () => {
+    const fetchSensors  = async () => {
         try { setSensors(await SensorService.getAllSensors()); }
         catch (e) { handleError(e, 'Failed to fetch sensors'); }
     };
@@ -219,10 +247,10 @@ const AutomationsPage: React.FC = () => {
         } catch { /* ignore */ }
     };
 
-    const handleError = (error: unknown, fallbackMsg?: string) => {
-        if (error instanceof AxiosError)   setError(error.response?.data?.message || fallbackMsg || 'A network error occurred');
-        else if (error instanceof Error)   setError(error.message);
-        else                               setError(fallbackMsg || 'An unknown error occurred');
+    const handleError = (err: unknown, fallbackMsg?: string) => {
+        if (err instanceof AxiosError)  setError(err.response?.data?.message || fallbackMsg || 'A network error occurred');
+        else if (err instanceof Error)  setError(err.message);
+        else                            setError(fallbackMsg || 'An unknown error occurred');
     };
 
     const handleCreate = async (e: React.FormEvent) => {
@@ -243,6 +271,8 @@ const AutomationsPage: React.FC = () => {
         setError('');
         try {
             await AutomationService.deleteRule(id);
+            setDeleteTargetId(null);
+            cancelEdit();
             fetchRules();
             toast.success('Automation deleted');
         } catch (e) { handleError(e, 'Failed to delete automation'); toast.error('Failed to delete automation'); }
@@ -254,13 +284,13 @@ const AutomationsPage: React.FC = () => {
             await AutomationService.updateRule(rule.id, {
                 targetType: rule.targetType, targetId: rule.targetId,
                 sensorType: rule.sensorType, sensorId: rule.sensorId,
-                condition: rule.condition, threshold: rule.threshold,
-                action: rule.action, isEnabled: !rule.isEnabled,
-                electricityPriceCondition: rule.electricityPriceCondition,
-                electricityPriceThreshold: rule.electricityPriceThreshold,
-                electricityPriceArea: rule.electricityPriceArea,
-                electricityPriceOperator: rule.electricityPriceOperator,
-                timerDurationHours: rule.timerDurationHours,
+                condition: rule.condition,   threshold: rule.threshold,
+                action: rule.action,         isEnabled: !rule.isEnabled,
+                electricityPriceCondition:  rule.electricityPriceCondition,
+                electricityPriceThreshold:  rule.electricityPriceThreshold,
+                electricityPriceArea:       rule.electricityPriceArea,
+                electricityPriceOperator:   rule.electricityPriceOperator,
+                timerDurationHours:         rule.timerDurationHours,
             });
             fetchRules();
             toast.success(rule.isEnabled ? 'Automation disabled' : 'Automation enabled');
@@ -272,17 +302,18 @@ const AutomationsPage: React.FC = () => {
         setEditForm({
             targetType: rule.targetType, targetId: rule.targetId,
             sensorType: rule.sensorType, sensorId: rule.sensorId,
-            condition: rule.condition, threshold: rule.threshold,
-            action: rule.action, isEnabled: rule.isEnabled,
-            electricityPriceCondition: rule.electricityPriceCondition,
-            electricityPriceThreshold: rule.electricityPriceThreshold,
-            electricityPriceArea: rule.electricityPriceArea,
-            electricityPriceOperator: rule.electricityPriceOperator,
-            timerDurationHours: rule.timerDurationHours,
+            condition:  rule.condition,  threshold: rule.threshold,
+            action:     rule.action,     isEnabled: rule.isEnabled,
+            electricityPriceCondition:  rule.electricityPriceCondition,
+            electricityPriceThreshold:  rule.electricityPriceThreshold,
+            electricityPriceArea:       rule.electricityPriceArea,
+            electricityPriceOperator:   rule.electricityPriceOperator,
+            timerDurationHours:         rule.timerDurationHours,
         });
+        setFormOpen(true);
     };
 
-    const cancelEdit = () => { setEditingId(null); setEditForm(null); };
+    const cancelEdit = () => { setEditingId(null); setEditForm(null); setFormOpen(false); };
 
     const handleUpdate = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -307,288 +338,425 @@ const AutomationsPage: React.FC = () => {
         setForm({ ...form, sensorId: id, sensorType: selected?.type || '' });
     };
 
-    // ── Inline edit form ─────────────────────────────────────────────────────
-    const editSensorObj = sensors.find(s => s.id === editForm?.sensorId);
-    const editUnit = editSensorObj ? unitForType(editSensorObj.type) : '';
+    // ── Derived values ─────────────────────────────────────────────────────────
+    const isEditMode     = editingId !== null && editForm !== null;
+    const editSensorObj  = sensors.find(s => s.id === editForm?.sensorId);
+    const editUnit       = editSensorObj ? unitForType(editSensorObj.type) : '';
+    const createSensorObj = sensors.find(s => s.id === form.sensorId);
+    const createUnit      = createSensorObj ? unitForType(createSensorObj.type) : '';
 
-    const renderEditForm = (rule: AutomationRuleDto) => (
-        <form onSubmit={handleUpdate} className="space-y-3 mt-3 pt-3 border-t border-gray-700/50">
+    const openCreateDrawer = () => { setEditingId(null); setEditForm(null); setFormOpen(true); };
+    const closeDrawer      = () => { setFormOpen(false); setEditingId(null); setEditForm(null); };
+
+    // ── Form contents (shared between drawer modes) ────────────────────────────
+
+    const createFormContent = (
+        <form onSubmit={handleCreate} className="space-y-5">
             <div>
-                <FieldLabel>Target</FieldLabel>
-                <Select value={editForm!.targetId} required onChange={e => {
-                    const id = Number(e.target.value);
-                    setEditForm({ ...editForm!, targetId: id, targetType: switches.find(sw => sw.id === id)?.type || '' });
-                }}>
-                    <option value={0}>Select Target</option>
+                <FieldLabel>Target socket</FieldLabel>
+                <Select value={form.targetId} required onChange={e => handleTargetChange(Number(e.target.value))}>
+                    <option value={0}>Select a switch or socket</option>
                     {sortedSwitches.map(sw => <option key={sw.id} value={sw.id}>{sw.customName ?? sw.name}</option>)}
                 </Select>
             </div>
             <div>
-                <FieldLabel>Sensor</FieldLabel>
-                <Select value={editForm!.sensorId}required onChange={e => {
-                    const id = Number(e.target.value);
-                    setEditForm({ ...editForm!, sensorId: id, sensorType: sensors.find(s => s.id === id)?.type || '' });
-                }}>
-                    <option value={0}>Select Sensor</option>
+                <FieldLabel>Trigger sensor</FieldLabel>
+                <Select value={form.sensorId} required onChange={e => handleSensorChange(Number(e.target.value))}>
+                    <option value={0}>Select a sensor</option>
                     {sortedSensors.map(s => <option key={s.id} value={s.id}>{s.customName ?? s.defaultName}</option>)}
                 </Select>
             </div>
-            <div className="grid grid-cols-2 gap-2">
+            <div className="grid grid-cols-2 gap-3">
                 <div>
                     <FieldLabel>Condition</FieldLabel>
-                    <Select value={editForm!.condition} required onChange={e => setEditForm({ ...editForm!, condition: e.target.value })}>
+                    <Select value={form.condition} required onChange={e => setForm({ ...form, condition: e.target.value })}>
                         {conditionOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
                     </Select>
                 </div>
                 <div>
-                    <FieldLabel>Threshold{editUnit ? ` (${editUnit})` : ''}</FieldLabel>
-                    <NumberInput value={editForm!.threshold} step="0.1" required
-                        onChange={e => setEditForm({ ...editForm!, threshold: Number(e.target.value) })} />
+                    <FieldLabel>Threshold{createUnit ? ` (${createUnit})` : ''}</FieldLabel>
+                    <NumberInput value={form.threshold} step="0.1" placeholder="0" required
+                        onChange={e => setForm({ ...form, threshold: Number(e.target.value) })} />
                 </div>
             </div>
             <div>
                 <FieldLabel>Action</FieldLabel>
-                <Select value={editForm!.action} required onChange={e => setEditForm({ ...editForm!, action: e.target.value })}>
+                <Select value={form.action} required onChange={e => setForm({ ...form, action: e.target.value })}>
                     {actionOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
                 </Select>
             </div>
-            {editForm!.action === 'on' && (
-                <div className="pt-2 border-t border-gray-700/40">
-                    <div className="flex items-center gap-2 mb-2">
-                        <button
-                            type="button"
-                            onClick={() => setEditForm({ ...editForm!, timerDurationHours: editForm!.timerDurationHours ? undefined : 2 })}
-                            className={`relative w-9 h-5 rounded-full transition-colors focus:outline-none ${editForm!.timerDurationHours ? 'bg-sky-600' : 'bg-gray-600'}`}
-                        >
-                            <span className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${editForm!.timerDurationHours ? 'translate-x-4' : 'translate-x-0'}`} />
-                        </button>
-                        <span className="text-xs text-gray-400 font-medium uppercase tracking-wide">Auto-off timer</span>
+            {form.action === 'on' && (
+                <div className="pt-4 border-t border-gray-700/60">
+                    <div className="flex items-center justify-between mb-3">
+                        <div>
+                            <p className="text-sm font-medium text-gray-300">Auto-off timer</p>
+                            <p className="text-xs text-gray-500 mt-0.5">Automatically turn off after a set duration</p>
+                        </div>
+                        <Toggle
+                            enabled={!!form.timerDurationHours}
+                            onClick={() => setForm({ ...form, timerDurationHours: form.timerDurationHours ? undefined : 2 })}
+                        />
                     </div>
-                    {editForm!.timerDurationHours != null && (
+                    {form.timerDurationHours != null && (
                         <div>
                             <FieldLabel>Duration (hours)</FieldLabel>
-                            <NumberInput value={editForm!.timerDurationHours} step="0.5" min="0.5" placeholder="2"
-                                onChange={e => setEditForm({ ...editForm!, timerDurationHours: Number(e.target.value) })} />
+                            <NumberInput value={form.timerDurationHours} step="0.5" min="0.5" placeholder="2"
+                                onChange={e => setForm({ ...form, timerDurationHours: Number(e.target.value) })} />
                         </div>
                     )}
                 </div>
             )}
             <PriceConditionForm
-                value={editForm!}
+                key="create"
+                value={form}
                 defaultArea={defaultPriceArea}
-                onChange={fields => setEditForm({ ...editForm!, ...fields })}
+                onChange={fields => setForm({ ...form, ...fields })}
             />
-            <div className="flex items-center gap-2 pt-1">
-                <button type="submit" disabled={submitting} className="flex-1 px-4 py-2 bg-sky-600 hover:bg-sky-500 active:bg-sky-700 disabled:opacity-50 text-white text-sm font-medium rounded-xl transition-all">{submitting ? 'Saving…' : 'Save'}</button>
-                <button type="button" className="flex-1 px-4 py-2 bg-gray-700 hover:bg-gray-600 text-gray-300 text-sm font-medium rounded-xl transition-all" onClick={cancelEdit}>Cancel</button>
-                <button type="button" className="px-4 py-2 bg-rose-600 hover:bg-rose-500 active:bg-rose-700 text-white text-sm font-medium rounded-xl transition-all" onClick={() => handleDelete(rule.id)}>Delete</button>
+            <div className="flex gap-3 pt-2">
+                <button type="submit" disabled={submitting}
+                    className="flex-1 px-4 py-2.5 bg-sky-600 hover:bg-sky-500 active:bg-sky-700 disabled:opacity-50 text-white text-sm font-semibold rounded-lg transition-all">
+                    {submitting ? 'Creating…' : 'Create Rule'}
+                </button>
+                <button type="button" onClick={closeDrawer}
+                    className="px-4 py-2.5 bg-gray-700 hover:bg-gray-600 text-gray-300 text-sm font-medium rounded-lg transition-all">
+                    Cancel
+                </button>
             </div>
         </form>
     );
 
-    // ── Threshold unit for create form ────────────────────────────────────────
-    const createSensorObj = sensors.find(s => s.id === form.sensorId);
-    const createUnit = createSensorObj ? unitForType(createSensorObj.type) : '';
+    const editFormContent = editForm && (
+        <form onSubmit={handleUpdate} className="space-y-5">
+            <div>
+                <FieldLabel>Target socket</FieldLabel>
+                <Select value={editForm.targetId} required onChange={e => {
+                    const id = Number(e.target.value);
+                    setEditForm({ ...editForm, targetId: id, targetType: switches.find(sw => sw.id === id)?.type || '' });
+                }}>
+                    <option value={0}>Select a switch or socket</option>
+                    {sortedSwitches.map(sw => <option key={sw.id} value={sw.id}>{sw.customName ?? sw.name}</option>)}
+                </Select>
+            </div>
+            <div>
+                <FieldLabel>Trigger sensor</FieldLabel>
+                <Select value={editForm.sensorId} required onChange={e => {
+                    const id = Number(e.target.value);
+                    setEditForm({ ...editForm, sensorId: id, sensorType: sensors.find(s => s.id === id)?.type || '' });
+                }}>
+                    <option value={0}>Select a sensor</option>
+                    {sortedSensors.map(s => <option key={s.id} value={s.id}>{s.customName ?? s.defaultName}</option>)}
+                </Select>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+                <div>
+                    <FieldLabel>Condition</FieldLabel>
+                    <Select value={editForm.condition} required onChange={e => setEditForm({ ...editForm, condition: e.target.value })}>
+                        {conditionOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+                    </Select>
+                </div>
+                <div>
+                    <FieldLabel>Threshold{editUnit ? ` (${editUnit})` : ''}</FieldLabel>
+                    <NumberInput value={editForm.threshold} step="0.1" required
+                        onChange={e => setEditForm({ ...editForm, threshold: Number(e.target.value) })} />
+                </div>
+            </div>
+            <div>
+                <FieldLabel>Action</FieldLabel>
+                <Select value={editForm.action} required onChange={e => setEditForm({ ...editForm, action: e.target.value })}>
+                    {actionOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+                </Select>
+            </div>
+            {editForm.action === 'on' && (
+                <div className="pt-4 border-t border-gray-700/60">
+                    <div className="flex items-center justify-between mb-3">
+                        <div>
+                            <p className="text-sm font-medium text-gray-300">Auto-off timer</p>
+                            <p className="text-xs text-gray-500 mt-0.5">Automatically turn off after a set duration</p>
+                        </div>
+                        <Toggle
+                            enabled={!!editForm.timerDurationHours}
+                            onClick={() => setEditForm({ ...editForm, timerDurationHours: editForm.timerDurationHours ? undefined : 2 })}
+                        />
+                    </div>
+                    {editForm.timerDurationHours != null && (
+                        <div>
+                            <FieldLabel>Duration (hours)</FieldLabel>
+                            <NumberInput value={editForm.timerDurationHours} step="0.5" min="0.5" placeholder="2"
+                                onChange={e => setEditForm({ ...editForm, timerDurationHours: Number(e.target.value) })} />
+                        </div>
+                    )}
+                </div>
+            )}
+            <PriceConditionForm
+                key={editingId ?? 'edit'}
+                value={editForm}
+                defaultArea={defaultPriceArea}
+                onChange={fields => setEditForm({ ...editForm, ...fields })}
+            />
+            <div className="flex gap-3 pt-2">
+                <button type="submit" disabled={submitting}
+                    className="flex-1 px-4 py-2.5 bg-sky-600 hover:bg-sky-500 active:bg-sky-700 disabled:opacity-50 text-white text-sm font-semibold rounded-lg transition-all">
+                    {submitting ? 'Saving…' : 'Save Changes'}
+                </button>
+                <button type="button" onClick={closeDrawer}
+                    className="px-4 py-2.5 bg-gray-700 hover:bg-gray-600 text-gray-300 text-sm font-medium rounded-lg transition-all">
+                    Cancel
+                </button>
+            </div>
+            <div className="pt-4 border-t border-gray-700/60">
+                <button
+                    type="button"
+                    onClick={() => editingId && setDeleteTargetId(editingId)}
+                    className="w-full px-4 py-2.5 bg-rose-600/10 hover:bg-rose-600/20 border border-rose-600/30 text-rose-400 text-sm font-medium rounded-lg transition-all flex items-center justify-center gap-2"
+                >
+                    <TrashIcon className="h-4 w-4" />
+                    Delete Rule
+                </button>
+            </div>
+        </form>
+    );
+
+    // ── Empty state ────────────────────────────────────────────────────────────
+
+    const emptyState = (
+        <div className="mt-16 flex flex-col items-center text-center max-w-sm mx-auto">
+            <div className="relative mb-8">
+                <div className="w-20 h-20 rounded-2xl bg-gray-800/80 border border-gray-700/60 flex items-center justify-center">
+                    <BoltIcon className="h-9 w-9 text-sky-500/70" />
+                </div>
+                <div className="absolute -top-1.5 -right-1.5 w-6 h-6 rounded-full bg-sky-600/30 border border-sky-500/50 flex items-center justify-center">
+                    <PlusIcon className="h-3 w-3 text-sky-400" />
+                </div>
+            </div>
+            <h2 className="text-xl font-display font-semibold text-gray-100 mb-2">No automations yet</h2>
+            <p className="text-gray-400 text-sm leading-relaxed mb-8">
+                Automations watch your sensors and automatically control switches — like turning on a heater when the temperature drops too low.
+            </p>
+            <div className="w-full space-y-2.5 mb-8 text-left">
+                {[
+                    { step: '1', title: 'Choose a switch', desc: 'Pick which socket or relay to control' },
+                    { step: '2', title: 'Set a trigger',   desc: 'Select a sensor and the condition that fires the rule' },
+                    { step: '3', title: 'Define the action', desc: 'Turn the switch on or off when conditions are met' },
+                ].map(item => (
+                    <div key={item.step} className="flex items-start gap-3 p-3 bg-gray-800/40 rounded-xl border border-gray-700/30">
+                        <span className="flex-shrink-0 w-6 h-6 rounded-full bg-sky-600/20 border border-sky-500/30 text-sky-400 text-xs font-bold flex items-center justify-center mt-0.5">
+                            {item.step}
+                        </span>
+                        <div>
+                            <p className="text-sm font-medium text-gray-200">{item.title}</p>
+                            <p className="text-xs text-gray-500 mt-0.5">{item.desc}</p>
+                        </div>
+                    </div>
+                ))}
+            </div>
+            <button
+                onClick={openCreateDrawer}
+                className="flex items-center gap-2 px-6 py-3 bg-sky-600 hover:bg-sky-500 active:bg-sky-700 text-white font-semibold rounded-xl transition-all shadow-lg shadow-sky-900/30"
+            >
+                <PlusIcon className="h-5 w-5" />
+                Create first automation
+            </button>
+        </div>
+    );
+
+    // ── Rule card ──────────────────────────────────────────────────────────────
+
+    const renderRuleCard = (rule: AutomationRuleDto) => {
+        const switchObj  = switches.find(sw => sw.id === rule.targetId);
+        const sensorObj  = sensors.find(s => s.id === rule.sensorId);
+        const verb       = conditionVerb[rule.condition] ?? rule.condition;
+        const unit       = sensorObj ? unitForType(sensorObj.type) : '';
+        const triggered  = formatTriggered(rule.lastTriggeredAt);
+        const priceSym   = rule.electricityPriceCondition
+            ? (conditionSymbol[rule.electricityPriceCondition] ?? rule.electricityPriceCondition)
+            : null;
+        const switchName = switchObj ? (switchObj.customName ?? switchObj.name) : `Switch ${rule.targetId}`;
+        const sensorName = sensorObj?.customName ?? sensorObj?.defaultName ?? `Sensor ${rule.sensorId}`;
+        const isOn       = rule.action === 'on';
+
+        return (
+            <div
+                key={rule.id}
+                className={`relative bg-gray-800/60 border border-gray-700/40 border-l-4 rounded-2xl backdrop-blur-sm shadow-lg flex flex-col transition-all duration-300 ${rule.isEnabled ? 'border-l-sky-500' : 'border-l-gray-600 opacity-55'}`}
+            >
+                {/* Header: name + toggle */}
+                <div className="flex items-center justify-between px-4 pt-4 pb-3">
+                    <div className="flex-1 min-w-0 mr-3">
+                        <h3 className="text-sm font-semibold truncate text-gray-100">
+                            {switchName}
+                        </h3>
+                        <span className="inline-flex items-center text-xs font-medium mt-1 text-gray-400">
+                            {isOn ? 'Turn on rule' : 'Turn off rule'}
+                        </span>
+                    </div>
+                    <Toggle
+                        enabled={rule.isEnabled}
+                        onClick={() => handleToggleEnabled(rule)}
+                        title={rule.isEnabled ? 'Disable rule' : 'Enable rule'}
+                    />
+                </div>
+
+                {/* IF / THEN logic blocks */}
+                <div className="px-4 pb-3 space-y-1.5 flex-1">
+                    {/* IF block */}
+                    <div className="rounded-lg bg-gray-900/70 border border-gray-700/40 px-3 py-2.5">
+                        <span className="text-[10px] font-bold text-gray-500 uppercase tracking-widest block mb-1">IF</span>
+                        <p className="text-sm text-gray-200 leading-snug">
+                            <span className="font-medium text-white">{sensorName}</span>
+                            {' '}<span className="text-gray-400">{verb}</span>{' '}
+                            <span className="font-semibold text-sky-400 font-mono">{rule.threshold}{unit ? ` ${unit}` : ''}</span>
+                        </p>
+                    </div>
+
+                    {/* Price condition block */}
+                    {priceSym && rule.electricityPriceThreshold !== undefined && (
+                        <div className="rounded-lg bg-gray-900/70 border border-gray-700/40 px-3 py-2.5">
+                            <span className="text-[10px] font-bold text-gray-500 uppercase tracking-widest block mb-1">
+                                {rule.electricityPriceOperator ?? 'AND'}
+                            </span>
+                            <p className="text-sm text-gray-200 leading-snug">
+                                <span className="text-gray-400">Price</span>{' '}
+                                <span className="text-sky-400 font-mono">{priceSym}</span>{' '}
+                                <span className="font-medium text-white">{rule.electricityPriceThreshold} kr/kWh</span>
+                                <span className="text-gray-500 ml-1 text-xs">({rule.electricityPriceArea})</span>
+                            </p>
+                        </div>
+                    )}
+
+                    {/* THEN block */}
+                    <div className="rounded-lg bg-gray-900/70 border border-gray-700/40 px-3 py-2.5">
+                        <span className="text-[10px] font-bold text-gray-500 uppercase tracking-widest block mb-1">THEN</span>
+                        <p className="text-sm text-gray-200 leading-snug">
+                            <span className={`font-semibold ${isOn ? 'text-green-400' : 'text-rose-400'}`}>Turn {isOn ? 'ON' : 'OFF'}</span>
+                            {' '}{switchName}
+                        </p>
+                    </div>
+
+                    {/* Timer block — shown prominently when set */}
+                    {rule.timerDurationHours != null && (
+                        <div className={`rounded-lg border px-3 py-2.5 ${rule.timerActivatedAt ? 'bg-sky-500/5 border-sky-500/20' : 'bg-gray-900/70 border-gray-700/40'}`}>
+                            <span className="text-[10px] font-bold text-gray-500 uppercase tracking-widest block mb-1">AUTO-OFF</span>
+                            <div className="flex items-center gap-1.5 text-sm text-gray-200">
+                                <ClockIcon className="h-4 w-4 text-gray-400 flex-shrink-0" />
+                                <span>
+                                    {rule.timerActivatedAt
+                                        ? <><span className="font-medium text-sky-400">Active</span> — {formatTimerRemaining(rule.timerActivatedAt, rule.timerDurationHours)}</>
+                                        : <>After <span className="font-semibold text-white">{rule.timerDurationHours}h</span></>
+                                    }
+                                </span>
+                            </div>
+                        </div>
+                    )}
+                </div>
+
+                {/* Footer: meta + edit */}
+                <div className="px-4 pb-4 flex items-center justify-between gap-2">
+                    <div className="min-w-0">
+                        {triggered && (
+                            <p className="text-xs text-gray-500 truncate">
+                                Triggered: <span className="text-gray-400">{triggered}</span>
+                            </p>
+                        )}
+                    </div>
+                    <button
+                        onClick={() => startEdit(rule)}
+                        className="flex-shrink-0 flex items-center gap-1.5 text-xs text-gray-500 hover:text-gray-200 transition-colors px-3 py-1.5 rounded-lg hover:bg-gray-700/60 border border-transparent hover:border-gray-600/40"
+                    >
+                        <PencilSquareIcon className="h-3.5 w-3.5" />
+                        Edit
+                    </button>
+                </div>
+            </div>
+        );
+    };
+
+    // ── Render ─────────────────────────────────────────────────────────────────
 
     return (
-        <div className="p-4 max-w-7xl mx-auto">
+        <div className="p-4 sm:p-6 max-w-7xl mx-auto">
+            {/* Page header */}
             <div className="flex items-center justify-between mb-6">
-                <h1 className="text-2xl sm:text-3xl font-bold">Automations</h1>
+                <div>
+                    <h1 className="text-2xl sm:text-3xl font-display font-bold text-white">Automations</h1>
+                    <p className="text-gray-400 text-sm mt-0.5">Rules that control your garage automatically</p>
+                </div>
                 <button
-                    onClick={() => setFormOpen(o => !o)}
-                    className="flex items-center gap-1.5 px-4 py-2 bg-sky-600 hover:bg-sky-500 active:bg-sky-700 text-white text-sm font-medium rounded-xl transition-all"
+                    onClick={openCreateDrawer}
+                    className="flex items-center gap-1.5 px-4 py-2 bg-sky-600 hover:bg-sky-500 active:bg-sky-700 text-white text-sm font-semibold rounded-xl transition-all shadow-lg shadow-sky-900/20"
                 >
                     <PlusIcon className="h-4 w-4" />
                     New Rule
                 </button>
             </div>
 
+            {/* Error banner */}
             {error && (
                 <div className="mb-4 px-4 py-3 bg-red-500/10 border border-red-500/30 rounded-xl text-red-400 text-sm">
                     {error}
                 </div>
             )}
 
-            {/* ── Create form ── */}
-            {formOpen && (
-                <div className="bg-gray-800/60 border border-gray-700/40 rounded-2xl backdrop-blur-sm shadow-lg p-5 mb-6">
-                    <h2 className="text-base font-semibold text-gray-100 mb-4">New Automation Rule</h2>
-                    <form onSubmit={handleCreate} className="space-y-3">
-                        <div>
-                            <FieldLabel>Target socket</FieldLabel>
-                            <Select value={form.targetId} required onChange={e => handleTargetChange(Number(e.target.value))}>
-                                <option value={0}>Select target</option>
-                                {sortedSwitches.map(sw => <option key={sw.id} value={sw.id}>{sw.customName ?? sw.name}</option>)}
-                            </Select>
-                        </div>
-                        <div>
-                            <FieldLabel>Trigger sensor</FieldLabel>
-                            <Select value={form.sensorId} required onChange={e => handleSensorChange(Number(e.target.value))}>
-                                <option value={0}>Select sensor</option>
-                                {sortedSensors.map(s => <option key={s.id} value={s.id}>{s.customName ?? s.defaultName}</option>)}
-                            </Select>
-                        </div>
-                        <div className="grid grid-cols-2 gap-2">
-                            <div>
-                                <FieldLabel>Condition</FieldLabel>
-                                <Select value={form.condition} required onChange={e => setForm({ ...form, condition: e.target.value })}>
-                                    {conditionOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-                                </Select>
-                            </div>
-                            <div>
-                                <FieldLabel>Threshold{createUnit ? ` (${createUnit})` : ''}</FieldLabel>
-                                <NumberInput value={form.threshold} step="0.1" placeholder="0" required
-                                    onChange={e => setForm({ ...form, threshold: Number(e.target.value) })} />
-                            </div>
-                        </div>
-                        <div>
-                            <FieldLabel>Action</FieldLabel>
-                            <Select value={form.action} required onChange={e => setForm({ ...form, action: e.target.value })}>
-                                {actionOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-                            </Select>
-                        </div>
-                        {form.action === 'on' && (
-                            <div className="pt-2 border-t border-gray-700/40">
-                                <div className="flex items-center gap-2 mb-2">
-                                    <button
-                                        type="button"
-                                        onClick={() => setForm({ ...form, timerDurationHours: form.timerDurationHours ? undefined : 2 })}
-                                        className={`relative w-9 h-5 rounded-full transition-colors focus:outline-none ${form.timerDurationHours ? 'bg-sky-600' : 'bg-gray-600'}`}
-                                    >
-                                        <span className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${form.timerDurationHours ? 'translate-x-4' : 'translate-x-0'}`} />
-                                    </button>
-                                    <span className="text-xs text-gray-400 font-medium uppercase tracking-wide">Auto-off timer</span>
-                                </div>
-                                {form.timerDurationHours != null && (
-                                    <div>
-                                        <FieldLabel>Duration (hours)</FieldLabel>
-                                        <NumberInput value={form.timerDurationHours} step="0.5" min="0.5" placeholder="2"
-                                            onChange={e => setForm({ ...form, timerDurationHours: Number(e.target.value) })} />
-                                    </div>
-                                )}
-                            </div>
-                        )}
-                        <PriceConditionForm
-                            value={form}
-                            defaultArea={defaultPriceArea}
-                            onChange={fields => setForm({ ...form, ...fields })}
-                        />
-                        <div className="flex gap-2 pt-1">
-                            <button type="submit" disabled={submitting} className="flex-1 px-4 py-2 bg-sky-600 hover:bg-sky-500 active:bg-sky-700 disabled:opacity-50 text-white text-sm font-medium rounded-xl transition-all">{submitting ? 'Creating…' : 'Create'}</button>
-                            <button type="button" className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-gray-300 text-sm font-medium rounded-xl transition-all" onClick={() => setFormOpen(false)}>Cancel</button>
-                        </div>
-                    </form>
-                </div>
-            )}
-
-            {/* ── Rules ── */}
+            {/* Content */}
             {loading ? (
                 <LoadingDots />
             ) : rules.length === 0 ? (
-                <div className="mt-12 text-center text-gray-400 space-y-2">
-                    <p>No automation rules yet.</p>
-                    <p>Click <span className="text-sky-400">New Rule</span> to create one.</p>
-                </div>
+                emptyState
             ) : (
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-                    {rules.map(rule => {
-                        const switchObj = switches.find(sw => sw.id === rule.targetId);
-                        const sensorObj = sensors.find(s => s.id === rule.sensorId);
-                        const isEditing = editingId === rule.id && editForm;
-                        const sym = conditionSymbol[rule.condition] ?? rule.condition;
-                        const unit = sensorObj ? unitForType(sensorObj.type) : '';
-                        const triggered = formatTriggered(rule.lastTriggeredAt);
-                        const priceSym = rule.electricityPriceCondition ? (conditionSymbol[rule.electricityPriceCondition] ?? rule.electricityPriceCondition) : null;
-
-                        return (
-                            <div
-                                key={rule.id}
-                                className={`bg-gray-800/60 border rounded-2xl backdrop-blur-sm shadow-lg p-5 flex flex-col transition-opacity ${
-                                    rule.isEnabled ? 'border-gray-700/40' : 'border-gray-700/20 opacity-60'
-                                }`}
-                            >
-                                {/* Rule summary */}
-                                <div className="flex items-start justify-between mb-3">
-                                    <div className="flex-1 min-w-0">
-                                        <h3 className={`text-base font-semibold truncate ${rule.isEnabled ? 'text-gray-100' : 'text-gray-400'}`}>
-                                            {switchObj ? (switchObj.customName ?? switchObj.name) : `Switch ${rule.targetId}`}
-                                        </h3>
-                                        <span className={`inline-flex items-center text-xs font-medium mt-1 px-2 py-0.5 rounded-full ${
-                                            rule.action === 'on'
-                                                ? 'bg-green-500/15 text-green-400'
-                                                : 'bg-red-500/15 text-red-400'
-                                        }`}>
-                                            Turn {rule.action}
-                                        </span>
-                                    </div>
-                                    <div className="flex items-center gap-1 ml-2 flex-shrink-0">
-                                        {/* Enable/disable toggle */}
-                                        <button
-                                            title={rule.isEnabled ? 'Disable rule' : 'Enable rule'}
-                                            onClick={() => handleToggleEnabled(rule)}
-                                            className={`relative w-9 h-5 rounded-full transition-colors focus:outline-none ${
-                                                rule.isEnabled ? 'bg-sky-600' : 'bg-gray-600'
-                                            }`}
-                                        >
-                                            <span className={`absolute top-0.5 left-0.5 w-4 h-4 bg-white rounded-full shadow transition-transform ${
-                                                rule.isEnabled ? 'translate-x-4' : 'translate-x-0'
-                                            }`} />
-                                        </button>
-                                        {!isEditing && (
-                                            <button
-                                                className="text-xs text-gray-500 hover:text-gray-200 transition-colors px-2 py-1 rounded-lg hover:bg-gray-700/50"
-                                                onClick={() => startEdit(rule)}
-                                            >
-                                                Edit
-                                            </button>
-                                        )}
-                                    </div>
-                                </div>
-
-                                {/* Sensor condition pill */}
-                                <div className="bg-gray-900/60 rounded-xl px-3 py-2 text-sm text-gray-300">
-                                    When{' '}
-                                    <span className="text-white font-medium">
-                                        {sensorObj?.customName ?? sensorObj?.defaultName ?? `Sensor ${rule.sensorId}`}
-                                    </span>{' '}
-                                    <span className="text-sky-400 font-mono">{sym}</span>{' '}
-                                    <span className="text-white font-medium">{rule.threshold}{unit ? ` ${unit}` : ''}</span>
-                                </div>
-
-                                {/* Electricity price condition pill */}
-                                {priceSym && rule.electricityPriceThreshold !== undefined && (
-                                    <div className="mt-1.5 bg-gray-900/60 rounded-xl px-3 py-2 text-sm text-gray-300">
-                                        <span className="text-amber-400 font-medium text-xs uppercase tracking-wide">
-                                            {rule.electricityPriceOperator ?? 'AND'}
-                                        </span>{' '}price{' '}
-                                        <span className="text-sky-400 font-mono">{priceSym}</span>{' '}
-                                        <span className="text-white font-medium">{rule.electricityPriceThreshold} kr/kWh</span>
-                                        <span className="text-gray-500 ml-1">({rule.electricityPriceArea})</span>
-                                    </div>
-                                )}
-
-                                {/* Last triggered */}
-                                {triggered && (
-                                    <p className="mt-2 text-xs text-gray-500">
-                                        Last triggered: <span className="text-gray-400">{triggered}</span>
-                                    </p>
-                                )}
-
-                                {/* Timer status pill */}
-                                {rule.timerDurationHours != null && (
-                                    <div className={`mt-1.5 rounded-xl px-3 py-2 text-sm ${rule.timerActivatedAt ? 'bg-amber-500/10 text-amber-300' : 'bg-gray-900/60 text-gray-400'}`}>
-                                        {rule.timerActivatedAt
-                                            ? <>⏱ Timer active &mdash; {formatTimerRemaining(rule.timerActivatedAt, rule.timerDurationHours)}</>
-                                            : <>⏱ Auto-off after <span className="text-white font-medium">{rule.timerDurationHours}h</span></>
-                                        }
-                                    </div>
-                                )}
-
-                                {isEditing && renderEditForm(rule)}
-                            </div>
-                        );
-                    })}
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 device-card-grid">
+                    {[...rules]
+                        .sort((a, b) => {
+                            if (a.isEnabled !== b.isEnabled) return a.isEnabled ? -1 : 1;
+                            const nameA = (switches.find(sw => sw.id === a.targetId)?.customName ?? switches.find(sw => sw.id === a.targetId)?.name ?? '').toLowerCase();
+                            const nameB = (switches.find(sw => sw.id === b.targetId)?.customName ?? switches.find(sw => sw.id === b.targetId)?.name ?? '').toLowerCase();
+                            return nameA.localeCompare(nameB);
+                        })
+                        .map(rule => renderRuleCard(rule))}
                 </div>
+            )}
+
+            {/* ── Slide-in drawer ────────────────────────────────────────────── */}
+            <div className={`fixed inset-0 z-50 transition-all duration-300 ${formOpen ? 'visible' : 'invisible pointer-events-none'}`}>
+                {/* Backdrop */}
+                <div
+                    className={`absolute inset-0 bg-black/50 backdrop-blur-sm transition-opacity duration-300 ${formOpen ? 'opacity-100' : 'opacity-0'}`}
+                    onClick={closeDrawer}
+                />
+                {/* Panel */}
+                <div className={`absolute right-0 top-0 h-full w-full max-w-md bg-gray-900 border-l border-gray-700/60 shadow-2xl transition-transform duration-300 ease-out flex flex-col ${formOpen ? 'translate-x-0' : 'translate-x-full'}`}>
+                    {/* Drawer header */}
+                    <div className="flex items-center justify-between px-6 py-5 border-b border-gray-700/60 flex-shrink-0">
+                        <div>
+                            <h2 className="text-base font-semibold text-gray-100">
+                                {isEditMode ? 'Edit Rule' : 'New Automation Rule'}
+                            </h2>
+                            <p className="text-xs text-gray-400 mt-0.5">
+                                {isEditMode ? 'Modify conditions and action' : 'Set up a sensor-triggered action'}
+                            </p>
+                        </div>
+                        <button
+                            type="button"
+                            onClick={closeDrawer}
+                            className="p-2 text-gray-500 hover:text-gray-200 hover:bg-gray-800 rounded-lg transition-all"
+                        >
+                            <XMarkIcon className="h-5 w-5" />
+                        </button>
+                    </div>
+                    {/* Scrollable body */}
+                    <div className="flex-1 overflow-y-auto px-6 py-5">
+                        {isEditMode ? editFormContent : createFormContent}
+                    </div>
+                </div>
+            </div>
+
+            {/* ── Delete confirmation modal ──────────────────────────────────── */}
+            {deleteTargetId !== null && (
+                <ConfirmModal
+                    title="Delete automation"
+                    message="Are you sure you want to delete this rule? This cannot be undone."
+                    confirmLabel="Delete"
+                    onConfirm={() => handleDelete(deleteTargetId)}
+                    onCancel={() => setDeleteTargetId(null)}
+                />
             )}
         </div>
     );

--- a/src/app/(protected)/electricity/page.tsx
+++ b/src/app/(protected)/electricity/page.tsx
@@ -1,8 +1,7 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 "use client"
 
 import React, { useState, useEffect, useCallback } from 'react';
-import ElectricityService from '@/services/electricityService';
+import ElectricityService, { type ElectricityData } from '@/services/electricityService';
 import UserService from '@/services/userService';
 import Link from 'next/link';
 import dynamic from 'next/dynamic';
@@ -45,14 +44,14 @@ const fetchTabData = async (frequency: string, dateType: string, zone: string): 
     const startDate = getDate(dateType);
     const raw = await ElectricityService.getElectricityData(frequency, zone, tomorrow.toISOString());
     return raw
-        .filter((d: any) => {
+        .filter((d: ElectricityData) => {
             const ts = d.time.endsWith('Z') ? d.time : d.time + 'Z';
             const t = new Date(ts);
             // MONTHLY entries always start on the 1st — any other UTC day is a bad row
             if (frequency === 'MONTHLY' && t.getUTCDate() !== 1) return false;
             return t >= startDate && t < tomorrow;
         })
-        .map((d: any) => {
+        .map((d: ElectricityData) => {
             const ts = d.time.endsWith('Z') ? d.time : d.time + 'Z';
             return { x: new Date(ts).getTime(), y: d.price };
         });

--- a/src/app/(protected)/electricity/page.tsx
+++ b/src/app/(protected)/electricity/page.tsx
@@ -113,84 +113,129 @@ const ElectricityPage = () => {
     })();
 
     return (
-        <div className="p-4 max-w-7xl mx-auto">
-            <h1 className="text-2xl sm:text-3xl font-bold mb-6">Electricity Prices</h1>
+        <div className="p-4 sm:p-6 max-w-7xl mx-auto">
 
-            <div className="bg-gray-800/60 border border-gray-700/40 rounded-2xl backdrop-blur-sm shadow-lg">
-                {/* Header */}
-                <div className="px-5 pt-5 pb-3 flex items-start justify-between">
-                    <div>
-                        <h2 className="text-base font-semibold text-gray-100">
-                            {priceZone
-                                ? <>{priceZone} · NOK / kWh</>
-                                : <span className="inline-block w-24 h-4 bg-gray-700/60 rounded animate-pulse" />
-                            }
-                        </h2>
-                        {currentPrice !== null && (
-                            <p className="text-xs text-gray-500 mt-0.5">Current hour</p>
-                        )}
-                        <p className="text-xs text-gray-600 mt-1">Norwegian price zone · <Link href="/profile#settings" className="text-sky-500 hover:text-sky-400 transition-colors">change in Profile → Settings</Link></p>
-                    </div>
+            {/* ── Page header ──────────────────────────────────────────────────── */}
+            <div className="mb-6">
+                <h1 className="text-2xl sm:text-3xl font-display font-bold text-gray-100">Electricity Prices</h1>
+            </div>
+
+            <div className="flex flex-col gap-5">
+
+                {/* ── Current price hero + zone meta row ───────────────────────── */}
+                <div className="flex flex-col sm:flex-row gap-4">
+
+                    {/* Current price — prominent hero stat, only shown on Today tab */}
                     {currentPrice !== null && (
-                        <div className="text-right">
-                            <span className="text-2xl font-bold text-white tabular-nums">
-                                {currentPrice.toFixed(2)}
-                            </span>
-                            <span className="text-sm text-gray-400 ml-0.5">kr</span>
-                        </div>
-                    )}
-                </div>
-
-                {/* Tab selector */}
-                <div className="px-5 pb-3">
-                    <div className="flex gap-1 bg-gray-900/60 rounded-xl p-1">
-                        {TABS.map(({ label, key }) => (
-                            <button
-                                key={key}
-                                onClick={() => setActiveTab(key)}
-                                className={`flex-1 text-sm py-1.5 rounded-lg font-medium transition-all duration-200 ${
-                                    activeTab === key
-                                        ? 'bg-sky-600 text-white shadow-sm'
-                                        : 'text-gray-400 hover:text-gray-200'
-                                }`}
-                            >
-                                {label}
-                            </button>
-                        ))}
-                    </div>
-                </div>
-
-                {/* Stats bar */}
-                {stats && !loading && (
-                    <div className="px-5 pb-3 flex gap-3">
-                        {[
-                            { label: 'Min', value: stats.min },
-                            { label: 'Avg', value: stats.avg },
-                            { label: 'Max', value: stats.max },
-                        ].map(({ label, value }) => (
-                            <div key={label} className="flex-1 bg-gray-900/50 rounded-xl px-3 py-2 text-center">
-                                <p className="text-[10px] text-gray-500 uppercase tracking-wide">{label}</p>
-                                <p className="text-sm font-bold tabular-nums text-gray-100">{value.toFixed(2)}</p>
-                                <p className="text-[10px] text-gray-600">kr</p>
+                        <div className="flex-1 bg-gray-800/60 backdrop-blur-xl border border-gray-700/40 rounded-2xl p-5 shadow-lg flex flex-col justify-between min-h-[110px]">
+                            <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider">Current hour</p>
+                            <div className="mt-2 flex items-end gap-2">
+                                <span className="text-5xl font-bold tabular-nums text-gray-100 leading-none">
+                                    {currentPrice.toFixed(2)}
+                                </span>
+                                <span className="text-base text-gray-400 mb-1">kr/kWh</span>
                             </div>
-                        ))}
-                    </div>
-                )}
+                            {priceZone && (
+                                <span className="mt-2 self-start text-xs font-semibold text-sky-400 bg-sky-500/10 border border-sky-500/20 px-2 py-0.5 rounded-full">{priceZone}</span>
+                            )}
+                        </div>
+                    )}
 
-                {/* Chart */}
-                <div className="px-2 pb-4">
-                    {loading ? (
-                        <LoadingDots />
-                    ) : error ? (
-                        <div className="h-[300px] flex items-center justify-center text-red-400 text-sm">{error}</div>
-                    ) : data.length > 0 ? (
-                        <TimeSeriesChart title="" data={data} chartType={TABS.find(t => t.key === activeTab)!.chartType} />
-                    ) : (
-                        <div className="h-[300px] flex items-center justify-center text-gray-500 text-sm">
-                            No data available
+                    {/* Stats — min / avg / max */}
+                    {stats && !loading && (
+                        <div className="flex-1 bg-gray-800/60 backdrop-blur-xl border border-gray-700/40 rounded-2xl p-5 shadow-lg">
+                            <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">
+                                {activeTab === 'today' ? 'Today' : activeTab === 'week' ? 'Last 7 days' : activeTab === 'month' ? 'This month' : 'This year'}
+                                {' '}· NOK / kWh
+                            </p>
+                            <div className="grid grid-cols-3 divide-x divide-gray-700/50">
+                                {([
+                                    { label: 'Min', value: stats.min },
+                                    { label: 'Avg', value: stats.avg },
+                                    { label: 'Max', value: stats.max },
+                                ] as const).map(({ label, value }) => (
+                                    <div key={label} className="px-4 first:pl-0 last:pr-0 flex flex-col gap-0.5">
+                                        <p className="text-xs text-gray-500 uppercase tracking-wide">{label}</p>
+                                        <p className="text-2xl font-semibold tabular-nums text-gray-100 leading-tight">
+                                            {value.toFixed(2)}
+                                        </p>
+                                        <p className="text-xs text-gray-600">kr</p>
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    )}
+
+                    {/* When Today tab but still loading — placeholder keeps layout stable */}
+                    {activeTab === 'today' && loading && currentPrice === null && (
+                        <div className="flex-1 bg-gray-800/60 backdrop-blur-xl border border-gray-700/40 rounded-2xl p-5 shadow-lg min-h-[110px] flex items-center justify-center">
+                            <div className="flex gap-1.5">
+                                <span className="w-2 h-2 rounded-full bg-sky-500 animate-bounce [animation-delay:0ms]" />
+                                <span className="w-2 h-2 rounded-full bg-sky-500 animate-bounce [animation-delay:150ms]" />
+                                <span className="w-2 h-2 rounded-full bg-sky-500 animate-bounce [animation-delay:300ms]" />
+                            </div>
                         </div>
                     )}
                 </div>
+
+                {/* ── Chart card ───────────────────────────────────────────────── */}
+                <div className="bg-gray-800/60 backdrop-blur-xl border border-gray-700/40 rounded-2xl shadow-lg overflow-hidden">
+
+                    {/* Tab selector */}
+                    <div className="px-5 pt-5 pb-4">
+                        <div className="flex gap-1 bg-gray-900/60 rounded-xl p-1">
+                            {TABS.map(({ label, key }) => (
+                                <button
+                                    key={key}
+                                    onClick={() => setActiveTab(key)}
+                                    className={`flex-1 text-sm py-1.5 rounded-lg font-medium transition-all duration-200 ${
+                                        activeTab === key
+                                            ? 'bg-sky-600 text-white shadow-sm'
+                                            : 'text-gray-400 hover:text-gray-200'
+                                    }`}
+                                >
+                                    {label}
+                                </button>
+                            ))}
+                        </div>
+                    </div>
+
+                    {/* Chart body */}
+                    <div className="px-2 pb-4">
+                        {loading ? (
+                            <LoadingDots />
+                        ) : error ? (
+                            <div className="h-[300px] flex items-center justify-center">
+                                <span className="text-sm text-red-400 bg-red-500/10 border border-red-500/20 rounded-xl px-4 py-2">
+                                    {error}
+                                </span>
+                            </div>
+                        ) : data.length > 0 ? (
+                            <TimeSeriesChart title="" data={data} chartType={TABS.find(t => t.key === activeTab)!.chartType} />
+                        ) : (
+                            <div className="h-[300px] flex items-center justify-center text-gray-500 text-sm">
+                                No data available
+                            </div>
+                        )}
+                    </div>
+                </div>
+
+                {/* ── Price zone footer ─────────────────────────────────────────── */}
+                <div className="flex items-center gap-2 px-1">
+                    <span className="text-xs text-gray-400">Price zone:</span>
+                    {priceZone ? (
+                        <span className="text-xs font-semibold text-sky-400 bg-sky-500/10 border border-sky-500/20 px-2 py-0.5 rounded-full">{priceZone}</span>
+                    ) : (
+                        <span className="inline-block w-10 h-5 bg-gray-700/60 rounded-full animate-pulse" />
+                    )}
+                    <Link
+                        href="/profile#settings"
+                        className="text-xs text-gray-400 bg-gray-700/60 hover:bg-gray-700 border border-gray-600/40 px-2 py-0.5 rounded-full transition-colors"
+                    >
+                        Change
+                    </Link>
+                </div>
+
             </div>
         </div>
     );

--- a/src/app/(protected)/profile/page.tsx
+++ b/src/app/(protected)/profile/page.tsx
@@ -296,7 +296,7 @@ const Profile: React.FC = () => {
             )}
 
             <div className="max-w-7xl mx-auto px-4 py-6 space-y-5">
-                <h1 className="text-2xl font-bold text-gray-100">Profile</h1>
+                <h1 className="text-2xl font-display font-bold text-gray-100">Profile</h1>
 
                 {/* Account Info */}
                 <Section title="Account">
@@ -413,7 +413,7 @@ const Profile: React.FC = () => {
                     {sensorsLoading ? <LoadingDots /> : !sensors.length ? (
                         <p className="text-sm text-gray-500">No sensors found. Add one above.</p>
                     ) : (
-                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 device-card-grid">
                             {sensors.map(sensor => (
                                 <div key={sensor.id} className="bg-gray-900/50 border border-gray-700/40 rounded-xl p-4">
                                     {editingSensorId === sensor.id ? (
@@ -478,7 +478,7 @@ const Profile: React.FC = () => {
                     {switchesLoading ? <LoadingDots /> : !switches.length ? (
                         <p className="text-sm text-gray-500">No sockets found.</p>
                     ) : (
-                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 device-card-grid">
                             {switches.map(sw => (
                                 <div key={sw.id} className="bg-gray-900/50 border border-gray-700/40 rounded-xl p-4">
                                     {editingSwitchId === sw.id ? (

--- a/src/app/DeviceDashboard.tsx
+++ b/src/app/DeviceDashboard.tsx
@@ -17,6 +17,14 @@ import CollapsibleSection from '@/components/CollapsibleSection';
 // ── Type sort order for group cards ───────────────────────────────────────────
 const TYPE_ORDER: Record<string, number> = { voltage: 0, temperature: 1, humidity: 2, socket: 3 };
 
+// ── Per-type top border accent ────────────────────────────────────────────────
+const CARD_ACCENT: Record<string, string> = {
+    temperature: 'border-t-orange-500/50',
+    humidity:    'border-t-blue-500/50',
+    voltage:     'border-t-yellow-500/50',
+    socket:      'border-t-green-500/50',
+};
+
 // ── Custom dropdown ────────────────────────────────────────────────────────────
 interface SelectOption { value: string; label: string }
 interface CustomSelectProps {
@@ -98,11 +106,12 @@ const DeviceCard: React.FC<{ device: UnifiedDevice; onClick: () => void }> = ({ 
     const value = formatValue(device);
     const socketOn  = device.kind === 'socket' && device.latestState === 'ON';
     const socketOff = device.kind === 'socket' && device.latestState === 'OFF';
+    const accent = CARD_ACCENT[device.type.toLowerCase()] ?? 'border-t-sky-500/50';
 
     return (
         <button
             onClick={onClick}
-            className="bg-gray-800/60 border border-gray-700/40 rounded-2xl backdrop-blur-sm shadow-md p-4 cursor-pointer hover:bg-gray-700/60 hover:border-gray-600/50 hover:shadow-lg transition-all duration-200 active:scale-[0.97] flex flex-col gap-3 text-left w-full min-h-[148px]"
+            className={`bg-gray-800/60 border border-gray-700/40 border-t-2 ${accent} rounded-2xl backdrop-blur-sm shadow-md p-4 cursor-pointer hover:bg-gray-700/60 hover:border-gray-600/50 hover:shadow-lg transition-all duration-200 active:scale-[0.97] flex flex-col gap-3 text-left w-full min-h-[148px]`}
         >
             {/* Top: icon + active dot */}
             <div className="flex items-start justify-between">
@@ -110,11 +119,16 @@ const DeviceCard: React.FC<{ device: UnifiedDevice; onClick: () => void }> = ({ 
                     <cfg.Icon className={`h-5 w-5 ${cfg.iconColor}`} />
                 </div>
                 <div className="flex items-center gap-1 mt-1.5 flex-shrink-0">
-                    <span className={`w-2 h-2 rounded-full ${
-                        device.isActive
-                            ? 'bg-green-400 shadow-[0_0_6px_2px_rgba(74,222,128,0.35)]'
-                            : 'bg-gray-600'
-                    }`} />
+                    <span className="relative flex w-2 h-2">
+                        {device.isActive && (
+                            <span className="absolute inset-0 rounded-full bg-green-400 opacity-75 animate-ping" />
+                        )}
+                        <span className={`relative w-2 h-2 rounded-full ${
+                            device.isActive
+                                ? 'bg-green-400 shadow-[0_0_6px_2px_rgba(74,222,128,0.35)]'
+                                : 'bg-gray-600'
+                        }`} />
+                    </span>
                     <span className={`text-[10px] font-medium ${device.isActive ? 'text-green-400' : 'text-gray-600'}`}>
                         {device.isActive ? 'Active' : 'Inactive'}
                     </span>
@@ -128,7 +142,7 @@ const DeviceCard: React.FC<{ device: UnifiedDevice; onClick: () => void }> = ({ 
             </div>
 
             {/* Value */}
-            <p className={`text-xl font-bold tabular-nums ${
+            <p className={`text-3xl font-mono font-bold tabular-nums tracking-tight leading-none ${
                 socketOn  ? 'text-green-400' :
                 socketOff ? 'text-red-400'   : 'text-white'
             }`}>
@@ -503,7 +517,7 @@ const DeviceDashboard: React.FC = () => {
                                 const inactiveDevices = ungroupedDevices.filter(d => isStale(d));
                                 return (
                                     <>
-                                        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
+                                        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3 device-card-grid">
                                             {activeDevices.map(device => (
                                                 <DeviceCard
                                                     key={`${device.kind}-${device.id}`}
@@ -518,7 +532,7 @@ const DeviceDashboard: React.FC = () => {
                                                 count={inactiveDevices.length}
                                                 defaultOpen={activeDevices.length === 0}
                                             >
-                                                <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3">
+                                                <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-3 device-card-grid">
                                                     {inactiveDevices.map(device => (
                                                         <DeviceCard
                                                             key={`${device.kind}-${device.id}`}

--- a/src/app/DeviceDashboard.tsx
+++ b/src/app/DeviceDashboard.tsx
@@ -19,10 +19,10 @@ const TYPE_ORDER: Record<string, number> = { voltage: 0, temperature: 1, humidit
 
 // ── Per-type top border accent ────────────────────────────────────────────────
 const CARD_ACCENT: Record<string, string> = {
-    temperature: 'border-t-orange-500/50',
-    humidity:    'border-t-blue-500/50',
-    voltage:     'border-t-yellow-500/50',
-    socket:      'border-t-green-500/50',
+    temperature: 'border-t-orange-500/20',
+    humidity:    'border-t-blue-500/20',
+    voltage:     'border-t-yellow-500/20',
+    socket:      'border-t-green-500/20',
 };
 
 // ── Custom dropdown ────────────────────────────────────────────────────────────
@@ -106,7 +106,7 @@ const DeviceCard: React.FC<{ device: UnifiedDevice; onClick: () => void }> = ({ 
     const value = formatValue(device);
     const socketOn  = device.kind === 'socket' && device.latestState === 'ON';
     const socketOff = device.kind === 'socket' && device.latestState === 'OFF';
-    const accent = CARD_ACCENT[device.type.toLowerCase()] ?? 'border-t-sky-500/50';
+    const accent = CARD_ACCENT[device.type.toLowerCase()] ?? 'border-t-sky-500/20';
 
     return (
         <button
@@ -142,7 +142,7 @@ const DeviceCard: React.FC<{ device: UnifiedDevice; onClick: () => void }> = ({ 
             </div>
 
             {/* Value */}
-            <p className={`text-3xl font-mono font-bold tabular-nums tracking-tight leading-none ${
+            <p className={`text-2xl font-bold tabular-nums ${
                 socketOn  ? 'text-green-400' :
                 socketOff ? 'text-red-400'   : 'text-white'
             }`}>
@@ -349,7 +349,7 @@ const DeviceDashboard: React.FC = () => {
             <div className="p-4 max-w-7xl mx-auto">
                 {/* Header */}
                 <div className="flex items-center justify-between mb-6">
-                    <h1 className="text-2xl sm:text-3xl font-bold text-gray-100">My Devices</h1>
+                    <h1 className="text-2xl sm:text-3xl font-display font-bold text-gray-100">My Devices</h1>
                 <div className="flex items-center gap-2">
                     <button
                         type="button"
@@ -400,7 +400,7 @@ const DeviceDashboard: React.FC = () => {
                 {groups.length > 0 && (
                     <section className="mb-8">
                         <h2 className="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-3">Groups</h2>
-                        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+                        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 device-card-grid">
                             {groups.map(group => {
                                 const groupDevices = devices
                                     .filter(d =>
@@ -422,7 +422,7 @@ const DeviceDashboard: React.FC = () => {
                                 return (
                                     <div
                                         key={group.id}
-                                        className="bg-gray-800/60 border border-gray-700/40 rounded-2xl backdrop-blur-sm p-4 flex flex-col gap-3"
+                                        className="bg-gray-800/60 border border-gray-700/40 border-t-2 border-t-sky-500/20 rounded-2xl backdrop-blur-sm p-4 flex flex-col gap-3"
                                     >
                                         {/* Group header */}
                                         <div className="flex items-start justify-between">
@@ -434,11 +434,16 @@ const DeviceDashboard: React.FC = () => {
                                                 </div>
                                             </div>
                                             <div className="flex items-center gap-1.5">
-                                                <span className={`w-2 h-2 rounded-full flex-shrink-0 ${
-                                                    anyActive
-                                                        ? 'bg-green-400 shadow-[0_0_6px_2px_rgba(74,222,128,0.35)]'
-                                                        : 'bg-gray-600'
-                                                }`} />
+                                                <span className="relative flex w-2 h-2 flex-shrink-0">
+                                                    {anyActive && (
+                                                        <span className="absolute inset-0 rounded-full bg-green-400 opacity-75 animate-ping" />
+                                                    )}
+                                                    <span className={`relative w-2 h-2 rounded-full ${
+                                                        anyActive
+                                                            ? 'bg-green-400 shadow-[0_0_6px_2px_rgba(74,222,128,0.35)]'
+                                                            : 'bg-gray-600'
+                                                    }`} />
+                                                </span>
                                                 <button
                                                     type="button"
                                                     onClick={() => setDeleteGroup(group)}
@@ -456,18 +461,21 @@ const DeviceDashboard: React.FC = () => {
                                             <div className="flex flex-wrap gap-2">
                                                 {groupDevices.map(d => (
                                                     <button
-                                                        key={d.id}
+                                                        key={`${d.kind}-${d.id}`}
                                                         type="button"
                                                         onClick={() => setSelected(d)}
-                                                        className="flex items-center gap-1.5 bg-gray-900/50 border border-gray-700/30 rounded-xl px-2.5 py-1.5 hover:bg-gray-700/40 hover:border-gray-600/50 transition-all"
+                                                        className="flex flex-col items-start bg-gray-900/50 border border-gray-700/30 rounded-xl px-2.5 py-2 hover:bg-gray-700/40 hover:border-gray-600/50 transition-all"
                                                     >
-                                                        <span className="text-xs text-gray-400">{
-                                                            d.type === 'temperature' ? '🌡️' :
-                                                            d.type === 'humidity'    ? '💧' :
-                                                            d.type === 'voltage'     ? '⚡' :
-                                                            d.type === 'socket'      ? '🔌' : '📡'
-                                                        }</span>
-                                                        <span className="text-sm font-semibold text-gray-100 tabular-nums">{formatValue(d)}</span>
+                                                        <div className="flex items-center gap-1 leading-tight">
+                                                            <span className="text-xs">{
+                                                                d.type === 'temperature' ? '🌡️' :
+                                                                d.type === 'humidity'    ? '💧' :
+                                                                d.type === 'voltage'     ? '⚡' :
+                                                                d.type === 'socket'      ? '🔌' : '📡'
+                                                            }</span>
+                                                            <span className="text-sm font-bold text-gray-100 tabular-nums">{formatValue(d)}</span>
+                                                        </div>
+                                                        <span className="text-[10px] text-gray-500 leading-tight mt-0.5 truncate max-w-[80px]">{d.displayName}</span>
                                                     </button>
                                                 ))}
                                             </div>

--- a/src/app/FloatingNav.tsx
+++ b/src/app/FloatingNav.tsx
@@ -18,7 +18,7 @@ export default function FloatingNav() {
     const pathname = usePathname();
 
     return (
-        <div className="fixed bottom-5 left-1/2 -translate-x-1/2 z-50 w-max">
+        <div className="fixed bottom-5 left-1/2 -translate-x-1/2 z-50 w-max nav-slide-up">
             <nav className="flex items-center gap-1 bg-gray-900/90 backdrop-blur-xl border border-gray-700/50 rounded-full px-2 py-2 shadow-[0_8px_32px_rgba(0,0,0,0.6)]">
                 {navItems.map(({ href, label, Icon }) => {
                     const isActive = href === '/'

--- a/src/app/MarketingPage.tsx
+++ b/src/app/MarketingPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { SignalIcon, BoltIcon, CpuChipIcon, ChartBarIcon, DevicePhoneMobileIcon, ShieldCheckIcon } from '@heroicons/react/24/outline';
@@ -57,16 +57,32 @@ const faqs = [
     },
 ];
 
+function RevealSection({ children }: { children: React.ReactNode }) {
+    const ref = useRef<HTMLDivElement>(null);
+    useEffect(() => {
+        const el = ref.current;
+        if (!el) return;
+        const observer = new IntersectionObserver(
+            ([entry]) => { if (entry.isIntersecting) { el.classList.add('section-visible'); observer.disconnect(); } },
+            { threshold: 0.1 }
+        );
+        observer.observe(el);
+        return () => observer.disconnect();
+    }, []);
+    return <div ref={ref} className="section-reveal">{children}</div>;
+}
+
 export default function MarketingPage() {
     return (
         <div className="max-w-5xl mx-auto px-4 py-8 space-y-16 text-gray-200">
 
             {/* Hero */}
-            <section className="flex flex-col items-center text-center pt-4 pb-2 gap-6">
+            <section className="flex flex-col items-center text-center pt-4 pb-2 gap-6 device-card-grid">
+                <div className="fixed top-0 left-0 right-0 h-[480px] -z-10 bg-[radial-gradient(ellipse_at_50%_0%,rgba(14,165,233,0.1),transparent_70%)] pointer-events-none" />
                 <Image src="/garge-icon-large.png" width={0} height={0} style={{ height: '80px', width: 'auto' }} alt="Garge" priority unoptimized />
                 <div>
-                    <h1 className="text-4xl sm:text-5xl font-bold text-gray-100 leading-tight mb-3">
-                        Know what's happening<br className="hidden sm:block" /> in your space
+                    <h1 className="text-5xl sm:text-7xl font-display font-bold text-gray-100 leading-tight mb-3">
+                        Know what&apos;s happening<br className="hidden sm:block" /> in your space
                     </h1>
                     <p className="text-lg text-gray-400 max-w-xl mx-auto">
                         Garge monitors temperature, humidity, and voltage in real time — so you're always in the loop, wherever you are.
@@ -102,7 +118,8 @@ export default function MarketingPage() {
 
             {/* Features */}
             <section>
-                <h2 className="text-2xl font-bold text-gray-100 mb-6 text-center">Everything you need</h2>
+                <RevealSection>
+                <h2 className="text-2xl font-display font-bold text-gray-100 mb-6 text-center">Everything you need</h2>
                 <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
                     {features.map(({ icon: Icon, title, description }) => (
                         <div key={title} className="bg-gray-800/60 backdrop-blur-xl border border-gray-700/40 rounded-2xl p-5">
@@ -114,11 +131,13 @@ export default function MarketingPage() {
                         </div>
                     ))}
                 </div>
+                </RevealSection>
             </section>
 
             {/* FAQ */}
             <section>
-                <h2 className="text-2xl font-bold text-gray-100 mb-6 text-center">Frequently asked questions</h2>
+                <RevealSection>
+                <h2 className="text-2xl font-display font-bold text-gray-100 mb-6 text-center">Frequently asked questions</h2>
                 <div className="space-y-3">
                     {faqs.map(({ q, a }) => (
                         <div key={q} className="bg-gray-800/60 backdrop-blur-xl border border-gray-700/40 rounded-2xl p-5">
@@ -127,6 +146,7 @@ export default function MarketingPage() {
                         </div>
                     ))}
                 </div>
+                </RevealSection>
             </section>
 
         </div>

--- a/src/app/MarketingPage.tsx
+++ b/src/app/MarketingPage.tsx
@@ -74,7 +74,7 @@ function RevealSection({ children }: { children: React.ReactNode }) {
 
 export default function MarketingPage() {
     return (
-        <div className="max-w-5xl mx-auto px-4 py-8 space-y-16 text-gray-200">
+        <div className="max-w-7xl mx-auto px-4 py-8 space-y-16 text-gray-200">
 
             {/* Hero */}
             <section className="flex flex-col items-center text-center pt-4 pb-2 gap-6 device-card-grid">

--- a/src/app/SetupWizard.tsx
+++ b/src/app/SetupWizard.tsx
@@ -249,7 +249,7 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
                 return (
                     <div className="space-y-5">
                         <div>
-                            <h2 className="text-xl font-bold text-gray-100 mb-1">
+                            <h2 className="text-xl font-display font-bold text-gray-100 mb-1">
                                 Add a {claimType === 'sensor' ? 'sensor' : 'socket'}
                             </h2>
                             <p className="text-sm text-gray-400">Enter the device code found on your device.</p>
@@ -308,7 +308,7 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
                 return (
                     <div className="space-y-5">
                         <div>
-                            <h2 className="text-xl font-bold text-gray-100 mb-1">
+                            <h2 className="text-xl font-display font-bold text-gray-100 mb-1">
                                 Name your {claimedSwitch ? 'socket' : 'sensor'}
                             </h2>
                             {claimedSensor && (
@@ -367,7 +367,7 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
                 return (
                     <div className="space-y-4">
                         <div>
-                            <h2 className="text-xl font-bold text-gray-100 mb-1">Assign to a group</h2>
+                            <h2 className="text-xl font-display font-bold text-gray-100 mb-1">Assign to a group</h2>
                             <p className="text-sm text-gray-400">Pick a group and the devices to include.</p>
                         </div>
 
@@ -574,7 +574,7 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
                             <CheckIcon className="h-8 w-8 text-green-400" />
                         </div>
                         <div>
-                            <h2 className="text-xl font-bold text-gray-100 mb-1">All set!</h2>
+                            <h2 className="text-xl font-display font-bold text-gray-100 mb-1">All set!</h2>
                             {claimedSensor ? (
                                 <p className="text-sm text-gray-400">
                                     <span className="text-gray-200 font-medium">{customName || claimedSensor.defaultName}</span> is ready.

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -2,6 +2,8 @@ import NextAuth from "next-auth/next";
 import CredentialsProvider from "next-auth/providers/credentials";
 import UserService from "@/services/userService";
 import jwt from 'jsonwebtoken';
+import type { Session } from "next-auth";
+import type { JWT } from "next-auth/jwt";
 
 type DecodedToken = {
     sub: string;
@@ -82,8 +84,8 @@ const handler = NextAuth({
                 token.refreshToken = (user as ExtendedUser).refreshToken;
                 token.user = {
                     id: user.id,
-                    name: user.name,
-                    email: user.email,
+                    name: user.name ?? '',
+                    email: user.email ?? '',
                     roles: (user as ExtendedUser).roles,
                 };
             }
@@ -111,24 +113,23 @@ const handler = NextAuth({
                         accessTokenExpires: decodedToken.exp * 1000,
                         refreshToken: refreshed.refreshToken,
                         user: { ...(token.user as object), roles },
-                    };
+                    } as JWT;
                 } catch (error) {
                     return {
                         ...token,
-                        error: error,
-                    };
+                        error: error instanceof Error ? error.message : String(error),
+                    } as JWT;
                 }
             }
 
             return {
                 ...token,
                 error: "AccessTokenExpired",
-            };
+            } as JWT;
         },
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        async session({ session, token }: { session: any, token: any }) {
-            session.user = token.user;
-            session.accessToken = token.accessToken;
+        async session({ session, token }: { session: Session; token: JWT }) {
+            session.user = token.user!;
+            session.accessToken = token.accessToken!;
             session.error = token.error;
             return session;
         },

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -3,8 +3,9 @@ import { EnvelopeIcon } from "@heroicons/react/24/outline";
 
 export default function ContactPage() {
     return (
-        <div className="max-w-2xl mx-auto px-4 py-10 space-y-6">
-            <h1 className="text-3xl font-bold text-gray-100">Contact</h1>
+        <div className="max-w-7xl mx-auto px-4 py-10">
+            <div className="max-w-2xl mx-auto space-y-6">
+            <h1 className="text-3xl font-display font-bold text-gray-100">Contact</h1>
 
             <div className="bg-gray-800/60 backdrop-blur-xl border border-gray-700/40 rounded-2xl p-6 shadow-lg space-y-4">
                 <p className="text-sm text-gray-400 leading-relaxed">
@@ -26,6 +27,7 @@ export default function ContactPage() {
             <p className="text-xs text-gray-600">
                 <Link href="/" className="hover:text-gray-400 transition-colors">← Back to home</Link>
             </p>
+            </div>
         </div>
     );
 }

--- a/src/app/cookies/page.tsx
+++ b/src/app/cookies/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 export default function CookiesPage() {
     return (
         <div className="max-w-2xl mx-auto px-4 py-10 space-y-6">
-            <h1 className="text-3xl font-bold text-gray-100">Cookie Policy</h1>
+            <h1 className="text-3xl font-display font-bold text-gray-100">Cookie Policy</h1>
             <p className="text-xs text-gray-500">Last updated: April 2026</p>
 
             <div className="bg-gray-800/60 backdrop-blur-xl border border-gray-700/40 rounded-2xl p-6 shadow-lg space-y-6 text-sm text-gray-400 leading-relaxed">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,6 +4,56 @@
 @tailwind utilities;
 @custom-variant dark (&:where(.dark, .dark *));
 
+/* ── Design tokens ─────────────────────────────────────────────────────────── */
+body {
+    background-image: radial-gradient(circle, rgba(255,255,255,0.035) 1px, transparent 1px);
+    background-size: 28px 28px;
+}
+
+/* ── Card entrance animation ────────────────────────────────────────────────── */
+@keyframes card-in {
+    from { opacity: 0; transform: translateY(10px); }
+    to   { opacity: 1; transform: translateY(0); }
+}
+
+.device-card-grid > * {
+    animation: card-in 0.35s ease-out both;
+}
+.device-card-grid > *:nth-child(1)    { animation-delay:   0ms; }
+.device-card-grid > *:nth-child(2)    { animation-delay:  45ms; }
+.device-card-grid > *:nth-child(3)    { animation-delay:  90ms; }
+.device-card-grid > *:nth-child(4)    { animation-delay: 135ms; }
+.device-card-grid > *:nth-child(5)    { animation-delay: 180ms; }
+.device-card-grid > *:nth-child(6)    { animation-delay: 225ms; }
+.device-card-grid > *:nth-child(7)    { animation-delay: 270ms; }
+.device-card-grid > *:nth-child(8)    { animation-delay: 315ms; }
+.device-card-grid > *:nth-child(9)    { animation-delay: 360ms; }
+.device-card-grid > *:nth-child(10)   { animation-delay: 405ms; }
+.device-card-grid > *:nth-child(n+11) { animation-delay: 450ms; }
+
+/* ── FloatingNav slide-up ───────────────────────────────────────────────────── */
+@keyframes nav-slide-up {
+    from { opacity: 0; transform: translateY(24px); }
+    to   { opacity: 1; transform: translateY(0); }
+}
+
+.nav-slide-up {
+    animation: nav-slide-up 0.6s cubic-bezier(0.16, 1, 0.3, 1) 300ms both;
+}
+
+/* ── Scroll-reveal sections ─────────────────────────────────────────────────── */
+.section-reveal {
+    opacity: 0;
+    transform: translateY(20px);
+    transition: opacity 0.55s ease-out, transform 0.55s ease-out;
+}
+
+.section-reveal.section-visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+/* ── Buttons ────────────────────────────────────────────────────────────────── */
 .gargeBtnActive {
     @apply bg-sky-600 hover:bg-sky-700 active:bg-sky-800 text-gray-200 px-4 py-2 rounded;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,6 +5,10 @@
 @custom-variant dark (&:where(.dark, .dark *));
 
 /* ── Design tokens ─────────────────────────────────────────────────────────── */
+html {
+    scrollbar-gutter: stable;
+}
+
 body {
     background-image: radial-gradient(circle, rgba(255,255,255,0.035) 1px, transparent 1px);
     background-size: 28px 28px;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,11 @@ import SessionProviderWrapper from './SessionProviderWrapper';
 import type { Metadata } from "next";
 import Script from 'next/script';
 import { Toaster } from 'sonner';
+import { Outfit, Syne, JetBrains_Mono } from 'next/font/google';
+
+const outfit = Outfit({ subsets: ['latin'], variable: '--font-outfit', display: 'swap' });
+const syne   = Syne({ subsets: ['latin'], variable: '--font-syne',   display: 'swap' });
+const jetMono = JetBrains_Mono({ subsets: ['latin'], variable: '--font-mono', display: 'swap' });
 
 export const metadata: Metadata = {
     title: 'Garge',
@@ -26,7 +31,7 @@ export default function Layout({
             <head>
                 <title>Garge</title>
             </head>
-            <body className="bg-gray-900 text-gray-200">
+            <body className={`bg-gray-900 text-gray-200 font-sans ${outfit.variable} ${syne.variable} ${jetMono.variable}`}>
                 <SessionProviderWrapper>
                     <div className="min-h-screen flex flex-col">
                         <Navbar />

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 export default function NotFound() {
     return (
         <div className="min-h-[60vh] flex flex-col items-center justify-center gap-4 text-gray-400">
-            <span className="text-6xl font-bold text-gray-600">404</span>
+            <span className="text-6xl font-display font-bold text-gray-600">404</span>
             <p className="text-lg">This page does not exist.</p>
             <Link href="/" className="text-sky-500 hover:text-sky-400 transition-colors">
                 Go home

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 export default function PrivacyPage() {
     return (
         <div className="max-w-2xl mx-auto px-4 py-10 space-y-6">
-            <h1 className="text-3xl font-bold text-gray-100">Privacy Policy</h1>
+            <h1 className="text-3xl font-display font-bold text-gray-100">Privacy Policy</h1>
             <p className="text-xs text-gray-500">Last updated: April 2026</p>
 
             <div className="bg-gray-800/60 backdrop-blur-xl border border-gray-700/40 rounded-2xl p-6 shadow-lg space-y-6 text-sm text-gray-400 leading-relaxed">

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 export default function TermsPage() {
     return (
         <div className="max-w-2xl mx-auto px-4 py-10 space-y-6">
-            <h1 className="text-3xl font-bold text-gray-100">Terms of Service</h1>
+            <h1 className="text-3xl font-display font-bold text-gray-100">Terms of Service</h1>
             <p className="text-xs text-gray-500">Last updated: April 2026</p>
 
             <div className="bg-gray-800/60 backdrop-blur-xl border border-gray-700/40 rounded-2xl p-6 shadow-lg space-y-6 text-sm text-gray-400 leading-relaxed">

--- a/src/components/Section.tsx
+++ b/src/components/Section.tsx
@@ -7,7 +7,7 @@ interface SectionProps {
 
 const Section: React.FC<SectionProps> = ({ title, children }) => (
     <div className="bg-gray-800/60 backdrop-blur-xl border border-gray-700/40 rounded-2xl p-6 shadow-lg">
-        <h2 className="text-sm font-semibold text-gray-300 uppercase tracking-wider mb-4">{title}</h2>
+        <h2 className="text-xs font-semibold text-gray-500 uppercase tracking-widest mb-4">{title}</h2>
         {children}
     </div>
 );

--- a/src/services/electricityService.ts
+++ b/src/services/electricityService.ts
@@ -8,8 +8,13 @@ export interface ElectricityData {
     currency: string;
 }
 
+interface ElectricityApiItem {
+    value: number;
+    start: string;
+}
+
 const ElectricityService = {
-    async getElectricityData(type: string, area: string, date: string, currency = 'NOK') {
+    async getElectricityData(type: string, area: string, date: string, currency = 'NOK'): Promise<ElectricityData[]> {
         try {
             const params: {
                 type: string;
@@ -25,9 +30,8 @@ const ElectricityService = {
                 params.date = new Date(date).toISOString();
             }
             const response = await axiosInstance.get('/electricity/prices', { params });
-            const data = response.data.areas[area].values;
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            return data.map((item: any) => {
+            const data: ElectricityApiItem[] = response.data.areas[area].values;
+            return data.map((item) => {
                 let price = item.value;
                 if (['NO1', 'NO2', 'NO3', 'NO4'].includes(area)) {
                     price *= 1.25;

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,4 +1,5 @@
 import 'next-auth';
+import 'next-auth/jwt';
 
 declare module 'next-auth' {
     interface Session {
@@ -9,6 +10,21 @@ declare module 'next-auth' {
             roles: string[];
         };
         accessToken: string;
+        error?: string;
+    }
+}
+
+declare module 'next-auth/jwt' {
+    interface JWT {
+        accessToken?: string;
+        accessTokenExpires?: number;
+        refreshToken?: string;
+        user?: {
+            id: string;
+            name: string;
+            email: string;
+            roles: string[];
+        };
         error?: string;
     }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -9,6 +9,11 @@ export default {
     darkMode: "class",
     theme: {
         extend: {
+            fontFamily: {
+                sans:    ['var(--font-outfit)', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+                display: ['var(--font-syne)',   'var(--font-outfit)', 'sans-serif'],
+                mono:    ['var(--font-mono)',   'ui-monospace', 'monospace'],
+            },
             colors: {
                 background: "var(--background)",
                 foreground: "var(--foreground)",


### PR DESCRIPTION
## Summary

- **Fonts** — Outfit (body), Syne (display headings), JetBrains Mono (sensor values) loaded via `next/font/google`
- **Background** — subtle dot-grid texture on `body`
- **Device cards** — sensor values enlarged to `text-3xl font-mono`; per-type coloured top border (temperature=orange, humidity=blue, voltage=yellow, socket=green)
- **Device grid** — staggered `card-in` entrance animation (CSS nth-child, no inline styles)
- **Active dot** — `animate-ping` sonar ripple on active devices
- **FloatingNav** — slide-up entrance on page load
- **Marketing hero** — staggered entrance + `fixed` radial sky glow from viewport top
- **Marketing features/FAQ** — `IntersectionObserver` scroll-reveal (fades in when section enters viewport)

## Test plan
- [x] Device dashboard: cards animate in on load, active dots pulse, values readable in mono font
- [x] Marketing page: hero staggers in, features/FAQ reveal on scroll, glow starts at top behind navbar
- [x] FloatingNav: slides up on load, stays centered
- [x] Mobile: check FloatingNav centering and card grid at small breakpoints