### PR TITLE
fix: replace native datetime-local input with DatePicker and fix dark theme time list

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -116,3 +116,20 @@ body {
 .dark .react-datepicker__triangle {
     display: none;
 }
+.dark .react-datepicker__time-container {
+    border-left-color: #374151;
+}
+.dark .react-datepicker__time-container .react-datepicker__time {
+    background-color: #1f2937;
+}
+.dark .react-datepicker__time-container .react-datepicker__time-list-item {
+    color: #e5e7eb;
+}
+.dark .react-datepicker__time-container .react-datepicker__time-list-item:hover {
+    background-color: #374151 !important;
+    color: #f9fafb;
+}
+.dark .react-datepicker__time-container .react-datepicker__time-list-item--selected {
+    background-color: #0284c7 !important;
+    color: #fff !important;
+}

--- a/src/components/ActivitiesSection.tsx
+++ b/src/components/ActivitiesSection.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { PencilIcon, TrashIcon, CheckIcon, XMarkIcon, PlusIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
 import LoadingDots from '@/components/LoadingDots';
 import ConfirmModal from '@/components/ConfirmModal';
+import DatePicker from '@/components/DatePicker';
 import SensorActivityService, { SensorActivity } from '@/services/sensorActivityService';
 import { formatDateTime } from '@/lib/dateUtils';
 
@@ -190,10 +191,10 @@ const ActivitiesSection: React.FC<ActivitiesSectionProps> = ({ sensorId }) => {
                         placeholder="Notes (optional)"
                         className="w-full bg-gray-900/60 border border-gray-700/60 rounded-lg px-2.5 py-1.5 text-sm text-gray-100 placeholder-gray-600 focus:outline-none focus:border-sky-500/60 resize-none"
                     />
-                    <input
-                        type="datetime-local"
+                    <DatePicker
+                        showTime
                         value={activityDate}
-                        onChange={(e) => setActivityDate(e.target.value)}
+                        onChange={setActivityDate}
                         className="w-full bg-gray-900/60 border border-gray-700/60 rounded-lg px-2.5 py-1.5 text-sm text-gray-100 focus:outline-none focus:border-sky-500/60"
                     />
 

--- a/src/components/DatePicker.tsx
+++ b/src/components/DatePicker.tsx
@@ -9,20 +9,24 @@ registerLocale('nb', nb)
 
 interface DatePickerProps {
     id?: string
-    value: string        // YYYY-MM-DD
+    value: string        // YYYY-MM-DD or YYYY-MM-DDTHH:MM when showTime=true
     onChange: (value: string) => void
     className?: string
+    showTime?: boolean
 }
 
-export default function DatePicker({ id, value, onChange, className }: DatePickerProps) {
+export default function DatePicker({ id, value, onChange, className, showTime = false }: DatePickerProps) {
     const selected = value ? new Date(value) : null
 
     const handleChange = (date: Date | null) => {
-        if (date) {
-            // Keep internal state as YYYY-MM-DD string (same as native input)
-            const yyyy = date.getFullYear()
-            const mm = String(date.getMonth() + 1).padStart(2, '0')
-            const dd = String(date.getDate()).padStart(2, '0')
+        if (!date) return
+        const pad = (n: number) => String(n).padStart(2, '0')
+        const yyyy = date.getFullYear()
+        const mm = pad(date.getMonth() + 1)
+        const dd = pad(date.getDate())
+        if (showTime) {
+            onChange(`${yyyy}-${mm}-${dd}T${pad(date.getHours())}:${pad(date.getMinutes())}`)
+        } else {
             onChange(`${yyyy}-${mm}-${dd}`)
         }
     }
@@ -31,7 +35,10 @@ export default function DatePicker({ id, value, onChange, className }: DatePicke
         <ReactDatePicker
             id={id}
             locale="nb"
-            dateFormat="dd.MM.yyyy"
+            dateFormat={showTime ? 'dd.MM.yyyy HH:mm' : 'dd.MM.yyyy'}
+            timeFormat="HH:mm"
+            showTimeSelect={showTime}
+            timeIntervals={15}
             selected={selected}
             onChange={handleChange}
             wrapperClassName="w-full"


### PR DESCRIPTION
## Summary
- Add `showTime` prop to `DatePicker` component to support datetime selection
- Replace native `datetime-local` input in `ActivitiesSection` with `DatePicker`
- Add missing dark theme CSS for react-datepicker time list (background, text color, hover, selected states)

## Test plan
- [x] Open activity form in DeviceDrawer — date+time picker renders correctly
- [x] Time list items are visible in dark theme (not white on white)
- [x] Selecting a time updates the activity date correctly
- [x] Date-only `DatePicker` usage still works as before