### PR TITLE
feat: persist device sort/filter and remove automations subtitle

### DIFF
--- a/src/app/(protected)/automations/page.tsx
+++ b/src/app/(protected)/automations/page.tsx
@@ -678,7 +678,7 @@ const AutomationsPage: React.FC = () => {
             <div className="flex items-center justify-between mb-6">
                 <div>
                     <h1 className="text-2xl sm:text-3xl font-display font-bold text-white">Automations</h1>
-                    <p className="text-gray-400 text-sm mt-0.5">Rules that control your garage automatically</p>
+
                 </div>
                 <button
                     onClick={openCreateDrawer}

--- a/src/app/DeviceDashboard.tsx
+++ b/src/app/DeviceDashboard.tsx
@@ -12,6 +12,7 @@ import DeviceDrawer from './DeviceDrawer';
 import SetupWizard from './SetupWizard';
 import ConfirmModal from '@/components/ConfirmModal';
 import { groupEmoji } from '@/lib/groupIcons';
+import { useLocalStorage } from '@/lib/useLocalStorage';
 import CollapsibleSection from '@/components/CollapsibleSection';
 
 // ── Type sort order for group cards ───────────────────────────────────────────
@@ -166,8 +167,8 @@ const DeviceDashboard: React.FC = () => {
     const [groups, setGroups]         = useState<Group[]>([]);
     const [loading, setLoading]       = useState(true);
     const [search, setSearch]         = useState('');
-    const [sort, setSort]             = useState<SortKey>('name-asc');
-    const [typeFilter, setTypeFilter] = useState<string>('all');
+    const [sort, setSort]             = useLocalStorage<SortKey>('device-sort', 'name-asc');
+    const [typeFilter, setTypeFilter] = useLocalStorage<string>('device-type-filter', 'all');
     const [selected, setSelected]     = useState<UnifiedDevice | null>(null);
     const [wizardOpen, setWizardOpen]   = useState(false);
     const [wizardStep, setWizardStep]   = useState(0);

--- a/src/lib/useLocalStorage.ts
+++ b/src/lib/useLocalStorage.ts
@@ -1,0 +1,20 @@
+import { useCallback, useState } from 'react';
+
+export function useLocalStorage<T>(key: string, defaultValue: T): [T, (value: T) => void] {
+    const [stored, setStored] = useState<T>(() => {
+        if (typeof window === 'undefined') return defaultValue;
+        try {
+            const item = localStorage.getItem(key);
+            return item !== null ? (JSON.parse(item) as T) : defaultValue;
+        } catch {
+            return defaultValue;
+        }
+    });
+
+    const setValue = useCallback((value: T) => {
+        setStored(value);
+        localStorage.setItem(key, JSON.stringify(value));
+    }, [key]);
+
+    return [stored, setValue];
+}

--- a/src/tests/lib/useLocalStorage.test.ts
+++ b/src/tests/lib/useLocalStorage.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useLocalStorage } from '@/lib/useLocalStorage'
+
+beforeEach(() => localStorage.clear())
+
+describe('useLocalStorage', () => {
+    it('returns default value when key absent', () => {
+        const { result } = renderHook(() => useLocalStorage('key', 'default'))
+        expect(result.current[0]).toBe('default')
+    })
+
+    it('reads existing value from localStorage', () => {
+        localStorage.setItem('key', JSON.stringify('saved'))
+        const { result } = renderHook(() => useLocalStorage('key', 'default'))
+        expect(result.current[0]).toBe('saved')
+    })
+
+    it('updates state and persists to localStorage', () => {
+        const { result } = renderHook(() => useLocalStorage('key', 'default'))
+        act(() => result.current[1]('updated'))
+        expect(result.current[0]).toBe('updated')
+        expect(JSON.parse(localStorage.getItem('key')!)).toBe('updated')
+    })
+
+    it('falls back to default on corrupt localStorage value', () => {
+        localStorage.setItem('key', 'not-json{{{')
+        const { result } = renderHook(() => useLocalStorage('key', 'fallback'))
+        expect(result.current[0]).toBe('fallback')
+    })
+
+    it('works with non-string types', () => {
+        const { result } = renderHook(() => useLocalStorage<number>('num', 0))
+        act(() => result.current[1](42))
+        expect(result.current[0]).toBe(42)
+        expect(JSON.parse(localStorage.getItem('num')!)).toBe(42)
+    })
+})


### PR DESCRIPTION
## Summary
- Add `useLocalStorage<T>` hook (`src/lib/useLocalStorage.ts`) — SSR-safe, works like `useState` but syncs with `localStorage`
- Device dashboard `sort` and `typeFilter` now persist across page refreshes
- Remove redundant subtitle from automations page

## Test plan
- [x] Unit tests for `useLocalStorage` — 5 cases covering default value, existing value, updates, corrupt data, non-string types