### PR TITLE
feat: UX improvements across dashboard, automations, admin, and profile

### DIFF
--- a/src/app/(protected)/admin/page.tsx
+++ b/src/app/(protected)/admin/page.tsx
@@ -41,6 +41,7 @@ export default function AdminPage() {
     const [roleLoading, setRoleLoading] = useState(false);
 
     const [deleteTarget, setDeleteTarget] = useState<AdminUser | null>(null);
+    const [loadedAt, setLoadedAt] = useState<Date | null>(null);
 
     const [userSearch, setUserSearch] = useState('');
     const [userPage, setUserPage] = useState(0);
@@ -58,6 +59,7 @@ export default function AdminPage() {
             setStats(s);
             setUsers(u);
             setHistory(h);
+            setLoadedAt(new Date());
         } catch {
             setError('Failed to load admin data');
         } finally {
@@ -127,7 +129,7 @@ export default function AdminPage() {
                             {([
                                 { label: 'Users', value: stats?.totalUsers, key: 'totalUsers' as StatKey },
                                 { label: 'Sensors', value: stats?.totalSensors, key: 'totalSensors' as StatKey },
-                                { label: 'Switches', value: stats?.totalSwitches, key: 'totalSwitches' as StatKey },
+                                { label: 'Sockets', value: stats?.totalSwitches, key: 'totalSwitches' as StatKey },
                                 { label: 'Active automations', value: stats?.activeAutomations, key: 'totalAutomations' as StatKey },
                             ]).map(({ label, value, key }) => {
                                 const isSelected = selectedStat === key;
@@ -154,7 +156,7 @@ export default function AdminPage() {
                                     title={{
                                         totalUsers: 'Users over time',
                                         totalSensors: 'Sensors over time',
-                                        totalSwitches: 'Switches over time',
+                                        totalSwitches: 'Sockets over time',
                                         totalAutomations: 'Automations over time',
                                     }[selectedStat]}
                                     data={history.map(s => ({
@@ -166,6 +168,30 @@ export default function AdminPage() {
                                 />
                             </div>
                         )}
+                    </Section>
+
+                    {/* System Health */}
+                    <Section title="System Health">
+                        <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+                            <div className="bg-gray-900/50 border border-gray-700/40 rounded-xl p-4 col-span-2 sm:col-span-1">
+                                <div className="flex items-center gap-2 mb-2">
+                                    <span className="relative flex w-2 h-2">
+                                        <span className="absolute inset-0 rounded-full bg-green-400 opacity-75 animate-ping" />
+                                        <span className="relative w-2 h-2 rounded-full bg-green-400 shadow-[0_0_6px_2px_rgba(74,222,128,0.35)]" />
+                                    </span>
+                                    <span className="text-xs text-gray-500 uppercase tracking-widest font-semibold">API</span>
+                                </div>
+                                <p className="text-sm font-semibold text-green-400">Operational</p>
+                            </div>
+                            <div className="bg-gray-900/50 border border-gray-700/40 rounded-xl p-4">
+                                <p className="text-2xl font-bold text-gray-100 tabular-nums">{(stats?.totalSensors ?? 0) + (stats?.totalSwitches ?? 0)}</p>
+                                <p className="text-xs text-gray-500 mt-1">Total devices</p>
+                            </div>
+                            <div className="bg-gray-900/50 border border-gray-700/40 rounded-xl p-4">
+                                <p className="text-xs text-gray-500 mb-1">Last refreshed</p>
+                                <p className="text-sm font-medium text-gray-300">{loadedAt ? loadedAt.toLocaleTimeString() : '—'}</p>
+                            </div>
+                        </div>
                     </Section>
 
                     {/* Users */}

--- a/src/app/(protected)/automations/page.tsx
+++ b/src/app/(protected)/automations/page.tsx
@@ -74,6 +74,17 @@ const formatTimerRemaining = (activatedAt: string, durationHours: number): strin
     return h > 0 ? `${h}h ${m}m remaining` : `${m}m remaining`;
 };
 
+const checkCondition = (value: number, condition: string, threshold: number): boolean => {
+    switch (condition) {
+        case '==': return value === threshold;
+        case '<':  return value < threshold;
+        case '>':  return value > threshold;
+        case '<=': return value <= threshold;
+        case '>=': return value >= threshold;
+        default:   return false;
+    }
+};
+
 // ── Shared field components ───────────────────────────────────────────────────
 
 const FieldLabel: React.FC<{ children: React.ReactNode }> = ({ children }) => (
@@ -93,7 +104,7 @@ const NumberInput: React.FC<React.InputHTMLAttributes<HTMLInputElement>> = ({ cl
     <input
         type="number"
         className={`block w-full px-3 py-2.5 bg-gray-800 border border-gray-600/60 rounded-lg text-gray-200 text-sm focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/30 transition-all ${className}`}
-        onFocus={e => { e.currentTarget.select(); onFocus?.(e); }}
+        onFocus={e => { const el = e.currentTarget; setTimeout(() => el.select(), 0); onFocus?.(e); }}
         {...props}
     />
 );
@@ -215,11 +226,30 @@ const AutomationsPage: React.FC = () => {
     const [sensors, setSensors]               = useState<Sensor[]>([]);
     const [defaultPriceArea, setDefaultPriceArea] = useState<string>('NO2');
     const [deleteTargetId, setDeleteTargetId]     = useState<number | null>(null);
+    const [latestValueMap, setLatestValueMap] = useState<Record<number, number>>({});
 
     useEffect(() => {
         Promise.all([fetchRules(), fetchSwitches(), fetchSensors(), fetchUserPriceZone()])
             .finally(() => setLoading(false));
     }, []);
+
+    useEffect(() => {
+        if (sensors.length === 0) return;
+        const ids = sensors.map(s => s.id);
+        SensorService.getMultipleSensorsData(ids, undefined, undefined, '1d', '30m', 1, 5000)
+            .then(resp => {
+                const tsMap: Record<number, { value: number; ts: number }> = {};
+                for (const d of resp.data) {
+                    const ts = new Date(d.timestamp).getTime();
+                    const ex = tsMap[d.sensorId];
+                    if (!ex || ts > ex.ts) tsMap[d.sensorId] = { value: Number(d.value), ts };
+                }
+                const map: Record<number, number> = {};
+                for (const [id, { value }] of Object.entries(tsMap)) map[Number(id)] = value;
+                setLatestValueMap(map);
+            })
+            .catch(() => {});
+    }, [sensors]);
 
     const sortedSwitches = [...switches].sort((a, b) =>
         (a.customName ?? a.name ?? '').toLowerCase().localeCompare((b.customName ?? b.name ?? '').toLowerCase())
@@ -355,7 +385,7 @@ const AutomationsPage: React.FC = () => {
             <div>
                 <FieldLabel>Target socket</FieldLabel>
                 <Select value={form.targetId} required onChange={e => handleTargetChange(Number(e.target.value))}>
-                    <option value={0}>Select a switch or socket</option>
+                    <option value={0}>Select a socket</option>
                     {sortedSwitches.map(sw => <option key={sw.id} value={sw.id}>{sw.customName ?? sw.name}</option>)}
                 </Select>
             </div>
@@ -379,6 +409,16 @@ const AutomationsPage: React.FC = () => {
                         onChange={e => setForm({ ...form, threshold: Number(e.target.value) })} />
                 </div>
             </div>
+            {form.sensorId > 0 && latestValueMap[form.sensorId] !== undefined && (() => {
+                const current = latestValueMap[form.sensorId];
+                const met = checkCondition(current, form.condition, form.threshold);
+                return (
+                    <div className={`flex items-center gap-2 px-3 py-2 rounded-lg border text-xs font-medium ${met ? 'bg-amber-500/10 border-amber-500/20 text-amber-400' : 'bg-gray-800/50 border-gray-700/30 text-gray-500'}`}>
+                        <BoltIcon className="h-3.5 w-3.5 flex-shrink-0" />
+                        {met ? `Would trigger now — current value: ${current}${createUnit ? ` ${createUnit}` : ''}` : `Would not trigger — current value: ${current}${createUnit ? ` ${createUnit}` : ''}`}
+                    </div>
+                );
+            })()}
             <div>
                 <FieldLabel>Action</FieldLabel>
                 <Select value={form.action} required onChange={e => setForm({ ...form, action: e.target.value })}>
@@ -433,7 +473,7 @@ const AutomationsPage: React.FC = () => {
                     const id = Number(e.target.value);
                     setEditForm({ ...editForm, targetId: id, targetType: switches.find(sw => sw.id === id)?.type || '' });
                 }}>
-                    <option value={0}>Select a switch or socket</option>
+                    <option value={0}>Select a socket</option>
                     {sortedSwitches.map(sw => <option key={sw.id} value={sw.id}>{sw.customName ?? sw.name}</option>)}
                 </Select>
             </div>
@@ -460,6 +500,16 @@ const AutomationsPage: React.FC = () => {
                         onChange={e => setEditForm({ ...editForm, threshold: Number(e.target.value) })} />
                 </div>
             </div>
+            {editForm.sensorId > 0 && latestValueMap[editForm.sensorId] !== undefined && (() => {
+                const current = latestValueMap[editForm.sensorId];
+                const met = checkCondition(current, editForm.condition, editForm.threshold);
+                return (
+                    <div className={`flex items-center gap-2 px-3 py-2 rounded-lg border text-xs font-medium ${met ? 'bg-amber-500/10 border-amber-500/20 text-amber-400' : 'bg-gray-800/50 border-gray-700/30 text-gray-500'}`}>
+                        <BoltIcon className="h-3.5 w-3.5 flex-shrink-0" />
+                        {met ? `Would trigger now — current value: ${current}${editUnit ? ` ${editUnit}` : ''}` : `Would not trigger — current value: ${current}${editUnit ? ` ${editUnit}` : ''}`}
+                    </div>
+                );
+            })()}
             <div>
                 <FieldLabel>Action</FieldLabel>
                 <Select value={editForm.action} required onChange={e => setEditForm({ ...editForm, action: e.target.value })}>
@@ -534,7 +584,7 @@ const AutomationsPage: React.FC = () => {
             </p>
             <div className="w-full space-y-2.5 mb-8 text-left">
                 {[
-                    { step: '1', title: 'Choose a switch', desc: 'Pick which socket or relay to control' },
+                    { step: '1', title: 'Choose a socket', desc: 'Pick which socket to control' },
                     { step: '2', title: 'Set a trigger',   desc: 'Select a sensor and the condition that fires the rule' },
                     { step: '3', title: 'Define the action', desc: 'Turn the switch on or off when conditions are met' },
                 ].map(item => (
@@ -570,7 +620,7 @@ const AutomationsPage: React.FC = () => {
         const priceSym   = rule.electricityPriceCondition
             ? (conditionSymbol[rule.electricityPriceCondition] ?? rule.electricityPriceCondition)
             : null;
-        const switchName = switchObj ? (switchObj.customName ?? switchObj.name) : `Switch ${rule.targetId}`;
+        const switchName = switchObj ? (switchObj.customName ?? switchObj.name) : `Socket ${rule.targetId}`;
         const sensorName = sensorObj?.customName ?? sensorObj?.defaultName ?? `Sensor ${rule.sensorId}`;
         const isOn       = rule.action === 'on';
 
@@ -736,6 +786,7 @@ const AutomationsPage: React.FC = () => {
                         <button
                             type="button"
                             onClick={closeDrawer}
+                            aria-label="Close"
                             className="p-2 text-gray-500 hover:text-gray-200 hover:bg-gray-800 rounded-lg transition-all"
                         >
                             <XMarkIcon className="h-5 w-5" />

--- a/src/app/(protected)/profile/page.tsx
+++ b/src/app/(protected)/profile/page.tsx
@@ -7,7 +7,7 @@ import UserService from '@/services/userService';
 import { UserDTO } from '@/dto/UserDTO';
 import SensorService, { Sensor } from '@/services/sensorService';
 import SwitchService, { Switch } from '@/services/switchService';
-import { PencilIcon, CheckIcon, XMarkIcon, TrashIcon } from '@heroicons/react/24/outline';
+import { PencilIcon, CheckIcon, XMarkIcon, TrashIcon, ClipboardDocumentIcon } from '@heroicons/react/24/outline';
 import ConfirmModal from '@/components/ConfirmModal';
 import LoadingDots from '@/components/LoadingDots';
 import Section from '@/components/Section';
@@ -261,6 +261,10 @@ const Profile: React.FC = () => {
         }
     };
 
+    const copyToClipboard = (text: string) => {
+        navigator.clipboard.writeText(text).then(() => toast.success('Copied')).catch(() => toast.error('Failed to copy'));
+    };
+
     const confirmSensor = sensors.find(s => s.id === confirmDeleteId);
     const confirmSwitch = switches.find(sw => sw.id === confirmDeleteSwitchId);
     const isUserLoading = status === 'loading' || !user;
@@ -454,7 +458,18 @@ const Profile: React.FC = () => {
                                             </div>
                                             <div className="space-y-0.5 mb-4">
                                                 <p className="text-xs text-gray-400">Type: {sensor.type}</p>
-                                        <p className="text-xs text-gray-500">Device code: {sensor.registrationCode}</p>
+                                        <div className="flex items-center gap-1.5">
+                                            <p className="text-xs text-gray-500">Device code: <span className="font-mono">{sensor.registrationCode}</span></p>
+                                            {sensor.registrationCode && (
+                                                <button
+                                                    onClick={() => copyToClipboard(sensor.registrationCode)}
+                                                    aria-label="Copy device code"
+                                                    className="p-0.5 rounded text-gray-600 hover:text-gray-400 transition-colors flex-shrink-0"
+                                                >
+                                                    <ClipboardDocumentIcon className="h-3.5 w-3.5" />
+                                                </button>
+                                            )}
+                                        </div>
                                                 {sensor.customName && <p className="text-xs text-gray-500">Default: {sensor.defaultName}</p>}
                                             </div>
                                             <button
@@ -519,7 +534,18 @@ const Profile: React.FC = () => {
                                             </div>
                                             <div className="space-y-0.5 mb-4">
                                                 <p className="text-xs text-gray-400">Type: {sw.type}</p>
-                                                {sw.registrationCode && <p className="text-xs text-gray-500">Device code: {sw.registrationCode}</p>}
+                                                {sw.registrationCode && (
+                                                    <div className="flex items-center gap-1.5">
+                                                        <p className="text-xs text-gray-500">Device code: <span className="font-mono">{sw.registrationCode}</span></p>
+                                                        <button
+                                                            onClick={() => copyToClipboard(sw.registrationCode!)}
+                                                            aria-label="Copy device code"
+                                                            className="p-0.5 rounded text-gray-600 hover:text-gray-400 transition-colors flex-shrink-0"
+                                                        >
+                                                            <ClipboardDocumentIcon className="h-3.5 w-3.5" />
+                                                        </button>
+                                                    </div>
+                                                )}
                                                 {sw.customName && <p className="text-xs text-gray-500">Default: {sw.name}</p>}
                                             </div>
                                             <button

--- a/src/app/DeviceDashboard.tsx
+++ b/src/app/DeviceDashboard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { MagnifyingGlassIcon, ChevronDownIcon, PlusIcon, PencilIcon, TrashIcon } from '@heroicons/react/24/outline';
+import { MagnifyingGlassIcon, ChevronDownIcon, PlusIcon, PencilIcon, TrashIcon, XMarkIcon, SignalIcon } from '@heroicons/react/24/outline';
 import { TYPE_CONFIG, DEFAULT_TYPE } from '@/lib/typeConfig';
 import { formatSensorValue } from '@/lib/typeUtils';
 import LoadingDots from '@/components/LoadingDots';
@@ -394,6 +394,17 @@ const DeviceDashboard: React.FC = () => {
                             options={SORT_OPTIONS}
                             onChange={v => setSort(v as SortKey)}
                         />
+                        {(typeFilter !== 'all' || search.trim()) && (
+                            <button
+                                type="button"
+                                onClick={() => { setSearch(''); setTypeFilter('all'); }}
+                                aria-label="Clear filters"
+                                className="flex items-center gap-1 px-2.5 py-2 bg-gray-700/40 hover:bg-gray-700/60 border border-gray-600/30 rounded-xl text-xs text-gray-400 hover:text-gray-200 transition-all whitespace-nowrap"
+                            >
+                                <XMarkIcon className="h-3.5 w-3.5" />
+                                Clear
+                            </button>
+                        )}
                     </div>
                 </div>
 
@@ -448,6 +459,7 @@ const DeviceDashboard: React.FC = () => {
                                                 <button
                                                     type="button"
                                                     onClick={() => setDeleteGroup(group)}
+                                                    aria-label="Delete group"
                                                     className="p-1 rounded-lg text-gray-600 hover:text-red-400 hover:bg-red-500/10 transition-colors"
                                                 >
                                                     <TrashIcon className="h-3.5 w-3.5" />
@@ -500,14 +512,42 @@ const DeviceDashboard: React.FC = () => {
 
                 {/* Ungrouped devices */}
                 {devices.length === 0 ? (
-                    <div className="mt-16 text-center text-gray-400 space-y-3">
-                        <p className="text-base">No devices added yet.</p>
+                    <div className="mt-12 max-w-sm mx-auto">
+                        <div className="flex flex-col items-center text-center mb-8">
+                            <div className="relative mb-6 mx-auto w-20">
+                                <div className="w-20 h-20 rounded-2xl bg-gray-800/80 border border-gray-700/60 flex items-center justify-center">
+                                    <SignalIcon className="h-9 w-9 text-sky-500/70" />
+                                </div>
+                                <div className="absolute -top-1.5 -right-1.5 w-6 h-6 rounded-full bg-sky-600/30 border border-sky-500/50 flex items-center justify-center">
+                                    <PlusIcon className="h-3 w-3 text-sky-400" />
+                                </div>
+                            </div>
+                            <h2 className="text-xl font-display font-semibold text-gray-100 mb-2">No devices yet</h2>
+                            <p className="text-sm text-gray-400 leading-relaxed">Get started by adding a sensor or socket.</p>
+                        </div>
+                        <div className="space-y-2.5 mb-8">
+                            {[
+                                { step: '1', title: 'Add a device', desc: 'Enter the device code from your sensor or socket' },
+                                { step: '2', title: 'Organize into groups', desc: 'Group devices by vehicle or location' },
+                                { step: '3', title: 'Set up automations', desc: 'Automatically control sockets based on sensor readings' },
+                            ].map(item => (
+                                <div key={item.step} className="flex items-start gap-3 p-3 bg-gray-800/40 border border-gray-700/30 rounded-xl">
+                                    <span className="flex-shrink-0 w-6 h-6 rounded-full bg-sky-600/20 border border-sky-500/30 text-sky-400 text-xs font-bold flex items-center justify-center mt-0.5">
+                                        {item.step}
+                                    </span>
+                                    <div>
+                                        <p className="text-sm font-medium text-gray-200">{item.title}</p>
+                                        <p className="text-xs text-gray-500 mt-0.5">{item.desc}</p>
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
                         <button
                             type="button"
-                            onClick={() => setWizardOpen(true)}
-                            className="inline-flex items-center gap-2 text-sm text-sky-400 hover:text-sky-300 transition-colors"
+                            onClick={() => { setWizardStep(0); setWizardOpen(true); }}
+                            className="w-full flex items-center justify-center gap-2 px-6 py-3 bg-sky-600 hover:bg-sky-500 active:bg-sky-700 text-white font-semibold rounded-xl transition-all shadow-lg shadow-sky-900/30"
                         >
-                            <PlusIcon className="h-4 w-4" />
+                            <PlusIcon className="h-5 w-5" />
                             Add your first device
                         </button>
                     </div>

--- a/src/app/DeviceDrawer.tsx
+++ b/src/app/DeviceDrawer.tsx
@@ -298,6 +298,7 @@ const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose }) => {
                                 <button
                                     onClick={handleSaveName}
                                     disabled={savingName}
+                                    aria-label="Save name"
                                     className="p-1 rounded-lg text-sky-400 hover:text-sky-300 hover:bg-sky-500/10 transition-colors flex-shrink-0"
                                 >
                                     <CheckIcon className="h-4 w-4" />
@@ -309,6 +310,7 @@ const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose }) => {
                                 {(device.kind === 'socket' || device.kind === 'sensor') && (
                                     <button
                                         onClick={() => { setEditName(device.displayName); setEditingName(true); }}
+                                        aria-label="Rename"
                                         className="p-0.5 rounded text-gray-600 hover:text-gray-400 transition-colors flex-shrink-0"
                                     >
                                         <PencilIcon className="h-3.5 w-3.5" />
@@ -320,6 +322,7 @@ const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose }) => {
                     </div>
                     <button
                         onClick={handleClose}
+                        aria-label="Close"
                         className="flex-shrink-0 p-1.5 rounded-xl text-gray-400 hover:text-gray-200 hover:bg-gray-800/60 transition-all"
                     >
                         <XMarkIcon className="h-5 w-5" />

--- a/src/app/SetupWizard.tsx
+++ b/src/app/SetupWizard.tsx
@@ -616,6 +616,7 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
                 <button
                     type="button"
                     onClick={onClose}
+                    aria-label="Close"
                     className="absolute top-4 right-4 p-1.5 rounded-xl text-gray-500 hover:text-gray-300 hover:bg-gray-800/60 transition-colors z-10"
                 >
                     <XMarkIcon className="h-5 w-5" />


### PR DESCRIPTION
## Summary

- **Dashboard**: rich empty-state onboarding (SignalIcon + 3-step guide + CTA), clear filters pill, aria-labels on icon buttons
- **Automations**: dry-run preview in create/edit drawer shows live sensor value vs threshold, Switch -> Socket terminology, number input auto-selects on focus
- **Admin**: system health card (API status, total devices, last refreshed), Switches -> Sockets in stat labels
- **Profile**: copy-to-clipboard button on sensor and socket registration codes
- **DeviceDrawer + SetupWizard**: aria-labels on all icon-only buttons