### PR TITLE
feat: add Brevo email stats section to admin page

### DIFF
--- a/src/app/(protected)/admin/page.tsx
+++ b/src/app/(protected)/admin/page.tsx
@@ -11,7 +11,7 @@ import ConfirmModal from '@/components/ConfirmModal';
 import { toast } from 'sonner';
 
 const TimeSeriesChart = dynamic(() => import('@/components/TimeSeriesChart'), { ssr: false });
-import AdminService, { AdminStats, AdminUser, StatSnapshot } from '@/services/adminService';
+import AdminService, { AdminStats, AdminUser, StatSnapshot, EmailStats } from '@/services/adminService';
 
 type StatKey = 'totalUsers' | 'totalSensors' | 'totalSwitches' | 'totalAutomations';
 
@@ -40,6 +40,10 @@ export default function AdminPage() {
     const [selectedRole, setSelectedRole] = useState('');
     const [roleLoading, setRoleLoading] = useState(false);
 
+    const [emailStats, setEmailStats] = useState<EmailStats | null>(null);
+    const [emailStatsDays, setEmailStatsDays] = useState(30);
+    const [emailStatsLoading, setEmailStatsLoading] = useState(false);
+
     const [deleteTarget, setDeleteTarget] = useState<AdminUser | null>(null);
     const [loadedAt, setLoadedAt] = useState<Date | null>(null);
 
@@ -66,6 +70,22 @@ export default function AdminPage() {
             setLoading(false);
         }
     }, []);
+
+    const loadEmailStats = useCallback(async (days: number) => {
+        setEmailStatsLoading(true);
+        try {
+            const es = await AdminService.getEmailStats(days);
+            setEmailStats(es);
+        } catch {
+            toast.error('Failed to load email stats');
+        } finally {
+            setEmailStatsLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        if (isAdmin) loadEmailStats(emailStatsDays);
+    }, [isAdmin, loadEmailStats, emailStatsDays]);
 
     useEffect(() => {
         if (isAdmin) load();
@@ -189,9 +209,53 @@ export default function AdminPage() {
                             </div>
                             <div className="bg-gray-900/50 border border-gray-700/40 rounded-xl p-4">
                                 <p className="text-xs text-gray-500 mb-1">Last refreshed</p>
-                                <p className="text-sm font-medium text-gray-300">{loadedAt ? loadedAt.toLocaleTimeString() : '—'}</p>
+                                <p className="text-sm font-medium text-gray-300">{loadedAt ? loadedAt.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false }) : '—'}</p>
                             </div>
                         </div>
+                    </Section>
+
+                    {/* Email Stats */}
+                    <Section title="Email (Brevo)">
+                        <div className="flex items-center justify-between mb-3">
+                            <p className="text-xs text-gray-500">Transactional email stats</p>
+                            <div className="flex gap-1">
+                                {([7, 30, 90] as const).map(d => (
+                                    <button
+                                        key={d}
+                                        onClick={() => setEmailStatsDays(d)}
+                                        className={`px-2.5 py-1 text-xs rounded-lg transition-colors ${
+                                            emailStatsDays === d
+                                                ? 'bg-sky-600 text-white'
+                                                : 'bg-gray-700/60 text-gray-400 hover:bg-gray-700 hover:text-gray-200'
+                                        }`}
+                                    >
+                                        {d}d
+                                    </button>
+                                ))}
+                            </div>
+                        </div>
+                        {emailStatsLoading ? (
+                            <LoadingDots height="h-16" />
+                        ) : emailStats ? (
+                            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                                {([
+                                    { label: 'Sent', value: emailStats.requests },
+                                    { label: 'Delivered', value: emailStats.delivered },
+                                    { label: 'Hard bounces', value: emailStats.hardBounces },
+                                    { label: 'Soft bounces', value: emailStats.softBounces },
+                                    { label: 'Blocked', value: emailStats.blocked },
+                                    { label: 'Spam reports', value: emailStats.spamReports },
+                                    { label: 'Invalid', value: emailStats.invalid },
+                                ]).map(({ label, value }) => (
+                                    <div key={label} className="bg-gray-900/50 border border-gray-700/40 rounded-xl p-4">
+                                        <p className="text-2xl font-bold tabular-nums text-gray-100">{value}</p>
+                                        <p className="text-xs text-gray-500 mt-1">{label}</p>
+                                    </div>
+                                ))}
+                            </div>
+                        ) : (
+                            <p className="text-xs text-gray-500">No data.</p>
+                        )}
                     </Section>
 
                     {/* Users */}

--- a/src/services/adminService.ts
+++ b/src/services/adminService.ts
@@ -32,6 +32,17 @@ export interface DiscoveredDevice {
     timestamp: string;
 }
 
+export interface EmailStats {
+    requests: number;
+    delivered: number;
+    hardBounces: number;
+    softBounces: number;
+    spamReports: number;
+    blocked: number;
+    invalid: number;
+    days: number;
+}
+
 const AdminService = {
     async getStats(): Promise<AdminStats> {
         const res = await axiosInstance.get<AdminStats>('/admin/stats');
@@ -70,6 +81,11 @@ const AdminService = {
         const res = await axiosInstance.get<StatSnapshot[] | { $values: StatSnapshot[] }>('/admin/stats/history');
         const data = res.data;
         return '$values' in data ? data.$values : data;
+    },
+
+    async getEmailStats(days = 30): Promise<EmailStats> {
+        const res = await axiosInstance.get<EmailStats>('/admin/email-stats', { params: { days } });
+        return res.data;
     },
 };
 

--- a/src/tests/services/adminService.test.ts
+++ b/src/tests/services/adminService.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import AdminService, { EmailStats } from '@/services/adminService'
+
+vi.mock('@/services/axiosInstance', () => ({
+    default: {
+        get: vi.fn(),
+        post: vi.fn(),
+        delete: vi.fn(),
+    },
+}))
+
+import axiosInstance from '@/services/axiosInstance'
+
+const mockGet = axiosInstance.get as ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+    vi.clearAllMocks()
+})
+
+describe('AdminService.getEmailStats', () => {
+    const mockEmailStats: EmailStats = {
+        requests: 100,
+        delivered: 95,
+        hardBounces: 2,
+        softBounces: 1,
+        spamReports: 0,
+        blocked: 1,
+        invalid: 1,
+        days: 30,
+    }
+
+    it('returns email stats from API', async () => {
+        mockGet.mockResolvedValueOnce({ data: mockEmailStats })
+        const result = await AdminService.getEmailStats()
+        expect(result).toEqual(mockEmailStats)
+    })
+
+    it('calls correct endpoint with default days=30', async () => {
+        mockGet.mockResolvedValueOnce({ data: mockEmailStats })
+        await AdminService.getEmailStats()
+        expect(mockGet).toHaveBeenCalledWith('/admin/email-stats', { params: { days: 30 } })
+    })
+
+    it('passes custom days param', async () => {
+        mockGet.mockResolvedValueOnce({ data: { ...mockEmailStats, days: 7 } })
+        await AdminService.getEmailStats(7)
+        expect(mockGet).toHaveBeenCalledWith('/admin/email-stats', { params: { days: 7 } })
+    })
+
+    it('passes 90 days param', async () => {
+        mockGet.mockResolvedValueOnce({ data: { ...mockEmailStats, days: 90 } })
+        await AdminService.getEmailStats(90)
+        expect(mockGet).toHaveBeenCalledWith('/admin/email-stats', { params: { days: 90 } })
+    })
+})


### PR DESCRIPTION
## Summary
- Adds Email (Brevo) section to admin page with sent, delivered, hard/soft bounces, blocked, spam, and invalid counts
- 7d / 30d / 90d time range toggle
- Fixes Last refreshed to show 24h format
- Unit tests for `AdminService.getEmailStats`

> Requires garge-api PR with `GET /api/admin/email-stats` endpoint merged first