### PR TITLE
feat: PWA push notifications

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,1 +1,21 @@
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', (event) => event.waitUntil(self.clients.claim()));
 self.addEventListener('fetch', () => { });
+
+self.addEventListener('push', (event) => {
+    let data = {};
+    try { data = event.data?.json() ?? {}; } catch { data = { title: 'Garge', body: event.data?.text() ?? '' }; }
+    event.waitUntil(
+        self.registration.showNotification(data.title ?? 'Garge', {
+            body: data.body ?? '',
+            icon: '/icon-512x512.png',
+            badge: '/garge-icon-small.png',
+            tag: 'garge-offline-alert',
+        })
+    );
+});
+
+self.addEventListener('notificationclick', (event) => {
+    event.notification.close();
+    event.waitUntil(clients.openWindow('/'));
+});

--- a/src/app/(protected)/profile/page.tsx
+++ b/src/app/(protected)/profile/page.tsx
@@ -7,7 +7,8 @@ import UserService from '@/services/userService';
 import { UserDTO } from '@/dto/UserDTO';
 import SensorService, { Sensor } from '@/services/sensorService';
 import SwitchService, { Switch } from '@/services/switchService';
-import { PencilIcon, CheckIcon, XMarkIcon, TrashIcon, ClipboardDocumentIcon } from '@heroicons/react/24/outline';
+import { PencilIcon, CheckIcon, XMarkIcon, TrashIcon, ClipboardDocumentIcon, BellIcon, BellSlashIcon } from '@heroicons/react/24/outline';
+import { isPushSupported, isPushSubscribed, subscribeToPush, unsubscribeFromPush, sendTestNotification } from '@/services/pushNotificationService';
 import ConfirmModal from '@/components/ConfirmModal';
 import LoadingDots from '@/components/LoadingDots';
 import Section from '@/components/Section';
@@ -52,6 +53,12 @@ const Profile: React.FC = () => {
     const [showDeleteAccount, setShowDeleteAccount] = useState(false);
     const [deleteAccountLoading, setDeleteAccountLoading] = useState(false);
     const [exportLoading, setExportLoading] = useState(false);
+    const [pushEnabled, setPushEnabled] = useState(false);
+    const [pushLoading, setPushLoading] = useState(false);
+    const [pushPermission, setPushPermission] = useState<NotificationPermission>('default');
+    const [offlineThreshold, setOfflineThreshold] = useState(4);
+    const [thresholdSaving, setThresholdSaving] = useState(false);
+    const [testNotifLoading, setTestNotifLoading] = useState(false);
 
     function sortSensorsByName(sensors: Sensor[]): Sensor[] {
         return [...sensors].sort((a, b) =>
@@ -74,7 +81,16 @@ const Profile: React.FC = () => {
 
     useEffect(() => {
         if (!isAuthenticated) { router.push('/login'); return; }
-        UserService.getUserProfile().then(u => { setUser(u); setPriceZone(u.priceZone ?? 'NO2'); }).catch(console.error).finally(() => setProfileLoading(false));
+        UserService.getUserProfile().then(u => {
+            setUser(u);
+            setPriceZone(u.priceZone ?? 'NO2');
+            setPushEnabled(u.pushNotificationsEnabled ?? false);
+            setOfflineThreshold(u.offlineAlertThresholdHours > 0 ? u.offlineAlertThresholdHours : 4);
+        }).catch(console.error).finally(() => setProfileLoading(false));
+        if (isPushSupported()) {
+            setPushPermission(Notification.permission);
+            isPushSubscribed().then(subscribed => setPushEnabled(prev => prev && subscribed)).catch(() => {});
+        }
         setSensorsLoading(true);
         refreshSensors().catch(console.error).finally(() => setSensorsLoading(false));
         setSwitchesLoading(true);
@@ -107,9 +123,57 @@ const Profile: React.FC = () => {
         setPriceZone(zone);
         setPriceZoneSaving(true);
         try {
-            await UserService.updatePreferences(user.id, zone);
+            await UserService.updatePreferences(user.id, { priceZone: zone });
         } catch { /* silent fail — zone is still set locally */ }
         finally { setPriceZoneSaving(false); }
+    };
+
+    const handleTogglePush = async () => {
+        if (!user?.id || pushLoading) return;
+        setPushLoading(true);
+        try {
+            if (!pushEnabled) {
+                await subscribeToPush();
+                await UserService.updatePreferences(user.id, { priceZone, pushNotificationsEnabled: true, offlineAlertThresholdHours: offlineThreshold });
+                setPushEnabled(true);
+                setPushPermission(Notification.permission);
+                toast.success('Offline alerts enabled');
+            } else {
+                await unsubscribeFromPush();
+                await UserService.updatePreferences(user.id, { priceZone, pushNotificationsEnabled: false });
+                setPushEnabled(false);
+                toast.success('Offline alerts disabled');
+            }
+        } catch (e: unknown) {
+            const msg = e instanceof Error ? e.message : 'Failed to update notification settings';
+            toast.error(msg);
+            setPushPermission(Notification.permission);
+        } finally {
+            setPushLoading(false);
+        }
+    };
+
+    const handleSendTestNotification = async () => {
+        setTestNotifLoading(true);
+        try {
+            await sendTestNotification();
+            toast.success('Test notification sent');
+        } catch {
+            toast.error('Failed to send test notification');
+        } finally {
+            setTestNotifLoading(false);
+        }
+    };
+
+    const handleThresholdChange = async (hours: number) => {
+        if (!user?.id) return;
+        const clamped = Math.min(168, Math.max(1, hours));
+        setOfflineThreshold(clamped);
+        setThresholdSaving(true);
+        try {
+            await UserService.updatePreferences(user.id, { priceZone, pushNotificationsEnabled: pushEnabled, offlineAlertThresholdHours: clamped });
+        } catch { /* silent */ }
+        finally { setThresholdSaving(false); }
     };
 
     const handleConfirmEmail = async () => {
@@ -599,6 +663,67 @@ const Profile: React.FC = () => {
                     </div>
                 </Section>
                 </div>
+
+                {/* Notifications */}
+                <Section title="Notifications">
+                    {!isPushSupported() ? (
+                        <p className="text-sm text-gray-500">Push notifications are not supported in this browser.</p>
+                    ) : (
+                        <div className="space-y-4">
+                            <div className="flex items-center justify-between">
+                                <div>
+                                    <p className="text-sm text-gray-100 font-medium">Offline alerts</p>
+                                    <p className="text-xs text-gray-500 mt-0.5">Notify when a sensor hasn't reported for a while. Requires the app to be installed.</p>
+                                </div>
+                                <button
+                                    onClick={handleTogglePush}
+                                    disabled={pushLoading || profileLoading}
+                                    aria-label={pushEnabled ? 'Disable offline alerts' : 'Enable offline alerts'}
+                                    className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors disabled:opacity-50 ${pushEnabled ? 'bg-sky-600' : 'bg-gray-700'}`}
+                                >
+                                    <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${pushEnabled ? 'translate-x-6' : 'translate-x-1'}`} />
+                                </button>
+                            </div>
+                            {pushEnabled && (
+                                <div className="flex items-center justify-between">
+                                    <div>
+                                        <p className="text-sm text-gray-100 font-medium">Alert after</p>
+                                        <p className="text-xs text-gray-500 mt-0.5">Hours of no data before notifying (1–168).</p>
+                                    </div>
+                                    <div className="flex items-center gap-2">
+                                        <input
+                                            type="number"
+                                            min={1}
+                                            max={168}
+                                            value={offlineThreshold}
+                                            onChange={e => handleThresholdChange(Number(e.target.value))}
+                                            className="w-20 bg-gray-900/70 border border-gray-700/60 rounded-xl text-gray-200 text-sm px-3 py-2 focus:outline-none focus:border-sky-500 transition-colors"
+                                        />
+                                        <span className="text-sm text-gray-500">h{thresholdSaving && <span className="ml-1 text-xs text-gray-600">saving…</span>}</span>
+                                    </div>
+                                </div>
+                            )}
+                            {pushEnabled && (
+                                <div className="flex items-center justify-between">
+                                    <div>
+                                        <p className="text-sm text-gray-100 font-medium">Test notification</p>
+                                        <p className="text-xs text-gray-500 mt-0.5">Send a test to confirm notifications are working.</p>
+                                    </div>
+                                    <button
+                                        onClick={handleSendTestNotification}
+                                        disabled={testNotifLoading}
+                                        className="px-4 py-2 bg-gray-700 hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded-xl transition-all whitespace-nowrap"
+                                    >
+                                        {testNotifLoading ? 'Sending…' : 'Send test'}
+                                    </button>
+                                </div>
+                            )}
+                            {pushPermission === 'denied' && (
+                                <Alert variant="error">Notifications blocked in browser settings. Enable them to use offline alerts.</Alert>
+                            )}
+                        </div>
+                    )}
+                </Section>
 
                 {/* Your data */}
                 <Section title="Your data">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import Navbar from './navbar';
 import Footer from './footer';
 import SessionProviderWrapper from './SessionProviderWrapper';
 import CookieBanner from '@/components/CookieBanner';
+import InstallPrompt from '@/components/InstallPrompt';
 import type { Metadata } from "next";
 import Script from 'next/script';
 import { Toaster } from 'sonner';
@@ -43,6 +44,7 @@ export default function Layout({
                         <FloatingNav />
                     </div>
                     <CookieBanner />
+                    <InstallPrompt />
                     <Toaster position="bottom-center" theme="dark" richColors />
                 </SessionProviderWrapper>
             </body>

--- a/src/components/InstallPrompt.tsx
+++ b/src/components/InstallPrompt.tsx
@@ -1,0 +1,80 @@
+"use client"
+
+import { useState, useEffect } from 'react';
+import { XMarkIcon } from '@heroicons/react/24/outline';
+
+type State = 'hidden' | 'android' | 'ios';
+
+interface BeforeInstallPromptEvent extends Event {
+    prompt(): Promise<void>;
+}
+
+export default function InstallPrompt() {
+    const [state, setState] = useState<State>('hidden');
+    const [deferred, setDeferred] = useState<BeforeInstallPromptEvent | null>(null);
+
+    useEffect(() => {
+        if (localStorage.getItem('install-dismissed')) return;
+
+        const isStandalone =
+            window.matchMedia('(display-mode: standalone)').matches ||
+            ('standalone' in navigator && (navigator as { standalone?: boolean }).standalone === true);
+        if (isStandalone) return;
+
+        const isIos = /iPad|iPhone|iPod/.test(navigator.userAgent) && !('MSStream' in window);
+        if (isIos) { setState('ios'); return; }
+
+        const handler = (e: Event) => {
+            e.preventDefault();
+            setDeferred(e as BeforeInstallPromptEvent);
+            setState('android');
+        };
+        window.addEventListener('beforeinstallprompt', handler);
+        return () => window.removeEventListener('beforeinstallprompt', handler);
+    }, []);
+
+    function dismiss() {
+        localStorage.setItem('install-dismissed', '1');
+        setState('hidden');
+    }
+
+    async function install() {
+        if (!deferred) return;
+        await deferred.prompt();
+        setState('hidden');
+    }
+
+    if (state === 'hidden') return null;
+
+    return (
+        <div className="fixed bottom-24 left-0 right-0 z-39 flex justify-center px-4 pointer-events-none">
+            <div className="pointer-events-auto max-w-lg w-full bg-gray-800/95 backdrop-blur-xl border border-gray-700/50 rounded-2xl px-5 py-4 shadow-[0_8px_32px_rgba(0,0,0,0.6)]">
+                <div className="flex items-start gap-3">
+                    <div className="flex-1">
+                        <p className="text-sm font-medium text-gray-100">Install Garge</p>
+                        {state === 'android' ? (
+                            <p className="text-xs text-gray-400 mt-0.5">Add to your home screen for the best experience and push notifications.</p>
+                        ) : (
+                            <p className="text-xs text-gray-400 mt-0.5">
+                                Tap <span className="text-gray-200">Share</span> → <span className="text-gray-200">Add to Home Screen</span> to install and enable push notifications.
+                            </p>
+                        )}
+                    </div>
+                    <button onClick={dismiss} className="text-gray-500 hover:text-gray-300 transition-colors shrink-0 mt-0.5">
+                        <XMarkIcon className="h-4 w-4" />
+                    </button>
+                </div>
+                {state === 'android' && (
+                    <div className="flex gap-2 mt-3">
+                        <button onClick={install} className="px-3 py-1.5 bg-sky-600 hover:bg-sky-500 text-white text-xs font-medium rounded-lg transition-colors">
+                            Install
+                        </button>
+                        <button onClick={dismiss} className="px-3 py-1.5 text-gray-400 hover:text-gray-200 text-xs transition-colors">
+                            Not now
+                        </button>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/src/dto/UserDTO.ts
+++ b/src/dto/UserDTO.ts
@@ -5,4 +5,6 @@ export interface UserDTO {
     lastName: string;
     emailConfirmed: boolean;
     priceZone: string;
+    pushNotificationsEnabled: boolean;
+    offlineAlertThresholdHours: number;
 }

--- a/src/services/pushNotificationService.ts
+++ b/src/services/pushNotificationService.ts
@@ -1,0 +1,64 @@
+import axiosInstance from '@/services/axiosInstance';
+
+function urlBase64ToUint8Array(base64: string): Uint8Array {
+    const padding = '='.repeat((4 - (base64.length % 4)) % 4);
+    const b64 = (base64 + padding).replace(/-/g, '+').replace(/_/g, '/');
+    const raw = atob(b64);
+    return Uint8Array.from([...raw].map(c => c.charCodeAt(0)));
+}
+
+export function isPushSupported(): boolean {
+    return typeof window !== 'undefined' &&
+        'serviceWorker' in navigator &&
+        'PushManager' in window &&
+        'Notification' in window;
+}
+
+export async function getVapidPublicKey(): Promise<string> {
+    const res = await axiosInstance.get<{ publicKey: string }>('/push-subscriptions/vapid-public-key');
+    return res.data.publicKey;
+}
+
+export async function subscribeToPush(): Promise<void> {
+    if (!isPushSupported()) throw new Error('Push not supported in this browser');
+
+    const permission = await Notification.requestPermission();
+    if (permission !== 'granted') throw new Error('Notification permission denied');
+
+    const publicKey = await getVapidPublicKey();
+    const reg = await navigator.serviceWorker.ready;
+    const sub = await reg.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: urlBase64ToUint8Array(publicKey) as BufferSource,
+    });
+
+    const key = sub.getKey('p256dh');
+    const auth = sub.getKey('auth');
+
+    await axiosInstance.post('/push-subscriptions', {
+        endpoint: sub.endpoint,
+        p256dh: key ? btoa(String.fromCharCode(...new Uint8Array(key))) : '',
+        auth: auth ? btoa(String.fromCharCode(...new Uint8Array(auth))) : '',
+    });
+}
+
+export async function unsubscribeFromPush(): Promise<void> {
+    if (!isPushSupported()) return;
+    const reg = await navigator.serviceWorker.ready;
+    const sub = await reg.pushManager.getSubscription();
+    if (!sub) return;
+    const endpoint = sub.endpoint;
+    await sub.unsubscribe();
+    await axiosInstance.delete('/push-subscriptions', { data: { endpoint } });
+}
+
+export async function sendTestNotification(): Promise<void> {
+    await axiosInstance.post('/push-subscriptions/send-test');
+}
+
+export async function isPushSubscribed(): Promise<boolean> {
+    if (!isPushSupported()) return false;
+    const reg = await navigator.serviceWorker.ready;
+    const sub = await reg.pushManager.getSubscription();
+    return sub !== null;
+}

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -175,9 +175,13 @@ const UserService = {
         }
     },
 
-    async updatePreferences(userId: string, priceZone: string): Promise<UserDTO> {
+    async updatePreferences(userId: string, data: {
+        priceZone: string;
+        pushNotificationsEnabled?: boolean;
+        offlineAlertThresholdHours?: number;
+    }): Promise<UserDTO> {
         try {
-            const response = await axiosInstance.put<UserDTO>(`/users/${userId}/preferences`, { priceZone });
+            const response = await axiosInstance.put<UserDTO>(`/users/${userId}/preferences`, data);
             return response.data;
         } catch (error: unknown) {
             if (error instanceof AxiosError) {


### PR DESCRIPTION
## Summary

- Add service worker (`sw.js`) with `skipWaiting`/`clients.claim` so SW activates immediately without requiring tab reload
- Push event handler with JSON parse error fallback
- Register SW via `/register-sw.js` script in root layout
- Add `pushNotificationService.ts`: subscribe, unsubscribe, VAPID key fetch, send-test
- Profile page: enable/disable push toggle, offline alert threshold setting, test notification button
- Add `InstallPrompt` PWA install banner component
- Extend `UserDTO` and `userService` with push preference fields