### PR TITLE
feat: declutter profile page with device sub-pages

### DIFF
--- a/src/app/(protected)/profile/page.tsx
+++ b/src/app/(protected)/profile/page.tsx
@@ -5,9 +5,9 @@ import { useRouter } from 'next/navigation';
 import { useSession, signOut } from 'next-auth/react';
 import UserService from '@/services/userService';
 import { UserDTO } from '@/dto/UserDTO';
-import SensorService, { Sensor } from '@/services/sensorService';
-import SwitchService, { Switch } from '@/services/switchService';
-import { PencilIcon, CheckIcon, XMarkIcon, TrashIcon, ClipboardDocumentIcon, BellIcon, BellSlashIcon } from '@heroicons/react/24/outline';
+import SensorService from '@/services/sensorService';
+import SwitchService from '@/services/switchService';
+import { ChevronRightIcon } from '@heroicons/react/24/outline';
 import { isPushSupported, isPushSubscribed, subscribeToPush, unsubscribeFromPush, sendTestNotification } from '@/services/pushNotificationService';
 import ConfirmModal from '@/components/ConfirmModal';
 import LoadingDots from '@/components/LoadingDots';
@@ -15,6 +15,7 @@ import Section from '@/components/Section';
 import { inputClass } from '@/components/TextInput';
 import Alert from '@/components/Alert';
 import { toast } from 'sonner';
+import Link from 'next/link';
 
 const Profile: React.FC = () => {
     const { status } = useSession();
@@ -28,28 +29,15 @@ const Profile: React.FC = () => {
     const [isButtonDisabled, setIsButtonDisabled] = useState(false);
     const [countdown, setCountdown] = useState(0);
     const [verificationCode, setVerificationCode] = useState('');
-    const [sensors, setSensors] = useState<Sensor[]>([]);
+    const [sensorCount, setSensorCount] = useState<number | null>(null);
+    const [socketCount, setSocketCount] = useState<number | null>(null);
     const [claimCode, setClaimCode] = useState('');
     const [claimType, setClaimType] = useState<'sensor' | 'socket'>('sensor');
     const [claimLoading, setClaimLoading] = useState(false);
-    const [emailMessage, setEmailMessage] = useState<string | null>(null);
-    const [emailError, setEmailError] = useState(false);
     const [claimMessage, setClaimMessage] = useState<string | null>(null);
     const [claimError, setClaimError] = useState(false);
-    const [editingSensorId, setEditingSensorId] = useState<number | null>(null);
-    const [newCustomName, setNewCustomName] = useState('');
-    const [editLoading, setEditLoading] = useState(false);
-    const [editError, setEditError] = useState<string | null>(null);
-    const [sensorsLoading, setSensorsLoading] = useState(true);
-    const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null);
-
-    const [switches, setSwitches] = useState<Switch[]>([]);
-    const [switchesLoading, setSwitchesLoading] = useState(true);
-    const [editingSwitchId, setEditingSwitchId] = useState<number | null>(null);
-    const [newSwitchName, setNewSwitchName] = useState('');
-    const [switchEditLoading, setSwitchEditLoading] = useState(false);
-    const [switchEditError, setSwitchEditError] = useState<string | null>(null);
-    const [confirmDeleteSwitchId, setConfirmDeleteSwitchId] = useState<number | null>(null);
+    const [emailMessage, setEmailMessage] = useState<string | null>(null);
+    const [emailError, setEmailError] = useState(false);
     const [showDeleteAccount, setShowDeleteAccount] = useState(false);
     const [deleteAccountLoading, setDeleteAccountLoading] = useState(false);
     const [exportLoading, setExportLoading] = useState(false);
@@ -59,25 +47,6 @@ const Profile: React.FC = () => {
     const [offlineThreshold, setOfflineThreshold] = useState(4);
     const [thresholdSaving, setThresholdSaving] = useState(false);
     const [testNotifLoading, setTestNotifLoading] = useState(false);
-
-    function sortSensorsByName(sensors: Sensor[]): Sensor[] {
-        return [...sensors].sort((a, b) =>
-            (a.customName ?? a.defaultName ?? '').toLowerCase()
-                .localeCompare((b.customName ?? b.defaultName ?? '').toLowerCase())
-        );
-    }
-
-    const refreshSensors = async () => {
-        const userSensors = await SensorService.getAllSensors();
-        setSensors(sortSensorsByName(userSensors));
-    };
-
-    const refreshSwitches = async () => {
-        const allSwitches = await SwitchService.getAllSwitches();
-        setSwitches([...allSwitches].sort((a, b) =>
-            (a.customName ?? a.name).toLowerCase().localeCompare((b.customName ?? b.name).toLowerCase())
-        ));
-    };
 
     useEffect(() => {
         if (!isAuthenticated) { router.push('/login'); return; }
@@ -89,12 +58,10 @@ const Profile: React.FC = () => {
         }).catch(console.error).finally(() => setProfileLoading(false));
         if (isPushSupported()) {
             setPushPermission(Notification.permission);
-            isPushSubscribed().then(subscribed => setPushEnabled(prev => prev && subscribed)).catch(() => {});
+            isPushSubscribed().then((subscribed: boolean) => setPushEnabled(prev => prev && subscribed)).catch(() => {});
         }
-        setSensorsLoading(true);
-        refreshSensors().catch(console.error).finally(() => setSensorsLoading(false));
-        setSwitchesLoading(true);
-        refreshSwitches().catch(console.error).finally(() => setSwitchesLoading(false));
+        SensorService.getAllSensors().then(s => setSensorCount(s.length)).catch(() => setSensorCount(0));
+        SwitchService.getAllSwitches().then(s => setSocketCount(s.length)).catch(() => setSocketCount(0));
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isAuthenticated, router]);
 
@@ -124,7 +91,7 @@ const Profile: React.FC = () => {
         setPriceZoneSaving(true);
         try {
             await UserService.updatePreferences(user.id, { priceZone: zone });
-        } catch { /* silent fail — zone is still set locally */ }
+        } catch { /* silent fail */ }
         finally { setPriceZoneSaving(false); }
     };
 
@@ -198,13 +165,13 @@ const Profile: React.FC = () => {
             if (claimType === 'sensor') {
                 await SensorService.claimSensor(claimCode.trim());
                 setClaimMessage('Sensor added successfully!');
+                setSensorCount(c => (c ?? 0) + 1);
                 toast.success('Sensor added');
-                await refreshSensors();
             } else {
                 await SwitchService.claimSwitch(claimCode.trim());
                 setClaimMessage('Socket added successfully!');
+                setSocketCount(c => (c ?? 0) + 1);
                 toast.success('Socket added');
-                await refreshSwitches();
             }
             setClaimError(false);
             setClaimCode('');
@@ -215,78 +182,6 @@ const Profile: React.FC = () => {
             toast.error(msg);
         } finally {
             setClaimLoading(false);
-        }
-    };
-
-    const handleUnclaimSensor = async () => {
-        if (confirmDeleteId === null) return;
-        await SensorService.unclaimSensor(confirmDeleteId);
-        setConfirmDeleteId(null);
-        await refreshSensors();
-        toast.success('Sensor removed');
-    };
-
-    const handleUnclaimSwitch = async () => {
-        if (confirmDeleteSwitchId === null) return;
-        await SwitchService.unclaimSwitch(confirmDeleteSwitchId);
-        setConfirmDeleteSwitchId(null);
-        await refreshSwitches();
-        toast.success('Socket removed');
-    };
-
-    const startEditing = (sensor: Sensor) => {
-        setEditingSensorId(sensor.id);
-        setNewCustomName(sensor.customName ?? sensor.defaultName ?? '');
-        setEditError(null);
-    };
-
-    const cancelEditing = () => { setEditingSensorId(null); setNewCustomName(''); setEditError(null); };
-
-    const handleSaveCustomName = async (sensorId: number) => {
-        if (!newCustomName.trim() || newCustomName.length > 50) {
-            setEditError('Name is required and must be at most 50 characters.');
-            return;
-        }
-        setEditLoading(true);
-        setEditError(null);
-        try {
-            await SensorService.updateCustomName(sensorId, newCustomName.trim());
-            await refreshSensors();
-            setEditingSensorId(null);
-            setNewCustomName('');
-            toast.success('Sensor renamed');
-        } catch (error: unknown) {
-            setEditError(error instanceof Error ? error.message : 'Failed to update sensor name.');
-        } finally {
-            setEditLoading(false);
-        }
-    };
-
-    const startEditingSwitch = (sw: Switch) => {
-        setEditingSwitchId(sw.id);
-        setNewSwitchName(sw.customName ?? sw.name);
-        setSwitchEditError(null);
-    };
-
-    const cancelEditingSwitch = () => { setEditingSwitchId(null); setNewSwitchName(''); setSwitchEditError(null); };
-
-    const handleSaveSwitchName = async (switchId: number) => {
-        if (!newSwitchName.trim() || newSwitchName.length > 50) {
-            setSwitchEditError('Name is required and must be at most 50 characters.');
-            return;
-        }
-        setSwitchEditLoading(true);
-        setSwitchEditError(null);
-        try {
-            await SwitchService.updateCustomName(switchId, newSwitchName.trim());
-            await refreshSwitches();
-            setEditingSwitchId(null);
-            setNewSwitchName('');
-            toast.success('Socket renamed');
-        } catch (error: unknown) {
-            setSwitchEditError(error instanceof Error ? error.message : 'Failed to update socket name.');
-        } finally {
-            setSwitchEditLoading(false);
         }
     };
 
@@ -325,12 +220,6 @@ const Profile: React.FC = () => {
         }
     };
 
-    const copyToClipboard = (text: string) => {
-        navigator.clipboard.writeText(text).then(() => toast.success('Copied')).catch(() => toast.error('Failed to copy'));
-    };
-
-    const confirmSensor = sensors.find(s => s.id === confirmDeleteId);
-    const confirmSwitch = switches.find(sw => sw.id === confirmDeleteSwitchId);
     const isUserLoading = status === 'loading' || !user;
 
     return (
@@ -344,29 +233,10 @@ const Profile: React.FC = () => {
                     onCancel={() => setShowDeleteAccount(false)}
                 />
             )}
-            {confirmDeleteId !== null && confirmSensor && (
-                <ConfirmModal
-                    title="Remove sensor"
-                    message={<>Are you sure you want to remove <span className="font-medium text-gray-100">{confirmSensor.customName ?? confirmSensor.defaultName}</span> from your account? You can re-add it later using the device code.</>}
-                    confirmLabel="Remove"
-                    onConfirm={handleUnclaimSensor}
-                    onCancel={() => setConfirmDeleteId(null)}
-                />
-            )}
-            {confirmDeleteSwitchId !== null && confirmSwitch && (
-                <ConfirmModal
-                    title="Remove socket"
-                    message={<>Are you sure you want to remove <span className="font-medium text-gray-100">{confirmSwitch.customName ?? confirmSwitch.name}</span> from your account? You can re-add it later using the device code.</>}
-                    confirmLabel="Remove"
-                    onConfirm={handleUnclaimSwitch}
-                    onCancel={() => setConfirmDeleteSwitchId(null)}
-                />
-            )}
 
             <div className="max-w-7xl mx-auto px-4 py-6 space-y-5">
                 <h1 className="text-2xl font-display font-bold text-gray-100">Profile</h1>
 
-                {/* Account Info */}
                 <Section title="Account">
                     {isUserLoading ? <LoadingDots /> : (
                         <div className="space-y-3">
@@ -384,7 +254,6 @@ const Profile: React.FC = () => {
                                     {user.emailConfirmed ? 'Confirmed' : 'Pending'}
                                 </span>
                             </div>
-
                             {!user.emailConfirmed && (
                                 <div className="pt-2 space-y-3">
                                     <div className="flex gap-2">
@@ -411,7 +280,6 @@ const Profile: React.FC = () => {
                                     </div>
                                 </div>
                             )}
-
                             {emailMessage && (
                                 emailError
                                     ? <Alert variant="error">{emailMessage}</Alert>
@@ -421,214 +289,84 @@ const Profile: React.FC = () => {
                     )}
                 </Section>
 
-                {/* Claim Device */}
-                <Section title="Add a device">
-                    <p className="text-sm text-gray-400 mb-3">Enter the device code to add a sensor or socket to your account.</p>
-
-                    {/* Type toggle */}
-                    <div className="flex gap-2 p-1 bg-gray-800/60 rounded-xl mb-3">
-                        <button
-                            type="button"
-                            onClick={() => { setClaimType('sensor'); setClaimCode(''); setClaimMessage(null); }}
-                            className={`flex-1 py-2 rounded-lg text-sm font-medium transition-all ${
-                                claimType === 'sensor'
-                                    ? 'bg-sky-600 text-white shadow'
-                                    : 'text-gray-400 hover:text-gray-200'
-                            }`}
-                        >
-                            🌡️ Sensor
-                        </button>
-                        <button
-                            type="button"
-                            onClick={() => { setClaimType('socket'); setClaimCode(''); setClaimMessage(null); }}
-                            className={`flex-1 py-2 rounded-lg text-sm font-medium transition-all ${
-                                claimType === 'socket'
-                                    ? 'bg-sky-600 text-white shadow'
-                                    : 'text-gray-400 hover:text-gray-200'
-                            }`}
-                        >
-                            🔌 Socket
-                        </button>
-                    </div>
-
-                    <div className="flex gap-2">
-                        <input
-                            type="text"
-                            value={claimCode}
-                            onChange={e => setClaimCode(e.target.value.toUpperCase())}
-                            onKeyDown={e => e.key === 'Enter' && handleClaimDevice()}
-                            placeholder="e.g. A1B2C3D4E5"
-                            className={inputClass}
-                            disabled={claimLoading}
-                        />
-                        <button
-                            onClick={handleClaimDevice}
-                            className="px-4 py-2.5 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded-xl transition-all whitespace-nowrap"
-                            disabled={claimLoading}
-                        >
-                            {claimLoading ? 'Adding…' : 'Add device'}
-                        </button>
-                    </div>
-                    {claimMessage && (
-                        claimError
-                            ? <Alert variant="error" className="mt-3">{claimMessage}</Alert>
-                            : <Alert variant="success" className="mt-3">{claimMessage}</Alert>
-                    )}
-                </Section>
-
-                {/* Sensors */}
-                <Section title="Your sensors">
-                    {sensorsLoading ? <LoadingDots /> : !sensors.length ? (
-                        <p className="text-sm text-gray-500">No sensors found. Add one above.</p>
-                    ) : (
-                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 device-card-grid">
-                            {sensors.map(sensor => (
-                                <div key={sensor.id} className="bg-gray-900/50 border border-gray-700/40 rounded-xl p-4">
-                                    {editingSensorId === sensor.id ? (
-                                        <div className="space-y-2">
-                                            <div className="relative">
-                                                <input
-                                                    type="text"
-                                                    value={newCustomName}
-                                                    onChange={e => setNewCustomName(e.target.value)}
-                                                    className={inputClass}
-                                                    maxLength={50}
-                                                    disabled={editLoading}
-                                                    autoFocus
-                                                />
-                                                <span className={`absolute right-2 top-1/2 -translate-y-1/2 text-[10px] tabular-nums pointer-events-none ${newCustomName.length >= 45 ? 'text-amber-400' : 'text-gray-600'}`}>{newCustomName.length}/50</span>
-                                            </div>
-                                            {editError && <p className="text-xs text-red-400">{editError}</p>}
-                                            <div className="flex gap-2">
-                                                <button onClick={() => handleSaveCustomName(sensor.id)} disabled={editLoading} className="flex items-center gap-1.5 px-3 py-1.5 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 text-white text-xs font-medium rounded-lg transition-all">
-                                                    <CheckIcon className="h-3.5 w-3.5" />
-                                                    {editLoading ? 'Saving…' : 'Save'}
-                                                </button>
-                                                <button onClick={cancelEditing} disabled={editLoading} className="flex items-center gap-1.5 px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-300 text-xs font-medium rounded-lg transition-all">
-                                                    <XMarkIcon className="h-3.5 w-3.5" />
-                                                    Cancel
-                                                </button>
-                                            </div>
-                                        </div>
-                                    ) : (
-                                        <>
-                                            <div className="flex items-start justify-between gap-2 mb-2">
-                                                <span className="text-sm font-semibold text-gray-100 leading-tight">
-                                                    {sensor.customName ?? sensor.defaultName}
-                                                </span>
-                                                <button onClick={() => startEditing(sensor)} className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-gray-700/60 transition-all flex-shrink-0" title="Rename">
-                                                    <PencilIcon className="h-3.5 w-3.5" />
-                                                </button>
-                                            </div>
-                                            <div className="space-y-0.5 mb-4">
-                                                <p className="text-xs text-gray-400">Type: {sensor.type}</p>
-                                        <div className="flex items-center gap-1.5">
-                                            <p className="text-xs text-gray-500">Device code: <span className="font-mono">{sensor.registrationCode}</span></p>
-                                            {sensor.registrationCode && (
-                                                <button
-                                                    onClick={() => copyToClipboard(sensor.registrationCode)}
-                                                    aria-label="Copy device code"
-                                                    className="p-0.5 rounded text-gray-600 hover:text-gray-400 transition-colors flex-shrink-0"
-                                                >
-                                                    <ClipboardDocumentIcon className="h-3.5 w-3.5" />
-                                                </button>
-                                            )}
-                                        </div>
-                                                {sensor.customName && <p className="text-xs text-gray-500">Default: {sensor.defaultName}</p>}
-                                            </div>
-                                            <button
-                                                onClick={() => setConfirmDeleteId(sensor.id)}
-                                                className="flex items-center gap-1.5 text-xs text-gray-600 hover:text-red-400 transition-colors"
-                                                title="Remove from account"
-                                            >
-                                                <TrashIcon className="h-3.5 w-3.5" />
-                                                Remove from account
-                                            </button>
-                                        </>
-                                    )}
-                                </div>
-                            ))}
+                <Section title="Devices">
+                    <div className="space-y-4">
+                        <div>
+                            <div className="flex gap-2 p-1 bg-gray-800/60 rounded-xl mb-3">
+                                <button
+                                    type="button"
+                                    onClick={() => { setClaimType('sensor'); setClaimCode(''); setClaimMessage(null); }}
+                                    className={`flex-1 py-2 rounded-lg text-sm font-medium transition-all ${claimType === 'sensor' ? 'bg-sky-600 text-white shadow' : 'text-gray-400 hover:text-gray-200'}`}
+                                >
+                                    🌡️ Sensor
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={() => { setClaimType('socket'); setClaimCode(''); setClaimMessage(null); }}
+                                    className={`flex-1 py-2 rounded-lg text-sm font-medium transition-all ${claimType === 'socket' ? 'bg-sky-600 text-white shadow' : 'text-gray-400 hover:text-gray-200'}`}
+                                >
+                                    🔌 Socket
+                                </button>
+                            </div>
+                            <div className="flex gap-2">
+                                <input
+                                    type="text"
+                                    value={claimCode}
+                                    onChange={e => setClaimCode(e.target.value.toUpperCase())}
+                                    onKeyDown={e => e.key === 'Enter' && handleClaimDevice()}
+                                    placeholder="e.g. A1B2C3D4E5"
+                                    className={inputClass}
+                                    disabled={claimLoading}
+                                />
+                                <button
+                                    onClick={handleClaimDevice}
+                                    className="px-4 py-2.5 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded-xl transition-all whitespace-nowrap"
+                                    disabled={claimLoading}
+                                >
+                                    {claimLoading ? 'Adding…' : 'Add device'}
+                                </button>
+                            </div>
+                            {claimMessage && (
+                                claimError
+                                    ? <Alert variant="error" className="mt-3">{claimMessage}</Alert>
+                                    : <Alert variant="success" className="mt-3">{claimMessage}</Alert>
+                            )}
                         </div>
-                    )}
-                </Section>
-
-                {/* Sockets */}
-                <Section title="Your sockets">
-                    {switchesLoading ? <LoadingDots /> : !switches.length ? (
-                        <p className="text-sm text-gray-500">No sockets found.</p>
-                    ) : (
-                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 device-card-grid">
-                            {switches.map(sw => (
-                                <div key={sw.id} className="bg-gray-900/50 border border-gray-700/40 rounded-xl p-4">
-                                    {editingSwitchId === sw.id ? (
-                                        <div className="space-y-2">
-                                            <div className="relative">
-                                                <input
-                                                    type="text"
-                                                    value={newSwitchName}
-                                                    onChange={e => setNewSwitchName(e.target.value)}
-                                                    className={inputClass}
-                                                    maxLength={50}
-                                                    disabled={switchEditLoading}
-                                                    autoFocus
-                                                />
-                                                <span className={`absolute right-2 top-1/2 -translate-y-1/2 text-[10px] tabular-nums pointer-events-none ${newSwitchName.length >= 45 ? 'text-amber-400' : 'text-gray-600'}`}>{newSwitchName.length}/50</span>
-                                            </div>
-                                            {switchEditError && <p className="text-xs text-red-400">{switchEditError}</p>}
-                                            <div className="flex gap-2">
-                                                <button onClick={() => handleSaveSwitchName(sw.id)} disabled={switchEditLoading} className="flex items-center gap-1.5 px-3 py-1.5 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 text-white text-xs font-medium rounded-lg transition-all">
-                                                    <CheckIcon className="h-3.5 w-3.5" />
-                                                    {switchEditLoading ? 'Saving…' : 'Save'}
-                                                </button>
-                                                <button onClick={cancelEditingSwitch} disabled={switchEditLoading} className="flex items-center gap-1.5 px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-300 text-xs font-medium rounded-lg transition-all">
-                                                    <XMarkIcon className="h-3.5 w-3.5" />
-                                                    Cancel
-                                                </button>
-                                            </div>
-                                        </div>
-                                    ) : (
-                                        <>
-                                            <div className="flex items-start justify-between gap-2 mb-2">
-                                                <span className="text-sm font-semibold text-gray-100 leading-tight">
-                                                    {sw.customName ?? sw.name}
-                                                </span>
-                                                <button onClick={() => startEditingSwitch(sw)} className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-gray-700/60 transition-all flex-shrink-0" title="Rename">
-                                                    <PencilIcon className="h-3.5 w-3.5" />
-                                                </button>
-                                            </div>
-                                            <div className="space-y-0.5 mb-4">
-                                                <p className="text-xs text-gray-400">Type: {sw.type}</p>
-                                                {sw.registrationCode && (
-                                                    <div className="flex items-center gap-1.5">
-                                                        <p className="text-xs text-gray-500">Device code: <span className="font-mono">{sw.registrationCode}</span></p>
-                                                        <button
-                                                            onClick={() => copyToClipboard(sw.registrationCode!)}
-                                                            aria-label="Copy device code"
-                                                            className="p-0.5 rounded text-gray-600 hover:text-gray-400 transition-colors flex-shrink-0"
-                                                        >
-                                                            <ClipboardDocumentIcon className="h-3.5 w-3.5" />
-                                                        </button>
-                                                    </div>
-                                                )}
-                                                {sw.customName && <p className="text-xs text-gray-500">Default: {sw.name}</p>}
-                                            </div>
-                                            <button
-                                                onClick={() => setConfirmDeleteSwitchId(sw.id)}
-                                                className="flex items-center gap-1.5 text-xs text-gray-600 hover:text-red-400 transition-colors"
-                                                title="Remove from account"
-                                            >
-                                                <TrashIcon className="h-3.5 w-3.5" />
-                                                Remove from account
-                                            </button>
-                                        </>
-                                    )}
+                        <div className="border-t border-gray-700/40 pt-3 space-y-2">
+                            <Link
+                                href="/profile/sensors"
+                                className="flex items-center justify-between p-3 rounded-xl bg-gray-900/50 border border-gray-700/40 hover:border-gray-600/60 hover:bg-gray-800/50 transition-all group"
+                            >
+                                <div className="flex items-center gap-3">
+                                    <span className="text-lg">🌡️</span>
+                                    <div>
+                                        <p className="text-sm font-medium text-gray-100">Manage sensors</p>
+                                        <p className="text-xs text-gray-500">
+                                            {sensorCount === null ? 'Loading…' : `${sensorCount} sensor${sensorCount !== 1 ? 's' : ''}`}
+                                        </p>
+                                    </div>
                                 </div>
-                            ))}
+                                <ChevronRightIcon className="h-4 w-4 text-gray-600 group-hover:text-gray-400 transition-colors" />
+                            </Link>
+                            <Link
+                                href="/profile/sockets"
+                                className="flex items-center justify-between p-3 rounded-xl bg-gray-900/50 border border-gray-700/40 hover:border-gray-600/60 hover:bg-gray-800/50 transition-all group"
+                            >
+                                <div className="flex items-center gap-3">
+                                    <span className="text-lg">🔌</span>
+                                    <div>
+                                        <p className="text-sm font-medium text-gray-100">Manage sockets</p>
+                                        <p className="text-xs text-gray-500">
+                                            {socketCount === null ? 'Loading…' : `${socketCount} socket${socketCount !== 1 ? 's' : ''}`}
+                                        </p>
+                                    </div>
+                                </div>
+                                <ChevronRightIcon className="h-4 w-4 text-gray-600 group-hover:text-gray-400 transition-colors" />
+                            </Link>
                         </div>
-                    )}
+                    </div>
                 </Section>
 
-                {/* Settings */}
                 <div id="settings">
                 <Section title="Settings">
                     <div className="flex items-center justify-between">
@@ -664,7 +402,6 @@ const Profile: React.FC = () => {
                 </Section>
                 </div>
 
-                {/* Notifications */}
                 <Section title="Notifications">
                     {!isPushSupported() ? (
                         <p className="text-sm text-gray-500">Push notifications are not supported in this browser.</p>
@@ -673,7 +410,7 @@ const Profile: React.FC = () => {
                             <div className="flex items-center justify-between">
                                 <div>
                                     <p className="text-sm text-gray-100 font-medium">Offline alerts</p>
-                                    <p className="text-xs text-gray-500 mt-0.5">Notify when a sensor hasn't reported for a while. Requires the app to be installed.</p>
+                                    <p className="text-xs text-gray-500 mt-0.5">Notify when a sensor has not reported for a while. Requires the app to be installed.</p>
                                 </div>
                                 <button
                                     onClick={handleTogglePush}
@@ -725,7 +462,6 @@ const Profile: React.FC = () => {
                     )}
                 </Section>
 
-                {/* Your data */}
                 <Section title="Your data">
                     <div className="space-y-4">
                         <div className="flex items-center justify-between">
@@ -741,7 +477,6 @@ const Profile: React.FC = () => {
                                 {exportLoading ? 'Exporting…' : 'Download'}
                             </button>
                         </div>
-
                         <div className="border-t border-gray-700/40 pt-4 flex items-center justify-between">
                             <div>
                                 <p className="text-sm text-red-400 font-medium">Delete account</p>

--- a/src/app/(protected)/profile/sensors/page.tsx
+++ b/src/app/(protected)/profile/sensors/page.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import SensorService, { Sensor } from '@/services/sensorService';
+import { DeviceManagePage, DevicePageConfig } from '@/components/DeviceManagePage';
+
+const config: DevicePageConfig<Sensor> = {
+    title: 'Sensors',
+    itemLabel: 'sensor',
+    emoji: '🌡️',
+    fetchAll: () => SensorService.getAllSensors(),
+    claim: (code) => SensorService.claimSensor(code),
+    unclaim: (id) => SensorService.unclaimSensor(id),
+    updateName: (id, name) => SensorService.updateCustomName(id, name),
+    getDisplayName: (s) => s.customName ?? s.defaultName ?? '',
+    getDefaultName: (s) => s.defaultName ?? undefined,
+};
+
+export default function SensorsPage() {
+    return <DeviceManagePage config={config} />;
+}

--- a/src/app/(protected)/profile/sockets/page.tsx
+++ b/src/app/(protected)/profile/sockets/page.tsx
@@ -1,0 +1,20 @@
+"use client"
+
+import SwitchService, { Switch } from '@/services/switchService';
+import { DeviceManagePage, DevicePageConfig } from '@/components/DeviceManagePage';
+
+const config: DevicePageConfig<Switch> = {
+    title: 'Sockets',
+    itemLabel: 'socket',
+    emoji: '🔌',
+    fetchAll: () => SwitchService.getAllSwitches(),
+    claim: (code) => SwitchService.claimSwitch(code),
+    unclaim: (id) => SwitchService.unclaimSwitch(id),
+    updateName: (id, name) => SwitchService.updateCustomName(id, name),
+    getDisplayName: (sw) => sw.customName ?? sw.name,
+    getDefaultName: (sw) => sw.name,
+};
+
+export default function SocketsPage() {
+    return <DeviceManagePage config={config} />;
+}

--- a/src/components/DeviceManagePage.tsx
+++ b/src/components/DeviceManagePage.tsx
@@ -1,0 +1,261 @@
+"use client"
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useSession } from 'next-auth/react';
+import { PencilIcon, CheckIcon, XMarkIcon, TrashIcon, ClipboardDocumentIcon, ArrowLeftIcon } from '@heroicons/react/24/outline';
+import ConfirmModal from '@/components/ConfirmModal';
+import LoadingDots from '@/components/LoadingDots';
+import Section from '@/components/Section';
+import { inputClass } from '@/components/TextInput';
+import Alert from '@/components/Alert';
+import { toast } from 'sonner';
+import Link from 'next/link';
+
+export interface DeviceItem {
+    id: number;
+    customName?: string | null;
+    type?: string;
+    registrationCode?: string | null;
+}
+
+export interface DevicePageConfig<T extends DeviceItem> {
+    title: string;
+    itemLabel: string;
+    emoji: string;
+    fetchAll: () => Promise<T[]>;
+    claim: (code: string) => Promise<unknown>;
+    unclaim: (id: number) => Promise<unknown>;
+    updateName: (id: number, name: string) => Promise<unknown>;
+    getDisplayName: (item: T) => string;
+    getDefaultName: (item: T) => string | undefined;
+}
+
+interface Props<T extends DeviceItem> {
+    config: DevicePageConfig<T>;
+}
+
+export function DeviceManagePage<T extends DeviceItem>({ config }: Props<T>) {
+    const { status } = useSession();
+    const router = useRouter();
+    const isAuthenticated = status === 'authenticated';
+
+    const [items, setItems] = useState<T[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [claimCode, setClaimCode] = useState('');
+    const [claimLoading, setClaimLoading] = useState(false);
+    const [claimMessage, setClaimMessage] = useState<string | null>(null);
+    const [claimError, setClaimError] = useState(false);
+    const [editingId, setEditingId] = useState<number | null>(null);
+    const [editName, setEditName] = useState('');
+    const [editLoading, setEditLoading] = useState(false);
+    const [editError, setEditError] = useState<string | null>(null);
+    const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null);
+
+    const { title, itemLabel, emoji, fetchAll, claim, unclaim, updateName, getDisplayName, getDefaultName } = config;
+    const label = itemLabel;
+    const Label = label.charAt(0).toUpperCase() + label.slice(1);
+
+    const refresh = async () => {
+        const all = await fetchAll();
+        setItems([...all].sort((a, b) => getDisplayName(a).toLowerCase().localeCompare(getDisplayName(b).toLowerCase())));
+    };
+
+    useEffect(() => {
+        if (!isAuthenticated) { router.push('/login'); return; }
+        setLoading(true);
+        refresh().catch(console.error).finally(() => setLoading(false));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isAuthenticated, router]);
+
+    const handleClaim = async () => {
+        if (!claimCode.trim()) { setClaimMessage('Please enter a device code.'); setClaimError(true); return; }
+        setClaimLoading(true);
+        setClaimMessage(null);
+        setClaimError(false);
+        try {
+            await claim(claimCode.trim());
+            setClaimMessage(`${Label} added successfully!`);
+            setClaimError(false);
+            setClaimCode('');
+            toast.success(`${Label} added`);
+            await refresh();
+        } catch (error: unknown) {
+            const msg = error instanceof Error ? error.message : `Failed to add ${label}.`;
+            setClaimMessage(msg);
+            setClaimError(true);
+            toast.error(msg);
+        } finally {
+            setClaimLoading(false);
+        }
+    };
+
+    const handleUnclaim = async () => {
+        if (confirmDeleteId === null) return;
+        await unclaim(confirmDeleteId);
+        setConfirmDeleteId(null);
+        await refresh();
+        toast.success(`${Label} removed`);
+    };
+
+    const startEditing = (item: T) => {
+        setEditingId(item.id);
+        setEditName(getDisplayName(item));
+        setEditError(null);
+    };
+
+    const cancelEditing = () => { setEditingId(null); setEditName(''); setEditError(null); };
+
+    const handleSaveName = async (id: number) => {
+        if (!editName.trim() || editName.length > 50) {
+            setEditError('Name is required and must be at most 50 characters.');
+            return;
+        }
+        setEditLoading(true);
+        setEditError(null);
+        try {
+            await updateName(id, editName.trim());
+            await refresh();
+            setEditingId(null);
+            setEditName('');
+            toast.success(`${Label} renamed`);
+        } catch (error: unknown) {
+            setEditError(error instanceof Error ? error.message : `Failed to update ${label} name.`);
+        } finally {
+            setEditLoading(false);
+        }
+    };
+
+    const copyToClipboard = (text: string) => {
+        navigator.clipboard.writeText(text).then(() => toast.success('Copied')).catch(() => toast.error('Failed to copy'));
+    };
+
+    const confirmItem = items.find(i => i.id === confirmDeleteId);
+
+    return (
+        <>
+            {confirmDeleteId !== null && confirmItem && (
+                <ConfirmModal
+                    title={`Remove ${label}`}
+                    message={<>Are you sure you want to remove <span className="font-medium text-gray-100">{getDisplayName(confirmItem)}</span> from your account? You can re-add it later using the device code.</>}
+                    confirmLabel="Remove"
+                    onConfirm={handleUnclaim}
+                    onCancel={() => setConfirmDeleteId(null)}
+                />
+            )}
+
+            <div className="max-w-7xl mx-auto px-4 py-6 space-y-5">
+                <div className="flex items-center gap-3">
+                    <Link href="/profile" className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-gray-700/60 transition-all">
+                        <ArrowLeftIcon className="h-4 w-4" />
+                    </Link>
+                    <h1 className="text-2xl font-display font-bold text-gray-100">{title}</h1>
+                </div>
+
+                <Section title={`Add a ${label}`}>
+                    <p className="text-sm text-gray-400 mb-3">Enter the device code to add a {label} to your account.</p>
+                    <div className="flex gap-2">
+                        <input
+                            type="text"
+                            value={claimCode}
+                            onChange={e => setClaimCode(e.target.value.toUpperCase())}
+                            onKeyDown={e => e.key === 'Enter' && handleClaim()}
+                            placeholder="e.g. A1B2C3D4E5"
+                            className={inputClass}
+                            disabled={claimLoading}
+                        />
+                        <button
+                            onClick={handleClaim}
+                            className="px-4 py-2.5 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded-xl transition-all whitespace-nowrap"
+                            disabled={claimLoading}
+                        >
+                            {claimLoading ? 'Adding…' : `Add ${label}`}
+                        </button>
+                    </div>
+                    {claimMessage && (
+                        claimError
+                            ? <Alert variant="error" className="mt-3">{claimMessage}</Alert>
+                            : <Alert variant="success" className="mt-3">{claimMessage}</Alert>
+                    )}
+                </Section>
+
+                <Section title={`Your ${title.toLowerCase()}`}>
+                    {loading ? <LoadingDots /> : !items.length ? (
+                        <p className="text-sm text-gray-500">No {title.toLowerCase()} yet. Add one above.</p>
+                    ) : (
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                            {items.map(item => {
+                                const displayName = getDisplayName(item);
+                                const defaultName = getDefaultName(item);
+                                return (
+                                    <div key={item.id} className="bg-gray-900/50 border border-gray-700/40 rounded-xl p-4">
+                                        {editingId === item.id ? (
+                                            <div className="space-y-2">
+                                                <div className="relative">
+                                                    <input
+                                                        type="text"
+                                                        value={editName}
+                                                        onChange={e => setEditName(e.target.value)}
+                                                        className={inputClass}
+                                                        maxLength={50}
+                                                        disabled={editLoading}
+                                                        autoFocus
+                                                    />
+                                                    <span className={`absolute right-2 top-1/2 -translate-y-1/2 text-[10px] tabular-nums pointer-events-none ${editName.length >= 45 ? 'text-amber-400' : 'text-gray-600'}`}>{editName.length}/50</span>
+                                                </div>
+                                                {editError && <p className="text-xs text-red-400">{editError}</p>}
+                                                <div className="flex gap-2">
+                                                    <button onClick={() => handleSaveName(item.id)} disabled={editLoading} className="flex items-center gap-1.5 px-3 py-1.5 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 text-white text-xs font-medium rounded-lg transition-all">
+                                                        <CheckIcon className="h-3.5 w-3.5" />
+                                                        {editLoading ? 'Saving…' : 'Save'}
+                                                    </button>
+                                                    <button onClick={cancelEditing} disabled={editLoading} className="flex items-center gap-1.5 px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-300 text-xs font-medium rounded-lg transition-all">
+                                                        <XMarkIcon className="h-3.5 w-3.5" />
+                                                        Cancel
+                                                    </button>
+                                                </div>
+                                            </div>
+                                        ) : (
+                                            <>
+                                                <div className="flex items-start justify-between gap-2 mb-2">
+                                                    <span className="text-sm font-semibold text-gray-100 leading-tight">{displayName}</span>
+                                                    <button onClick={() => startEditing(item)} className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-gray-700/60 transition-all flex-shrink-0" title="Rename">
+                                                        <PencilIcon className="h-3.5 w-3.5" />
+                                                    </button>
+                                                </div>
+                                                <div className="space-y-0.5 mb-4">
+                                                    {item.type && <p className="text-xs text-gray-400">Type: {item.type}</p>}
+                                                    {item.registrationCode && (
+                                                        <div className="flex items-center gap-1.5">
+                                                            <p className="text-xs text-gray-500">Device code: <span className="font-mono">{item.registrationCode}</span></p>
+                                                            <button
+                                                                onClick={() => copyToClipboard(item.registrationCode!)}
+                                                                aria-label="Copy device code"
+                                                                className="p-0.5 rounded text-gray-600 hover:text-gray-400 transition-colors flex-shrink-0"
+                                                            >
+                                                                <ClipboardDocumentIcon className="h-3.5 w-3.5" />
+                                                            </button>
+                                                        </div>
+                                                    )}
+                                                    {item.customName && defaultName && <p className="text-xs text-gray-500">Default: {defaultName}</p>}
+                                                </div>
+                                                <button
+                                                    onClick={() => setConfirmDeleteId(item.id)}
+                                                    className="flex items-center gap-1.5 text-xs text-gray-600 hover:text-red-400 transition-colors"
+                                                    title="Remove from account"
+                                                >
+                                                    <TrashIcon className="h-3.5 w-3.5" />
+                                                    Remove from account
+                                                </button>
+                                            </>
+                                        )}
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    )}
+                </Section>
+            </div>
+        </>
+    );
+}


### PR DESCRIPTION
## Summary

- Profile page now shows a compact Devices section with an add-device form and nav cards linking to /profile/sensors and /profile/sockets
- Sensor and socket management (rename, remove) moved to dedicated sub-pages
- Shared DeviceManagePage component eliminates duplication between the two sub-pages
- Settings, Notifications, and Your data sections remain on the profile page