### PR TITLE
feat: add cookie banner toggle to admin site settings

### DIFF
--- a/src/app/(protected)/admin/page.tsx
+++ b/src/app/(protected)/admin/page.tsx
@@ -11,7 +11,7 @@ import ConfirmModal from '@/components/ConfirmModal';
 import { toast } from 'sonner';
 
 const TimeSeriesChart = dynamic(() => import('@/components/TimeSeriesChart'), { ssr: false });
-import AdminService, { AdminStats, AdminUser, StatSnapshot, EmailStats } from '@/services/adminService';
+import AdminService, { AdminStats, AdminUser, StatSnapshot, EmailStats, AppSettings } from '@/services/adminService';
 
 type StatKey = 'totalUsers' | 'totalSensors' | 'totalSwitches' | 'totalAutomations';
 
@@ -50,6 +50,9 @@ export default function AdminPage() {
     const [userSearch, setUserSearch] = useState('');
     const [userPage, setUserPage] = useState(0);
     const PAGE_SIZE = 10;
+
+    const [appSettings, setAppSettings] = useState<AppSettings | null>(null);
+    const [appSettingsLoading, setAppSettingsLoading] = useState(false);
 
     const load = useCallback(async () => {
         setLoading(true);
@@ -90,6 +93,26 @@ export default function AdminPage() {
     useEffect(() => {
         if (isAdmin) load();
     }, [isAdmin, load]);
+
+    useEffect(() => {
+        if (!isAdmin) return;
+        AdminService.getAppSettings()
+            .then(setAppSettings)
+            .catch(() => toast.error('Failed to load app settings'));
+    }, [isAdmin]);
+
+    const handleToggleAppSetting = async <K extends keyof AppSettings>(key: K, value: AppSettings[K]) => {
+        setAppSettingsLoading(true);
+        try {
+            const updated = await AdminService.updateAppSettings({ [key]: value });
+            setAppSettings(updated);
+            toast.success('Setting updated');
+        } catch {
+            toast.error('Failed to update setting');
+        } finally {
+            setAppSettingsLoading(false);
+        }
+    };
 
     const handleAssignRole = async (user: AdminUser) => {
         if (!selectedRole) return;
@@ -256,6 +279,30 @@ export default function AdminPage() {
                         ) : (
                             <p className="text-xs text-gray-500">No data.</p>
                         )}
+                    </Section>
+
+                    {/* Site Settings */}
+                    <Section title="Site Settings">
+                        <div className="space-y-3">
+                            <div className="flex items-center justify-between bg-gray-900/50 border border-gray-700/40 rounded-xl p-4">
+                                <div>
+                                    <p className="text-sm font-medium text-gray-200">Cookie consent banner</p>
+                                    <p className="text-xs text-gray-500 mt-0.5">Show banner asking users to accept cookies</p>
+                                </div>
+                                {appSettings === null ? (
+                                    <div className="w-10 h-6 bg-gray-700 rounded-full animate-pulse shrink-0" />
+                                ) : (
+                                    <button
+                                        onClick={() => handleToggleAppSetting('cookieBannerEnabled', !appSettings.cookieBannerEnabled)}
+                                        disabled={appSettingsLoading}
+                                        aria-label="Toggle cookie banner"
+                                        className={`relative shrink-0 w-10 h-6 rounded-full transition-colors disabled:opacity-50 ${appSettings.cookieBannerEnabled ? 'bg-sky-600' : 'bg-gray-600'}`}
+                                    >
+                                        <span className={`absolute top-1 left-0 w-4 h-4 bg-white rounded-full shadow transition-transform ${appSettings.cookieBannerEnabled ? 'translate-x-5' : 'translate-x-1'}`} />
+                                    </button>
+                                )}
+                            </div>
+                        </div>
                     </Section>
 
                     {/* Users */}

--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -12,15 +12,28 @@ export default function CookieBanner() {
     const [visible, setVisible] = useState(false);
 
     useEffect(() => {
-        try {
-            const raw = localStorage.getItem(STORAGE_KEY);
-            const record: ConsentRecord | null = raw ? JSON.parse(raw) : null;
-            if (!record || record.version !== CONSENT_VERSION) {
+        async function init() {
+            try {
+                const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/admin/settings`);
+                if (res.ok) {
+                    const settings = await res.json();
+                    if (!settings.cookieBannerEnabled) return;
+                }
+            } catch {
+                // backend unreachable — fall through to consent check
+            }
+
+            try {
+                const raw = localStorage.getItem(STORAGE_KEY);
+                const record: ConsentRecord | null = raw ? JSON.parse(raw) : null;
+                if (!record || record.version !== CONSENT_VERSION) {
+                    setVisible(true);
+                }
+            } catch {
                 setVisible(true);
             }
-        } catch {
-            setVisible(true);
         }
+        init();
     }, []);
 
     function dismiss() {

--- a/src/services/adminService.ts
+++ b/src/services/adminService.ts
@@ -43,6 +43,10 @@ export interface EmailStats {
     days: number;
 }
 
+export interface AppSettings {
+    cookieBannerEnabled: boolean;
+}
+
 const AdminService = {
     async getStats(): Promise<AdminStats> {
         const res = await axiosInstance.get<AdminStats>('/admin/stats');
@@ -85,6 +89,16 @@ const AdminService = {
 
     async getEmailStats(days = 30): Promise<EmailStats> {
         const res = await axiosInstance.get<EmailStats>('/admin/email-stats', { params: { days } });
+        return res.data;
+    },
+
+    async getAppSettings(): Promise<AppSettings> {
+        const res = await axiosInstance.get<AppSettings>('/admin/settings');
+        return res.data;
+    },
+
+    async updateAppSettings(patch: Partial<AppSettings>): Promise<AppSettings> {
+        const res = await axiosInstance.put<AppSettings>('/admin/settings', patch);
         return res.data;
     },
 };

--- a/src/tests/services/adminService.test.ts
+++ b/src/tests/services/adminService.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import AdminService, { EmailStats } from '@/services/adminService'
+import AdminService, { AppSettings, EmailStats } from '@/services/adminService'
 
 vi.mock('@/services/axiosInstance', () => ({
     default: {
         get: vi.fn(),
         post: vi.fn(),
+        put: vi.fn(),
         delete: vi.fn(),
     },
 }))
@@ -12,6 +13,7 @@ vi.mock('@/services/axiosInstance', () => ({
 import axiosInstance from '@/services/axiosInstance'
 
 const mockGet = axiosInstance.get as ReturnType<typeof vi.fn>
+const mockPut = axiosInstance.put as ReturnType<typeof vi.fn>
 
 beforeEach(() => {
     vi.clearAllMocks()
@@ -51,5 +53,37 @@ describe('AdminService.getEmailStats', () => {
         mockGet.mockResolvedValueOnce({ data: { ...mockEmailStats, days: 90 } })
         await AdminService.getEmailStats(90)
         expect(mockGet).toHaveBeenCalledWith('/admin/email-stats', { params: { days: 90 } })
+    })
+})
+
+describe('AdminService.getAppSettings', () => {
+    const mockSettings: AppSettings = { cookieBannerEnabled: true }
+
+    it('returns app settings from API', async () => {
+        mockGet.mockResolvedValueOnce({ data: mockSettings })
+        const result = await AdminService.getAppSettings()
+        expect(result).toEqual(mockSettings)
+    })
+
+    it('calls correct endpoint', async () => {
+        mockGet.mockResolvedValueOnce({ data: mockSettings })
+        await AdminService.getAppSettings()
+        expect(mockGet).toHaveBeenCalledWith('/admin/settings')
+    })
+})
+
+describe('AdminService.updateAppSettings', () => {
+    it('calls PUT with correct endpoint and body', async () => {
+        const updated: AppSettings = { cookieBannerEnabled: false }
+        mockPut.mockResolvedValueOnce({ data: updated })
+        const result = await AdminService.updateAppSettings({ cookieBannerEnabled: false })
+        expect(mockPut).toHaveBeenCalledWith('/admin/settings', { cookieBannerEnabled: false })
+        expect(result).toEqual(updated)
+    })
+
+    it('returns updated settings from response', async () => {
+        mockPut.mockResolvedValueOnce({ data: { cookieBannerEnabled: true } })
+        const result = await AdminService.updateAppSettings({ cookieBannerEnabled: true })
+        expect(result.cookieBannerEnabled).toBe(true)
     })
 })


### PR DESCRIPTION
## Summary
- Admin page gets new Site Settings section with cookie banner toggle
- CookieBanner fetches GET /api/admin/settings on mount — hides if admin disabled it
- adminService gets getAppSettings() and updateAppSettings() methods
- Falls back to showing banner if backend is unreachable