### PR TITLE
fix: use standalone output to reduce inotify watchers in k8s

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:23.10.0-slim
+FROM node:23.10.0-slim AS builder
 
 ARG NEXT_PUBLIC_API_URL
 ENV NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL}
@@ -15,6 +15,16 @@ ENV NODE_ENV=production
 
 RUN npm run build
 
+FROM node:23.10.0-slim AS runner
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+COPY --from=builder /app/.next/standalone ./
+COPY --from=builder /app/.next/static ./.next/static
+COPY --from=builder /app/public ./public
+
 EXPOSE 3000
 
-CMD ["npm", "start"]
+CMD ["node", "server.js"]

--- a/next.config.ts
+++ b/next.config.ts
@@ -12,6 +12,7 @@ function getApiOrigin(): string {
 }
 
 const nextConfig: NextConfig = {
+    output: 'standalone',
     images: {
         qualities: [75, 100],
     },


### PR DESCRIPTION
## Summary
- Next.js with `next start` creates inotify file watchers via chokidar, exhausting node-level `fs.inotify.max_user_instances` in Kubernetes
- Enable `output: 'standalone'` in `next.config.ts` — builds a minimal standalone server with only required files, dramatically reducing the number of file watchers
- Update `Dockerfile` to multi-stage build: builder stage compiles, runner stage copies only `.next/standalone`, `.next/static`, and `public`

## Test plan
- [ ] Build Docker image and verify it starts correctly
- [ ] Deploy to Kubernetes and verify `failed to create fsnotify watcher: too many open files` error is gone
- [ ] Verify app loads and all pages function correctly
- [ ] Verify `NEXT_PUBLIC_API_URL` build arg still propagates correctly