### PR TITLE
fix: make push notification toggle per-device

### DIFF
--- a/src/app/(protected)/profile/page.tsx
+++ b/src/app/(protected)/profile/page.tsx
@@ -107,7 +107,7 @@ const Profile: React.FC = () => {
                 toast.success('Offline alerts enabled');
             } else {
                 await unsubscribeFromPush();
-                await UserService.updatePreferences(user.id, { priceZone, pushNotificationsEnabled: false });
+                await UserService.updatePreferences(user.id, { priceZone });
                 setPushEnabled(false);
                 toast.success('Offline alerts disabled');
             }
@@ -138,7 +138,7 @@ const Profile: React.FC = () => {
         setOfflineThreshold(clamped);
         setThresholdSaving(true);
         try {
-            await UserService.updatePreferences(user.id, { priceZone, pushNotificationsEnabled: pushEnabled, offlineAlertThresholdHours: clamped });
+            await UserService.updatePreferences(user.id, { priceZone, offlineAlertThresholdHours: clamped });
         } catch { /* silent */ }
         finally { setThresholdSaving(false); }
     };


### PR DESCRIPTION
## Summary

- Unsubscribing on device B no longer sets global `pushNotificationsEnabled=false`, which was breaking notifications on already-subscribed devices
- Threshold changes no longer write the global flag either
- Per-device toggle state is driven by `isPushSubscribed()` (local PushManager), not the server-side flag