### PR TITLE
feat: shop and billing pages for Vipps payments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ yarn-error.log*
 next-env.d.ts
 
 .vs
+
+# playwright
+playwright-report/
+test-results/

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -58,23 +58,27 @@ const Login: React.FC = () => {
 
                     <form onSubmit={handleLogin} className="space-y-4">
                         <div>
-                            <label className="block text-xs font-medium text-gray-400 mb-1.5">Email</label>
+                            <label htmlFor="email" className="block text-xs font-medium text-gray-400 mb-1.5">Email</label>
                             <input
+                                id="email"
                                 className={inputClass}
                                 type="email"
                                 placeholder="you@example.com"
+                                required
                                 value={email}
                                 onChange={(e) => setEmail(e.target.value)}
                             />
                         </div>
 
                         <div>
-                            <label className="block text-xs font-medium text-gray-400 mb-1.5">Password</label>
+                            <label htmlFor="password" className="block text-xs font-medium text-gray-400 mb-1.5">Password</label>
                             <div className="relative">
                                 <input
+                                    id="password"
                                     className={`${inputClass} pr-10`}
                                     type={showPassword ? 'text' : 'password'}
                                     placeholder="••••••••"
+                                    required
                                     value={password}
                                     onChange={(e) => setPassword(e.target.value)}
                                 />

--- a/src/app/(protected)/admin/orders/page.tsx
+++ b/src/app/(protected)/admin/orders/page.tsx
@@ -6,11 +6,23 @@ import { ArrowLeftIcon } from '@heroicons/react/24/outline';
 import Section from '@/components/Section';
 import LoadingDots from '@/components/LoadingDots';
 import ConfirmModal from '@/components/ConfirmModal';
+import TestPill from '@/components/TestPill';
 import { toast } from 'sonner';
 import ShopService, { AdminOrder } from '@/services/shopService';
 import { formatNok } from '@/lib/formatUtils';
 import { formatDate } from '@/lib/dateUtils';
 import { statusColor } from '@/lib/statusUtils';
+import { formatApiError } from '@/lib/errorMessages';
+
+const RESERVATION_DAYS = 7;
+
+function reservationCountdown(createdAt: string): { days: number; expired: boolean } {
+    const created = new Date(createdAt).getTime();
+    const expiry = created + RESERVATION_DAYS * 24 * 60 * 60 * 1000;
+    const remainingMs = expiry - Date.now();
+    const days = Math.ceil(remainingMs / (24 * 60 * 60 * 1000));
+    return { days, expired: remainingMs <= 0 };
+}
 
 export default function AdminOrdersPage() {
     const [orders, setOrders] = useState<AdminOrder[]>([]);
@@ -23,8 +35,8 @@ export default function AdminOrdersPage() {
         async function load() {
             try {
                 setOrders(await ShopService.getAllOrders());
-            } catch {
-                toast.error('Failed to load orders');
+            } catch (err) {
+                toast.error(formatApiError(err, 'Failed to load orders'));
             } finally {
                 setLoading(false);
             }
@@ -39,8 +51,8 @@ export default function AdminOrdersPage() {
             toast.success(`Order #${captureTarget.id} captured`);
             setOrders(prev => prev.map(o => o.id === captureTarget.id ? { ...o, status: 'Paid' as const } : o));
             setCaptureTarget(null);
-        } catch {
-            toast.error('Failed to capture order');
+        } catch (err) {
+            toast.error(formatApiError(err, 'Failed to capture order'));
         }
     }
 
@@ -51,16 +63,16 @@ export default function AdminOrdersPage() {
             toast.success(`Order #${cancelTarget.id} cancelled`);
             setOrders(prev => prev.map(o => o.id === cancelTarget.id ? { ...o, status: 'Cancelled' as const } : o));
             setCancelTarget(null);
-        } catch {
-            toast.error('Failed to cancel order');
+        } catch (err) {
+            toast.error(formatApiError(err, 'Failed to cancel order'));
         }
     }
 
     return (
         <div className="max-w-3xl mx-auto px-4 py-6 space-y-5 pb-32">
             <div className="flex items-center gap-3">
-                <Link href="/admin" className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-gray-700/60 transition-all">
-                    <ArrowLeftIcon className="h-4 w-4" />
+                <Link href="/admin" className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-gray-700/60 transition-all" aria-label="Back to admin">
+                    <ArrowLeftIcon className="h-4 w-4" aria-hidden />
                 </Link>
                 <h1 className="text-xl font-display font-bold text-gray-100">Orders</h1>
             </div>
@@ -73,53 +85,66 @@ export default function AdminOrdersPage() {
                         <p className="text-sm text-gray-500">No orders yet.</p>
                     ) : (
                         <ul className="space-y-3">
-                            {orders.map(order => (
-                                <li key={order.id} className="bg-gray-900/40 border border-gray-700/30 rounded-xl p-4 space-y-3">
-                                    <div className="flex items-start justify-between gap-3">
-                                        <div>
-                                            <p className="text-sm font-medium text-gray-100">
-                                                Order #{order.id}
-                                            </p>
-                                            <p className="text-xs text-gray-500 mt-0.5">
-                                                {order.userName} · {order.userEmail}
-                                            </p>
-                                            <p className="text-xs text-gray-600 mt-0.5">{formatDate(order.createdAt)}</p>
+                            {orders.map(order => {
+                                const reserved = order.status === 'Reserved';
+                                const countdown = reserved ? reservationCountdown(order.createdAt) : null;
+                                return (
+                                    <li key={order.id} className="bg-gray-900/40 border border-gray-700/30 rounded-xl p-4 space-y-3">
+                                        <div className="flex items-start justify-between gap-3">
+                                            <div>
+                                                <div className="flex items-center gap-2">
+                                                    <p className="text-sm font-medium text-gray-100">Order #{order.id}</p>
+                                                    <TestPill visible={order.isTest} />
+                                                </div>
+                                                <p className="text-xs text-gray-500 mt-0.5">
+                                                    {order.userName} · {order.userEmail}
+                                                </p>
+                                                <p className="text-xs text-gray-600 mt-0.5">{formatDate(order.createdAt)}</p>
+                                            </div>
+                                            <div className="flex flex-col items-end gap-1.5">
+                                                <span className={`px-2 py-0.5 border rounded text-xs font-medium ${statusColor(order.status)}`}>
+                                                    {order.status}
+                                                </span>
+                                                <span className="text-xs font-medium text-gray-300">{formatNok(order.totalInOre)}</span>
+                                            </div>
                                         </div>
-                                        <div className="flex flex-col items-end gap-1.5">
-                                            <span className={`px-2 py-0.5 border rounded text-xs font-medium ${statusColor(order.status)}`}>
-                                                {order.status}
-                                            </span>
-                                            <span className="text-xs font-medium text-gray-300">{formatNok(order.totalInOre)}</span>
-                                        </div>
-                                    </div>
 
-                                    <ul className="space-y-0.5">
-                                        {order.items.map(oi => (
-                                            <li key={oi.id} className="text-xs text-gray-400 flex justify-between">
-                                                <span>{oi.shopItemName} × {oi.quantity}</span>
-                                                <span>{formatNok(oi.priceAtPurchaseInOre * oi.quantity)}</span>
-                                            </li>
-                                        ))}
-                                    </ul>
+                                        {countdown && (
+                                            <p className={`text-xs ${countdown.expired ? 'text-red-400' : countdown.days <= 2 ? 'text-red-400' : countdown.days <= 4 ? 'text-amber-400' : 'text-gray-500'}`}>
+                                                {countdown.expired
+                                                    ? 'Reservation expired — capture before Vipps releases the hold.'
+                                                    : `Reservation expires in ${countdown.days} day${countdown.days === 1 ? '' : 's'}.`}
+                                            </p>
+                                        )}
 
-                                    {order.status === 'Reserved' && (
-                                        <div className="flex gap-2 pt-1">
-                                            <button
-                                                onClick={() => setCaptureTarget(order)}
-                                                className="px-3 py-1.5 bg-green-600/80 hover:bg-green-500 text-white text-xs font-medium rounded-lg transition-colors"
-                                            >
-                                                Capture payment
-                                            </button>
-                                            <button
-                                                onClick={() => setCancelTarget(order)}
-                                                className="px-3 py-1.5 bg-gray-700/60 hover:bg-red-900/40 border border-gray-600/40 hover:border-red-700/50 text-gray-400 hover:text-red-400 text-xs rounded-lg transition-all"
-                                            >
-                                                Cancel order
-                                            </button>
-                                        </div>
-                                    )}
-                                </li>
-                            ))}
+                                        <ul className="space-y-0.5">
+                                            {order.items.map(oi => (
+                                                <li key={oi.id} className="text-xs text-gray-400 flex justify-between">
+                                                    <span>{oi.shopItemName} × {oi.quantity}</span>
+                                                    <span>{formatNok(oi.priceAtPurchaseInOre * oi.quantity)}</span>
+                                                </li>
+                                            ))}
+                                        </ul>
+
+                                        {reserved && (
+                                            <div className="flex gap-2 pt-1">
+                                                <button
+                                                    onClick={() => setCaptureTarget(order)}
+                                                    className="px-3 py-1.5 bg-green-600/80 hover:bg-green-500 text-white text-xs font-medium rounded-lg transition-colors"
+                                                >
+                                                    Capture payment
+                                                </button>
+                                                <button
+                                                    onClick={() => setCancelTarget(order)}
+                                                    className="px-3 py-1.5 bg-gray-700/60 hover:bg-red-900/40 border border-gray-600/40 hover:border-red-700/50 text-gray-400 hover:text-red-400 text-xs rounded-lg transition-all"
+                                                >
+                                                    Cancel order
+                                                </button>
+                                            </div>
+                                        )}
+                                    </li>
+                                );
+                            })}
                         </ul>
                     )}
                 </Section>

--- a/src/app/(protected)/admin/orders/page.tsx
+++ b/src/app/(protected)/admin/orders/page.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { ArrowLeftIcon } from '@heroicons/react/24/outline';
+import Section from '@/components/Section';
+import LoadingDots from '@/components/LoadingDots';
+import ConfirmModal from '@/components/ConfirmModal';
+import { toast } from 'sonner';
+import ShopService, { AdminOrder } from '@/services/shopService';
+import { formatNok } from '@/lib/formatUtils';
+import { formatDate } from '@/lib/dateUtils';
+import { statusColor } from '@/lib/statusUtils';
+
+export default function AdminOrdersPage() {
+    const [orders, setOrders] = useState<AdminOrder[]>([]);
+    const [loading, setLoading] = useState(true);
+
+    const [captureTarget, setCaptureTarget] = useState<AdminOrder | null>(null);
+    const [cancelTarget, setCancelTarget] = useState<AdminOrder | null>(null);
+
+    useEffect(() => {
+        async function load() {
+            try {
+                setOrders(await ShopService.getAllOrders());
+            } catch {
+                toast.error('Failed to load orders');
+            } finally {
+                setLoading(false);
+            }
+        }
+        load();
+    }, []);
+
+    async function handleCapture() {
+        if (!captureTarget) return;
+        try {
+            await ShopService.captureOrder(captureTarget.id);
+            toast.success(`Order #${captureTarget.id} captured`);
+            setOrders(prev => prev.map(o => o.id === captureTarget.id ? { ...o, status: 'Paid' as const } : o));
+            setCaptureTarget(null);
+        } catch {
+            toast.error('Failed to capture order');
+        }
+    }
+
+    async function handleCancel() {
+        if (!cancelTarget) return;
+        try {
+            await ShopService.cancelOrder(cancelTarget.id);
+            toast.success(`Order #${cancelTarget.id} cancelled`);
+            setOrders(prev => prev.map(o => o.id === cancelTarget.id ? { ...o, status: 'Cancelled' as const } : o));
+            setCancelTarget(null);
+        } catch {
+            toast.error('Failed to cancel order');
+        }
+    }
+
+    return (
+        <div className="max-w-3xl mx-auto px-4 py-6 space-y-5 pb-32">
+            <div className="flex items-center gap-3">
+                <Link href="/admin" className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-gray-700/60 transition-all">
+                    <ArrowLeftIcon className="h-4 w-4" />
+                </Link>
+                <h1 className="text-xl font-display font-bold text-gray-100">Orders</h1>
+            </div>
+
+            {loading ? (
+                <LoadingDots height="h-32" />
+            ) : (
+                <Section title={`All orders (${orders.length})`}>
+                    {orders.length === 0 ? (
+                        <p className="text-sm text-gray-500">No orders yet.</p>
+                    ) : (
+                        <ul className="space-y-3">
+                            {orders.map(order => (
+                                <li key={order.id} className="bg-gray-900/40 border border-gray-700/30 rounded-xl p-4 space-y-3">
+                                    <div className="flex items-start justify-between gap-3">
+                                        <div>
+                                            <p className="text-sm font-medium text-gray-100">
+                                                Order #{order.id}
+                                            </p>
+                                            <p className="text-xs text-gray-500 mt-0.5">
+                                                {order.userName} · {order.userEmail}
+                                            </p>
+                                            <p className="text-xs text-gray-600 mt-0.5">{formatDate(order.createdAt)}</p>
+                                        </div>
+                                        <div className="flex flex-col items-end gap-1.5">
+                                            <span className={`px-2 py-0.5 border rounded text-xs font-medium ${statusColor(order.status)}`}>
+                                                {order.status}
+                                            </span>
+                                            <span className="text-xs font-medium text-gray-300">{formatNok(order.totalInOre)}</span>
+                                        </div>
+                                    </div>
+
+                                    <ul className="space-y-0.5">
+                                        {order.items.map(oi => (
+                                            <li key={oi.id} className="text-xs text-gray-400 flex justify-between">
+                                                <span>{oi.shopItemName} × {oi.quantity}</span>
+                                                <span>{formatNok(oi.priceAtPurchaseInOre * oi.quantity)}</span>
+                                            </li>
+                                        ))}
+                                    </ul>
+
+                                    {order.status === 'Reserved' && (
+                                        <div className="flex gap-2 pt-1">
+                                            <button
+                                                onClick={() => setCaptureTarget(order)}
+                                                className="px-3 py-1.5 bg-green-600/80 hover:bg-green-500 text-white text-xs font-medium rounded-lg transition-colors"
+                                            >
+                                                Capture payment
+                                            </button>
+                                            <button
+                                                onClick={() => setCancelTarget(order)}
+                                                className="px-3 py-1.5 bg-gray-700/60 hover:bg-red-900/40 border border-gray-600/40 hover:border-red-700/50 text-gray-400 hover:text-red-400 text-xs rounded-lg transition-all"
+                                            >
+                                                Cancel order
+                                            </button>
+                                        </div>
+                                    )}
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                </Section>
+            )}
+
+            {captureTarget && (
+                <ConfirmModal
+                    title="Capture payment"
+                    message={`Capture ${formatNok(captureTarget.totalInOre)} for order #${captureTarget.id} from ${captureTarget.userName}? Only do this when the order has been shipped.`}
+                    confirmLabel="Capture"
+                    onConfirm={handleCapture}
+                    onCancel={() => setCaptureTarget(null)}
+                />
+            )}
+
+            {cancelTarget && (
+                <ConfirmModal
+                    title="Cancel order"
+                    message={`Cancel order #${cancelTarget.id} and release the reserved payment of ${formatNok(cancelTarget.totalInOre)}?`}
+                    confirmLabel="Cancel order"
+                    onConfirm={handleCancel}
+                    onCancel={() => setCancelTarget(null)}
+                />
+            )}
+        </div>
+    );
+}

--- a/src/app/(protected)/admin/page.tsx
+++ b/src/app/(protected)/admin/page.tsx
@@ -321,6 +321,24 @@ export default function AdminPage() {
                                     </button>
                                 )}
                             </div>
+                            <div className="flex items-center justify-between bg-gray-900/50 border border-amber-700/30 rounded-xl p-4">
+                                <div>
+                                    <p className="text-sm font-medium text-gray-200">Vipps test mode</p>
+                                    <p className="text-xs text-gray-500 mt-0.5">Use Vipps test environment. Test subscriptions only gate access while this is on.</p>
+                                </div>
+                                {appSettings === null ? (
+                                    <div className="w-10 h-6 bg-gray-700 rounded-full animate-pulse shrink-0" />
+                                ) : (
+                                    <button
+                                        onClick={() => handleToggleAppSetting('vippsTestMode', !appSettings.vippsTestMode)}
+                                        disabled={appSettingsLoading}
+                                        aria-label="Toggle Vipps test mode"
+                                        className={`relative shrink-0 w-10 h-6 rounded-full transition-colors disabled:opacity-50 ${appSettings.vippsTestMode ? 'bg-amber-500' : 'bg-gray-600'}`}
+                                    >
+                                        <span className={`absolute top-1 left-0 w-4 h-4 bg-white rounded-full shadow transition-transform ${appSettings.vippsTestMode ? 'translate-x-5' : 'translate-x-1'}`} />
+                                    </button>
+                                )}
+                            </div>
                         </div>
                     </Section>
 

--- a/src/app/(protected)/admin/page.tsx
+++ b/src/app/(protected)/admin/page.tsx
@@ -16,7 +16,7 @@ import AdminService, { AdminStats, AdminUser, StatSnapshot, EmailStats, AppSetti
 
 type StatKey = 'totalUsers' | 'totalSensors' | 'totalSwitches' | 'totalAutomations';
 
-const ALL_ROLES = ['Admin', 'Default', 'Electricity', 'SensorAdmin', 'MqttAdmin', 'AutomationAdmin', 'SwitchAdmin'];
+const ALL_ROLES = ['Admin', 'Default', 'Electricity', 'SensorAdmin', 'MqttAdmin', 'AutomationAdmin', 'SwitchAdmin', 'ComplimentaryUser'];
 
 
 export default function AdminPage() {

--- a/src/app/(protected)/admin/page.tsx
+++ b/src/app/(protected)/admin/page.tsx
@@ -3,7 +3,8 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { useSession } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
-import { TrashIcon, PlusIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import Link from 'next/link';
+import { TrashIcon, PlusIcon, XMarkIcon, ChevronRightIcon } from '@heroicons/react/24/outline';
 import dynamic from 'next/dynamic';
 import Section from '@/components/Section';
 import LoadingDots from '@/components/LoadingDots';
@@ -302,6 +303,47 @@ export default function AdminPage() {
                                     </button>
                                 )}
                             </div>
+                            <div className="flex items-center justify-between bg-gray-900/50 border border-gray-700/40 rounded-xl p-4">
+                                <div>
+                                    <p className="text-sm font-medium text-gray-200">VAT (mva 25%)</p>
+                                    <p className="text-xs text-gray-500 mt-0.5">Add 25% VAT to prices. Disable if below the 50,000 NOK threshold.</p>
+                                </div>
+                                {appSettings === null ? (
+                                    <div className="w-10 h-6 bg-gray-700 rounded-full animate-pulse shrink-0" />
+                                ) : (
+                                    <button
+                                        onClick={() => handleToggleAppSetting('vatEnabled', !appSettings.vatEnabled)}
+                                        disabled={appSettingsLoading}
+                                        aria-label="Toggle VAT"
+                                        className={`relative shrink-0 w-10 h-6 rounded-full transition-colors disabled:opacity-50 ${appSettings.vatEnabled ? 'bg-sky-600' : 'bg-gray-600'}`}
+                                    >
+                                        <span className={`absolute top-1 left-0 w-4 h-4 bg-white rounded-full shadow transition-transform ${appSettings.vatEnabled ? 'translate-x-5' : 'translate-x-1'}`} />
+                                    </button>
+                                )}
+                            </div>
+                        </div>
+                    </Section>
+
+                    {/* Management */}
+                    <Section title="Manage">
+                        <div className="space-y-2">
+                            {([
+                                { href: '/admin/products', label: 'Subscription Plans', description: 'Create and manage monthly/yearly plans' },
+                                { href: '/admin/shop', label: 'Shop Items', description: 'Manage physical products and stock' },
+                                { href: '/admin/orders', label: 'Orders', description: 'View and capture or cancel shop orders' },
+                            ]).map(({ href, label, description }) => (
+                                <Link
+                                    key={href}
+                                    href={href}
+                                    className="flex items-center justify-between bg-gray-900/40 border border-gray-700/30 rounded-xl p-4 hover:border-gray-600/60 hover:bg-gray-900/60 transition-all group"
+                                >
+                                    <div>
+                                        <p className="text-sm font-medium text-gray-200 group-hover:text-gray-100">{label}</p>
+                                        <p className="text-xs text-gray-500 mt-0.5">{description}</p>
+                                    </div>
+                                    <ChevronRightIcon className="h-4 w-4 text-gray-600 group-hover:text-gray-400 shrink-0" />
+                                </Link>
+                            ))}
                         </div>
                     </Section>
 

--- a/src/app/(protected)/admin/products/page.tsx
+++ b/src/app/(protected)/admin/products/page.tsx
@@ -12,7 +12,7 @@ import { toast } from 'sonner';
 import ProductService, { Product, CreateProductPayload, UpdateProductPayload } from '@/services/productService';
 import { formatNok } from '@/lib/formatUtils';
 
-const emptyForm = { name: '', description: '', priceNok: '', interval: 0 as 0 | 1 };
+const emptyForm = { name: '', description: '', priceNok: '', interval: 0 as 0 | 1, type: 0 as 0 | 1 };
 
 export default function AdminProductsPage() {
     const { data: session, status } = useSession();
@@ -57,6 +57,7 @@ export default function AdminProductsPage() {
             description: p.description ?? '',
             priceNok: (p.priceInOre / 100).toFixed(2),
             interval: p.interval === 'Monthly' ? 0 : 1,
+            type: p.type === 'Primary' ? 0 : 1,
         });
         setShowForm(true);
     }
@@ -80,6 +81,7 @@ export default function AdminProductsPage() {
                     description: form.description.trim() || undefined,
                     priceInOre,
                     interval: form.interval,
+                    type: form.type,
                     isActive: editTarget.isActive,
                 };
                 await ProductService.updateProduct(editTarget.id, payload);
@@ -90,6 +92,7 @@ export default function AdminProductsPage() {
                     description: form.description.trim() || undefined,
                     priceInOre,
                     interval: form.interval,
+                    type: form.type,
                 };
                 await ProductService.createProduct(payload);
                 toast.success('Plan created');
@@ -144,7 +147,10 @@ export default function AdminProductsPage() {
                                         <div className="flex items-center gap-2 flex-wrap">
                                             <span className="text-sm font-semibold text-gray-100">{p.name}</span>
                                             <span className="text-xs font-medium text-sky-400">
-                                                {formatNok(p.priceInOre)} / {p.interval === 'Monthly' ? 'mnd' : 'år'}
+                                                {formatNok(p.priceInOre)} / {p.interval === 'Monthly' ? 'mo' : 'yr'}
+                                            </span>
+                                            <span className={`px-1.5 py-0.5 border rounded text-xs font-medium ${p.type === 'Primary' ? 'bg-sky-900/30 border-sky-700/40 text-sky-400' : 'bg-purple-900/30 border-purple-700/40 text-purple-400'}`}>
+                                                {p.type === 'Primary' ? 'Primary' : 'Add-on'}
                                             </span>
                                             {!p.isActive && (
                                                 <span className="px-1.5 py-0.5 bg-gray-700/50 border border-gray-600/40 text-gray-500 text-xs rounded">Inactive</span>
@@ -213,6 +219,14 @@ export default function AdminProductsPage() {
                                     >
                                         <option value={0}>Monthly</option>
                                         <option value={1}>Yearly</option>
+                                    </select>
+                                    <select
+                                        value={form.type}
+                                        onChange={e => setForm(f => ({ ...f, type: Number(e.target.value) as 0 | 1 }))}
+                                        className="bg-gray-900/60 border border-gray-700/60 rounded-lg px-3 py-2 text-sm text-gray-100 focus:outline-none focus:border-sky-500/60"
+                                    >
+                                        <option value={0}>Primary</option>
+                                        <option value={1}>Add-on</option>
                                     </select>
                                 </div>
                                 <div className="flex gap-2">

--- a/src/app/(protected)/admin/products/page.tsx
+++ b/src/app/(protected)/admin/products/page.tsx
@@ -1,0 +1,258 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useSession } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { ArrowLeftIcon, PencilSquareIcon, TrashIcon, PlusIcon } from '@heroicons/react/24/outline';
+import Section from '@/components/Section';
+import LoadingDots from '@/components/LoadingDots';
+import ConfirmModal from '@/components/ConfirmModal';
+import { toast } from 'sonner';
+import ProductService, { Product, CreateProductPayload, UpdateProductPayload } from '@/services/productService';
+import { formatNok } from '@/lib/formatUtils';
+
+const emptyForm = { name: '', description: '', priceNok: '', interval: 0 as 0 | 1 };
+
+export default function AdminProductsPage() {
+    const { data: session, status } = useSession();
+    const router = useRouter();
+
+    const roles: string[] = (session?.user as { roles?: string[] })?.roles ?? [];
+    const isAdmin = roles.includes('Admin');
+
+    useEffect(() => {
+        if (status === 'authenticated' && !isAdmin) router.push('/');
+    }, [status, isAdmin, router]);
+
+    const [products, setProducts] = useState<Product[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [showForm, setShowForm] = useState(false);
+    const [editTarget, setEditTarget] = useState<Product | null>(null);
+    const [deleteTarget, setDeleteTarget] = useState<Product | null>(null);
+    const [form, setForm] = useState(emptyForm);
+    const [saving, setSaving] = useState(false);
+
+    async function refresh() {
+        const all = await ProductService.getProducts();
+        setProducts(all);
+    }
+
+    useEffect(() => {
+        if (!isAdmin) return;
+        setLoading(true);
+        refresh().catch(() => toast.error('Failed to load plans')).finally(() => setLoading(false));
+    }, [isAdmin]);
+
+    function openCreate() {
+        setEditTarget(null);
+        setForm(emptyForm);
+        setShowForm(true);
+    }
+
+    function openEdit(p: Product) {
+        setEditTarget(p);
+        setForm({
+            name: p.name,
+            description: p.description ?? '',
+            priceNok: (p.priceInOre / 100).toFixed(2),
+            interval: p.interval === 'Monthly' ? 0 : 1,
+        });
+        setShowForm(true);
+    }
+
+    function closeForm() {
+        setShowForm(false);
+        setEditTarget(null);
+    }
+
+    async function handleSave() {
+        const priceInOre = Math.round(parseFloat(form.priceNok) * 100);
+        if (!form.name.trim() || isNaN(priceInOre) || priceInOre < 1) {
+            toast.error('Name and valid price required');
+            return;
+        }
+        setSaving(true);
+        try {
+            if (editTarget) {
+                const payload: UpdateProductPayload = {
+                    name: form.name.trim(),
+                    description: form.description.trim() || undefined,
+                    priceInOre,
+                    interval: form.interval,
+                    isActive: editTarget.isActive,
+                };
+                await ProductService.updateProduct(editTarget.id, payload);
+                toast.success('Plan updated');
+            } else {
+                const payload: CreateProductPayload = {
+                    name: form.name.trim(),
+                    description: form.description.trim() || undefined,
+                    priceInOre,
+                    interval: form.interval,
+                };
+                await ProductService.createProduct(payload);
+                toast.success('Plan created');
+            }
+            closeForm();
+            await refresh();
+        } catch {
+            toast.error('Failed to save plan');
+        } finally {
+            setSaving(false);
+        }
+    }
+
+    async function handleDelete() {
+        if (!deleteTarget) return;
+        try {
+            await ProductService.deleteProduct(deleteTarget.id);
+            toast.success(`Deleted ${deleteTarget.name}`);
+            setDeleteTarget(null);
+            await refresh();
+        } catch {
+            toast.error('Failed to delete plan');
+            setDeleteTarget(null);
+        }
+    }
+
+    if (status === 'loading' || (status === 'authenticated' && !isAdmin)) {
+        return <LoadingDots height="h-64" />;
+    }
+
+    return (
+        <div className="max-w-3xl mx-auto px-4 py-6 space-y-5 pb-32">
+            <div className="flex items-center gap-3">
+                <Link href="/admin" className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-gray-700/60 transition-all">
+                    <ArrowLeftIcon className="h-4 w-4" />
+                </Link>
+                <h1 className="text-xl font-display font-bold text-gray-100">Subscription Plans</h1>
+            </div>
+
+            <Section title="Plans">
+                {loading ? (
+                    <LoadingDots height="h-16" />
+                ) : (
+                    <>
+                        <ul className="space-y-2 mb-4">
+                            {products.length === 0 && !showForm && (
+                                <p className="text-sm text-gray-500">No plans yet.</p>
+                            )}
+                            {products.map(p => (
+                                <li key={p.id} className="bg-gray-900/40 border border-gray-700/30 rounded-xl p-4 flex items-center justify-between gap-3">
+                                    <div className="min-w-0">
+                                        <div className="flex items-center gap-2 flex-wrap">
+                                            <span className="text-sm font-semibold text-gray-100">{p.name}</span>
+                                            <span className="text-xs font-medium text-sky-400">
+                                                {formatNok(p.priceInOre)} / {p.interval === 'Monthly' ? 'mnd' : 'år'}
+                                            </span>
+                                            {!p.isActive && (
+                                                <span className="px-1.5 py-0.5 bg-gray-700/50 border border-gray-600/40 text-gray-500 text-xs rounded">Inactive</span>
+                                            )}
+                                        </div>
+                                        {p.description && (
+                                            <p className="text-xs text-gray-500 mt-1">{p.description}</p>
+                                        )}
+                                    </div>
+                                    <div className="flex items-center gap-1 shrink-0">
+                                        <button
+                                            onClick={() => openEdit(p)}
+                                            className="p-1.5 rounded-lg text-gray-500 hover:text-sky-400 hover:bg-gray-700/60 transition-all"
+                                            title="Edit"
+                                        >
+                                            <PencilSquareIcon className="h-4 w-4" />
+                                        </button>
+                                        <button
+                                            onClick={() => setDeleteTarget(p)}
+                                            className="p-1.5 rounded-lg text-gray-500 hover:text-red-400 hover:bg-gray-700/60 transition-all"
+                                            title="Delete"
+                                        >
+                                            <TrashIcon className="h-4 w-4" />
+                                        </button>
+                                    </div>
+                                </li>
+                            ))}
+                        </ul>
+
+                        {showForm ? (
+                            <div className="bg-gray-900/40 border border-gray-700/30 rounded-xl p-4 space-y-3">
+                                <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
+                                    {editTarget ? 'Edit plan' : 'New plan'}
+                                </p>
+                                <input
+                                    type="text"
+                                    value={form.name}
+                                    onChange={e => setForm(f => ({ ...f, name: e.target.value }))}
+                                    placeholder="Name"
+                                    className="w-full bg-gray-900/60 border border-gray-700/60 rounded-lg px-3 py-2 text-sm text-gray-100 placeholder-gray-600 focus:outline-none focus:border-sky-500/60"
+                                />
+                                <input
+                                    type="text"
+                                    value={form.description}
+                                    onChange={e => setForm(f => ({ ...f, description: e.target.value }))}
+                                    placeholder="Description (optional)"
+                                    className="w-full bg-gray-900/60 border border-gray-700/60 rounded-lg px-3 py-2 text-sm text-gray-100 placeholder-gray-600 focus:outline-none focus:border-sky-500/60"
+                                />
+                                <div className="flex gap-2">
+                                    <div className="relative flex-1">
+                                        <span className="absolute left-3 top-1/2 -translate-y-1/2 text-xs text-gray-500 pointer-events-none">NOK</span>
+                                        <input
+                                            type="number"
+                                            value={form.priceNok}
+                                            onChange={e => setForm(f => ({ ...f, priceNok: e.target.value }))}
+                                            placeholder="0.00"
+                                            step="0.01"
+                                            min="0.01"
+                                            className="w-full bg-gray-900/60 border border-gray-700/60 rounded-lg pl-11 pr-3 py-2 text-sm text-gray-100 placeholder-gray-600 focus:outline-none focus:border-sky-500/60"
+                                        />
+                                    </div>
+                                    <select
+                                        value={form.interval}
+                                        onChange={e => setForm(f => ({ ...f, interval: Number(e.target.value) as 0 | 1 }))}
+                                        className="bg-gray-900/60 border border-gray-700/60 rounded-lg px-3 py-2 text-sm text-gray-100 focus:outline-none focus:border-sky-500/60"
+                                    >
+                                        <option value={0}>Monthly</option>
+                                        <option value={1}>Yearly</option>
+                                    </select>
+                                </div>
+                                <div className="flex gap-2">
+                                    <button
+                                        onClick={handleSave}
+                                        disabled={saving}
+                                        className="px-4 py-2 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors"
+                                    >
+                                        {saving ? 'Saving…' : 'Save'}
+                                    </button>
+                                    <button
+                                        onClick={closeForm}
+                                        className="px-4 py-2 bg-gray-700/60 hover:bg-gray-700 text-gray-300 text-sm rounded-lg transition-colors"
+                                    >
+                                        Cancel
+                                    </button>
+                                </div>
+                            </div>
+                        ) : (
+                            <button
+                                onClick={openCreate}
+                                className="flex items-center gap-2 px-3 py-2 bg-gray-700/50 hover:bg-gray-700 border border-gray-600/40 rounded-lg text-sm text-gray-400 hover:text-gray-200 transition-all"
+                            >
+                                <PlusIcon className="h-4 w-4" />
+                                Add plan
+                            </button>
+                        )}
+                    </>
+                )}
+            </Section>
+
+            {deleteTarget && (
+                <ConfirmModal
+                    title="Delete plan"
+                    message={<>Delete <span className="font-medium text-gray-100">{deleteTarget.name}</span>? Existing subscriptions are unaffected.</>}
+                    confirmLabel="Delete"
+                    onConfirm={handleDelete}
+                    onCancel={() => setDeleteTarget(null)}
+                />
+            )}
+        </div>
+    );
+}

--- a/src/app/(protected)/admin/shop/page.tsx
+++ b/src/app/(protected)/admin/shop/page.tsx
@@ -1,0 +1,260 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useSession } from 'next-auth/react';
+import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { ArrowLeftIcon, PencilSquareIcon, TrashIcon, PlusIcon } from '@heroicons/react/24/outline';
+import Section from '@/components/Section';
+import LoadingDots from '@/components/LoadingDots';
+import ConfirmModal from '@/components/ConfirmModal';
+import { toast } from 'sonner';
+import ShopService, { ShopItem, CreateShopItemPayload, UpdateShopItemPayload } from '@/services/shopService';
+import { formatNok } from '@/lib/formatUtils';
+
+const emptyForm = { name: '', description: '', priceNok: '', stock: '-1' };
+
+export default function AdminShopPage() {
+    const { data: session, status } = useSession();
+    const router = useRouter();
+
+    const roles: string[] = (session?.user as { roles?: string[] })?.roles ?? [];
+    const isAdmin = roles.includes('Admin');
+
+    useEffect(() => {
+        if (status === 'authenticated' && !isAdmin) router.push('/');
+    }, [status, isAdmin, router]);
+
+    const [items, setItems] = useState<ShopItem[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [showForm, setShowForm] = useState(false);
+    const [editTarget, setEditTarget] = useState<ShopItem | null>(null);
+    const [deleteTarget, setDeleteTarget] = useState<ShopItem | null>(null);
+    const [form, setForm] = useState(emptyForm);
+    const [saving, setSaving] = useState(false);
+
+    async function refresh() {
+        const all = await ShopService.getShopItems();
+        setItems(all);
+    }
+
+    useEffect(() => {
+        if (!isAdmin) return;
+        setLoading(true);
+        refresh().catch(() => toast.error('Failed to load items')).finally(() => setLoading(false));
+    }, [isAdmin]);
+
+    function openCreate() {
+        setEditTarget(null);
+        setForm(emptyForm);
+        setShowForm(true);
+    }
+
+    function openEdit(item: ShopItem) {
+        setEditTarget(item);
+        setForm({
+            name: item.name,
+            description: item.description ?? '',
+            priceNok: (item.priceInOre / 100).toFixed(2),
+            stock: item.stockCount.toString(),
+        });
+        setShowForm(true);
+    }
+
+    function closeForm() {
+        setShowForm(false);
+        setEditTarget(null);
+    }
+
+    async function handleSave() {
+        const priceInOre = Math.round(parseFloat(form.priceNok) * 100);
+        const stockCount = parseInt(form.stock, 10);
+        if (!form.name.trim() || isNaN(priceInOre) || priceInOre < 1) {
+            toast.error('Name and valid price required');
+            return;
+        }
+        setSaving(true);
+        try {
+            const stock = isNaN(stockCount) ? -1 : stockCount;
+            if (editTarget) {
+                const payload: UpdateShopItemPayload = {
+                    name: form.name.trim(),
+                    description: form.description.trim() || undefined,
+                    priceInOre,
+                    stockCount: stock,
+                    isActive: editTarget.isActive,
+                };
+                await ShopService.updateShopItem(editTarget.id, payload);
+                toast.success('Item updated');
+            } else {
+                const payload: CreateShopItemPayload = {
+                    name: form.name.trim(),
+                    description: form.description.trim() || undefined,
+                    priceInOre,
+                    stockCount: stock,
+                };
+                await ShopService.createShopItem(payload);
+                toast.success('Item created');
+            }
+            closeForm();
+            await refresh();
+        } catch {
+            toast.error('Failed to save item');
+        } finally {
+            setSaving(false);
+        }
+    }
+
+    async function handleDelete() {
+        if (!deleteTarget) return;
+        try {
+            await ShopService.deleteShopItem(deleteTarget.id);
+            toast.success(`Deleted ${deleteTarget.name}`);
+            setDeleteTarget(null);
+            await refresh();
+        } catch {
+            toast.error('Failed to delete item');
+            setDeleteTarget(null);
+        }
+    }
+
+    if (status === 'loading' || (status === 'authenticated' && !isAdmin)) {
+        return <LoadingDots height="h-64" />;
+    }
+
+    return (
+        <div className="max-w-3xl mx-auto px-4 py-6 space-y-5 pb-32">
+            <div className="flex items-center gap-3">
+                <Link href="/admin" className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-gray-700/60 transition-all">
+                    <ArrowLeftIcon className="h-4 w-4" />
+                </Link>
+                <h1 className="text-xl font-display font-bold text-gray-100">Shop Items</h1>
+            </div>
+
+            <Section title="Items">
+                {loading ? (
+                    <LoadingDots height="h-16" />
+                ) : (
+                    <>
+                        <ul className="space-y-2 mb-4">
+                            {items.length === 0 && !showForm && (
+                                <p className="text-sm text-gray-500">No items yet.</p>
+                            )}
+                            {items.map(item => (
+                                <li key={item.id} className="bg-gray-900/40 border border-gray-700/30 rounded-xl p-4 flex items-center justify-between gap-3">
+                                    <div className="min-w-0">
+                                        <div className="flex items-center gap-2 flex-wrap">
+                                            <span className="text-sm font-semibold text-gray-100">{item.name}</span>
+                                            <span className="text-xs font-medium text-sky-400">{formatNok(item.priceInOre)}</span>
+                                            <span className="text-xs text-gray-600">
+                                                {item.stockCount === -1 ? 'Unlimited' : `${item.stockCount} in stock`}
+                                            </span>
+                                            {!item.isActive && (
+                                                <span className="px-1.5 py-0.5 bg-gray-700/50 border border-gray-600/40 text-gray-500 text-xs rounded">Inactive</span>
+                                            )}
+                                        </div>
+                                        {item.description && (
+                                            <p className="text-xs text-gray-500 mt-1">{item.description}</p>
+                                        )}
+                                    </div>
+                                    <div className="flex items-center gap-1 shrink-0">
+                                        <button
+                                            onClick={() => openEdit(item)}
+                                            className="p-1.5 rounded-lg text-gray-500 hover:text-sky-400 hover:bg-gray-700/60 transition-all"
+                                            title="Edit"
+                                        >
+                                            <PencilSquareIcon className="h-4 w-4" />
+                                        </button>
+                                        <button
+                                            onClick={() => setDeleteTarget(item)}
+                                            className="p-1.5 rounded-lg text-gray-500 hover:text-red-400 hover:bg-gray-700/60 transition-all"
+                                            title="Delete"
+                                        >
+                                            <TrashIcon className="h-4 w-4" />
+                                        </button>
+                                    </div>
+                                </li>
+                            ))}
+                        </ul>
+
+                        {showForm ? (
+                            <div className="bg-gray-900/40 border border-gray-700/30 rounded-xl p-4 space-y-3">
+                                <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
+                                    {editTarget ? 'Edit item' : 'New item'}
+                                </p>
+                                <input
+                                    type="text"
+                                    value={form.name}
+                                    onChange={e => setForm(f => ({ ...f, name: e.target.value }))}
+                                    placeholder="Name"
+                                    className="w-full bg-gray-900/60 border border-gray-700/60 rounded-lg px-3 py-2 text-sm text-gray-100 placeholder-gray-600 focus:outline-none focus:border-sky-500/60"
+                                />
+                                <input
+                                    type="text"
+                                    value={form.description}
+                                    onChange={e => setForm(f => ({ ...f, description: e.target.value }))}
+                                    placeholder="Description (optional)"
+                                    className="w-full bg-gray-900/60 border border-gray-700/60 rounded-lg px-3 py-2 text-sm text-gray-100 placeholder-gray-600 focus:outline-none focus:border-sky-500/60"
+                                />
+                                <div className="flex gap-2">
+                                    <div className="relative flex-1">
+                                        <span className="absolute left-3 top-1/2 -translate-y-1/2 text-xs text-gray-500 pointer-events-none">NOK</span>
+                                        <input
+                                            type="number"
+                                            value={form.priceNok}
+                                            onChange={e => setForm(f => ({ ...f, priceNok: e.target.value }))}
+                                            placeholder="0.00"
+                                            step="0.01"
+                                            min="0.01"
+                                            className="w-full bg-gray-900/60 border border-gray-700/60 rounded-lg pl-11 pr-3 py-2 text-sm text-gray-100 placeholder-gray-600 focus:outline-none focus:border-sky-500/60"
+                                        />
+                                    </div>
+                                    <input
+                                        type="number"
+                                        value={form.stock}
+                                        onChange={e => setForm(f => ({ ...f, stock: e.target.value }))}
+                                        placeholder="Stock (-1 = ∞)"
+                                        className="w-36 bg-gray-900/60 border border-gray-700/60 rounded-lg px-3 py-2 text-sm text-gray-100 placeholder-gray-600 focus:outline-none focus:border-sky-500/60"
+                                    />
+                                </div>
+                                <div className="flex gap-2">
+                                    <button
+                                        onClick={handleSave}
+                                        disabled={saving}
+                                        className="px-4 py-2 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors"
+                                    >
+                                        {saving ? 'Saving…' : 'Save'}
+                                    </button>
+                                    <button
+                                        onClick={closeForm}
+                                        className="px-4 py-2 bg-gray-700/60 hover:bg-gray-700 text-gray-300 text-sm rounded-lg transition-colors"
+                                    >
+                                        Cancel
+                                    </button>
+                                </div>
+                            </div>
+                        ) : (
+                            <button
+                                onClick={openCreate}
+                                className="flex items-center gap-2 px-3 py-2 bg-gray-700/50 hover:bg-gray-700 border border-gray-600/40 rounded-lg text-sm text-gray-400 hover:text-gray-200 transition-all"
+                            >
+                                <PlusIcon className="h-4 w-4" />
+                                Add item
+                            </button>
+                        )}
+                    </>
+                )}
+            </Section>
+
+            {deleteTarget && (
+                <ConfirmModal
+                    title="Delete item"
+                    message={<>Delete <span className="font-medium text-gray-100">{deleteTarget.name}</span>? Existing orders are unaffected.</>}
+                    confirmLabel="Delete"
+                    onConfirm={handleDelete}
+                    onCancel={() => setDeleteTarget(null)}
+                />
+            )}
+        </div>
+    );
+}

--- a/src/app/(protected)/profile/billing/page.tsx
+++ b/src/app/(protected)/profile/billing/page.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { ArrowLeftIcon } from '@heroicons/react/24/outline';
+import Section from '@/components/Section';
+import LoadingDots from '@/components/LoadingDots';
+import ConfirmModal from '@/components/ConfirmModal';
+import { toast } from 'sonner';
+import AdminService, { AppSettings } from '@/services/adminService';
+import SubscriptionService, { Subscription } from '@/services/subscriptionService';
+import ShopService, { Order } from '@/services/shopService';
+import { formatNok } from '@/lib/formatUtils';
+import { formatDate } from '@/lib/dateUtils';
+import { statusColor } from '@/lib/statusUtils';
+
+function effectivePrice(priceInOre: number, vatEnabled: boolean): number {
+    return vatEnabled ? Math.round(priceInOre * 1.25) : priceInOre;
+}
+
+function vatLabel(vatEnabled: boolean): string {
+    return vatEnabled ? 'inkl. mva' : 'ekskl. mva';
+}
+
+export default function BillingPage() {
+    const [subscription, setSubscription] = useState<Subscription | null>(null);
+    const [orders, setOrders] = useState<Order[]>([]);
+    const [appSettings, setAppSettings] = useState<AppSettings | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [cancelConfirm, setCancelConfirm] = useState(false);
+
+    useEffect(() => {
+        async function load() {
+            try {
+                const [sub, myOrders, settings] = await Promise.all([
+                    SubscriptionService.getMySubscription(),
+                    ShopService.getMyOrders(),
+                    AdminService.getAppSettings(),
+                ]);
+                setSubscription(sub);
+                setOrders(myOrders);
+                setAppSettings(settings);
+            } catch {
+                toast.error('Failed to load billing data');
+            } finally {
+                setLoading(false);
+            }
+        }
+        load();
+    }, []);
+
+    const vatEnabled = appSettings?.vatEnabled ?? false;
+    const hasActive = subscription?.status === 'Active' || subscription?.status === 'Pending';
+
+    async function handleCancel() {
+        await SubscriptionService.cancelSubscription();
+        toast.success('Subscription cancelled');
+        setCancelConfirm(false);
+        const sub = await SubscriptionService.getMySubscription();
+        setSubscription(sub);
+    }
+
+    if (loading) return <LoadingDots height="h-64" />;
+
+    return (
+        <div className="max-w-2xl mx-auto px-4 py-6 space-y-5 pb-32">
+            <div className="flex items-center gap-3">
+                <Link href="/profile" className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-gray-700/60 transition-all">
+                    <ArrowLeftIcon className="h-4 w-4" />
+                </Link>
+                <h1 className="text-xl font-display font-bold text-gray-100">Billing</h1>
+            </div>
+
+            <Section title="Subscription">
+                {hasActive && subscription ? (
+                    <div className="bg-gray-900/40 border border-gray-700/30 rounded-xl p-4 space-y-3">
+                        <div className="flex items-start justify-between gap-3">
+                            <div>
+                                <p className="text-sm font-semibold text-gray-100">{subscription.productName}</p>
+                                <p className="text-xs text-gray-500 mt-0.5">
+                                    {formatNok(effectivePrice(subscription.priceInOre, vatEnabled))} / {subscription.interval === 'Monthly' ? 'month' : 'year'} · {vatLabel(vatEnabled)}
+                                </p>
+                            </div>
+                            <span className={`px-2 py-0.5 border rounded text-xs font-medium ${statusColor(subscription.status)}`}>
+                                {subscription.status}
+                            </span>
+                        </div>
+                        <div className="grid grid-cols-2 gap-2 text-xs">
+                            <div>
+                                <p className="text-gray-600">Start date</p>
+                                <p className="text-gray-400 mt-0.5">{subscription.startDate ? formatDate(subscription.startDate) : '—'}</p>
+                            </div>
+                            <div>
+                                <p className="text-gray-600">Next charge</p>
+                                <p className="text-gray-400 mt-0.5">{subscription.nextChargeDate ? formatDate(subscription.nextChargeDate) : '—'}</p>
+                            </div>
+                        </div>
+                        {subscription.status === 'Active' && (
+                            <button
+                                onClick={() => setCancelConfirm(true)}
+                                className="mt-1 px-3 py-1.5 bg-gray-700/60 hover:bg-red-900/40 hover:border-red-700/50 border border-gray-600/40 text-gray-400 hover:text-red-400 text-xs rounded-lg transition-all"
+                            >
+                                Cancel subscription
+                            </button>
+                        )}
+                    </div>
+                ) : (
+                    <div className="flex flex-col items-start gap-3 py-1">
+                        <p className="text-sm text-gray-500">No active subscription.</p>
+                        <Link
+                            href="/shop"
+                            className="px-4 py-2 bg-sky-600 hover:bg-sky-500 text-white text-sm font-medium rounded-lg transition-colors"
+                        >
+                            Browse plans
+                        </Link>
+                    </div>
+                )}
+            </Section>
+
+            {orders.length > 0 && (
+                <Section title="Order history">
+                    <ul className="space-y-2">
+                        {orders.map(order => (
+                            <li key={order.id} className="bg-gray-900/40 border border-gray-700/30 rounded-xl p-4 space-y-2">
+                                <div className="flex items-center justify-between gap-2">
+                                    <p className="text-xs text-gray-500">{formatDate(order.createdAt)}</p>
+                                    <div className="flex items-center gap-2">
+                                        <span className="text-xs font-medium text-gray-300">{formatNok(order.totalInOre)}</span>
+                                        <span className={`px-2 py-0.5 border rounded text-xs font-medium ${statusColor(order.status)}`}>
+                                            {order.status}
+                                        </span>
+                                    </div>
+                                </div>
+                                <ul className="space-y-0.5">
+                                    {order.items.map(oi => (
+                                        <li key={oi.id} className="text-xs text-gray-400 flex justify-between">
+                                            <span>{oi.shopItemName} × {oi.quantity}</span>
+                                            <span>{formatNok(oi.priceAtPurchaseInOre * oi.quantity)}</span>
+                                        </li>
+                                    ))}
+                                </ul>
+                            </li>
+                        ))}
+                    </ul>
+                </Section>
+            )}
+
+            {cancelConfirm && (
+                <ConfirmModal
+                    title="Cancel subscription"
+                    message={`Cancel your subscription? You keep access until ${subscription?.nextChargeDate ? formatDate(subscription.nextChargeDate) : 'the end of the current period'}.`}
+                    confirmLabel="Cancel subscription"
+                    onConfirm={handleCancel}
+                    onCancel={() => setCancelConfirm(false)}
+                />
+            )}
+        </div>
+    );
+}

--- a/src/app/(protected)/profile/billing/page.tsx
+++ b/src/app/(protected)/profile/billing/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { ArrowLeftIcon } from '@heroicons/react/24/outline';
 import Section from '@/components/Section';
 import LoadingDots from '@/components/LoadingDots';
+import TestModeBanner from '@/components/TestModeBanner';
 import ConfirmModal from '@/components/ConfirmModal';
 import { toast } from 'sonner';
 import AdminService, { AppSettings } from '@/services/adminService';
@@ -71,11 +72,7 @@ export default function BillingPage() {
                 <h1 className="text-xl font-display font-bold text-gray-100">Billing</h1>
             </div>
 
-            {appSettings?.vippsTestMode && (
-                <div className="bg-amber-500/10 border border-amber-500/30 rounded-xl px-4 py-3">
-                    <p className="text-xs font-medium text-amber-400">Vipps test mode is active — no real payments will be processed</p>
-                </div>
-            )}
+            <TestModeBanner settings={appSettings} />
 
             <Section title="Subscription">
                 {hasActive && subscription ? (

--- a/src/app/(protected)/profile/billing/page.tsx
+++ b/src/app/(protected)/profile/billing/page.tsx
@@ -2,10 +2,12 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { ArrowLeftIcon } from '@heroicons/react/24/outline';
+import { ArrowLeftIcon, ArrowDownTrayIcon, ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
 import Section from '@/components/Section';
 import LoadingDots from '@/components/LoadingDots';
 import TestModeBanner from '@/components/TestModeBanner';
+import TestPill from '@/components/TestPill';
+import RedirectingOverlay from '@/components/RedirectingOverlay';
 import ConfirmModal from '@/components/ConfirmModal';
 import { toast } from 'sonner';
 import AdminService, { AppSettings } from '@/services/adminService';
@@ -14,35 +16,43 @@ import ShopService, { Order } from '@/services/shopService';
 import { formatNok } from '@/lib/formatUtils';
 import { formatDate } from '@/lib/dateUtils';
 import { statusColor } from '@/lib/statusUtils';
+import { effectivePriceInOre, vatLabel } from '@/lib/pricing';
+import { formatApiError } from '@/lib/errorMessages';
 
-function effectivePrice(priceInOre: number, vatEnabled: boolean): number {
-    return vatEnabled ? Math.round(priceInOre * 1.25) : priceInOre;
-}
-
-function vatLabel(vatEnabled: boolean): string {
-    return vatEnabled ? 'inkl. mva' : 'ekskl. mva';
+function deriveCancelEndDate(sub: Subscription): string {
+    if (sub.nextChargeDate) return formatDate(sub.nextChargeDate);
+    if (sub.startDate) {
+        const d = new Date(sub.startDate);
+        if (sub.interval === 'Monthly') d.setMonth(d.getMonth() + 1);
+        else d.setFullYear(d.getFullYear() + 1);
+        return formatDate(d.toISOString());
+    }
+    return 'the end of the current period';
 }
 
 export default function BillingPage() {
-    const [subscription, setSubscription] = useState<Subscription | null>(null);
+    const [subscriptions, setSubscriptions] = useState<Subscription[]>([]);
     const [orders, setOrders] = useState<Order[]>([]);
     const [appSettings, setAppSettings] = useState<AppSettings | null>(null);
     const [loading, setLoading] = useState(true);
-    const [cancelConfirm, setCancelConfirm] = useState(false);
+    const [cancelTarget, setCancelTarget] = useState<Subscription | null>(null);
+    const [resuming, setResuming] = useState<number | null>(null);
+    const [downloading, setDownloading] = useState<number | null>(null);
+    const [redirecting, setRedirecting] = useState(false);
 
     useEffect(() => {
         async function load() {
             try {
-                const [sub, myOrders, settings] = await Promise.all([
-                    SubscriptionService.getMySubscription(),
+                const [subs, myOrders, settings] = await Promise.all([
+                    SubscriptionService.getMySubscriptions(),
                     ShopService.getMyOrders(),
                     AdminService.getAppSettings(),
                 ]);
-                setSubscription(sub);
+                setSubscriptions(subs);
                 setOrders(myOrders);
                 setAppSettings(settings);
-            } catch {
-                toast.error('Failed to load billing data');
+            } catch (err) {
+                toast.error(formatApiError(err, 'Failed to load billing data'));
             } finally {
                 setLoading(false);
             }
@@ -51,14 +61,40 @@ export default function BillingPage() {
     }, []);
 
     const vatEnabled = appSettings?.vatEnabled ?? false;
-    const hasActive = subscription?.status === 'Active' || subscription?.status === 'Pending';
 
     async function handleCancel() {
-        await SubscriptionService.cancelSubscription();
-        toast.success('Subscription cancelled');
-        setCancelConfirm(false);
-        const sub = await SubscriptionService.getMySubscription();
-        setSubscription(sub);
+        if (!cancelTarget) return;
+        try {
+            await SubscriptionService.cancelSubscription(cancelTarget.id);
+            toast.success('Subscription cancelled');
+            setCancelTarget(null);
+            setSubscriptions(await SubscriptionService.getMySubscriptions());
+        } catch (err) {
+            toast.error(formatApiError(err, 'Failed to cancel subscription'));
+        }
+    }
+
+    async function handleResume(sub: Subscription) {
+        setResuming(sub.id);
+        try {
+            const url = await SubscriptionService.getConfirmationUrl(sub.id);
+            setRedirecting(true);
+            window.location.href = url;
+        } catch (err) {
+            toast.error(formatApiError(err, 'Could not get Vipps URL'));
+            setResuming(null);
+        }
+    }
+
+    async function handleInvoiceDownload(orderId: number) {
+        setDownloading(orderId);
+        try {
+            await ShopService.downloadInvoice(orderId);
+        } catch (err) {
+            toast.error(formatApiError(err, 'Failed to download invoice'));
+        } finally {
+            setDownloading(null);
+        }
     }
 
     if (loading) return <LoadingDots height="h-64" />;
@@ -67,7 +103,7 @@ export default function BillingPage() {
         <div className="max-w-2xl mx-auto px-4 py-6 space-y-5 pb-32">
             <div className="flex items-center gap-3">
                 <Link href="/profile" className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-gray-700/60 transition-all">
-                    <ArrowLeftIcon className="h-4 w-4" />
+                    <ArrowLeftIcon className="h-4 w-4" aria-hidden />
                 </Link>
                 <h1 className="text-xl font-display font-bold text-gray-100">Billing</h1>
             </div>
@@ -75,38 +111,70 @@ export default function BillingPage() {
             <TestModeBanner settings={appSettings} />
 
             <Section title="Subscription">
-                {hasActive && subscription ? (
-                    <div className="bg-gray-900/40 border border-gray-700/30 rounded-xl p-4 space-y-3">
-                        <div className="flex items-start justify-between gap-3">
-                            <div>
-                                <p className="text-sm font-semibold text-gray-100">{subscription.productName}</p>
-                                <p className="text-xs text-gray-500 mt-0.5">
-                                    {formatNok(effectivePrice(subscription.priceInOre, vatEnabled))} / {subscription.interval === 'Monthly' ? 'month' : 'year'} · {vatLabel(vatEnabled)}
-                                </p>
-                            </div>
-                            <span className={`px-2 py-0.5 border rounded text-xs font-medium ${statusColor(subscription.status)}`}>
-                                {subscription.status}
-                            </span>
-                        </div>
-                        <div className="grid grid-cols-2 gap-2 text-xs">
-                            <div>
-                                <p className="text-gray-600">Start date</p>
-                                <p className="text-gray-400 mt-0.5">{subscription.startDate ? formatDate(subscription.startDate) : '—'}</p>
-                            </div>
-                            <div>
-                                <p className="text-gray-600">Next charge</p>
-                                <p className="text-gray-400 mt-0.5">{subscription.nextChargeDate ? formatDate(subscription.nextChargeDate) : '—'}</p>
-                            </div>
-                        </div>
-                        {subscription.status === 'Active' && (
-                            <button
-                                onClick={() => setCancelConfirm(true)}
-                                className="mt-1 px-3 py-1.5 bg-gray-700/60 hover:bg-red-900/40 hover:border-red-700/50 border border-gray-600/40 text-gray-400 hover:text-red-400 text-xs rounded-lg transition-all"
-                            >
-                                Cancel subscription
-                            </button>
-                        )}
-                    </div>
+                {subscriptions.length > 0 ? (
+                    <ul className="space-y-2">
+                        {subscriptions.map(sub => {
+                            const isStoppedGrace = sub.status === 'Stopped' || sub.status === 'Expired';
+                            return (
+                                <li key={sub.id} className="bg-gray-900/40 border border-gray-700/30 rounded-xl p-4 space-y-3">
+                                    <div className="flex items-start justify-between gap-3">
+                                        <div>
+                                            <div className="flex items-center gap-2 flex-wrap">
+                                                <p className="text-sm font-semibold text-gray-100">{sub.productName}</p>
+                                                <span className={`px-1.5 py-0.5 border rounded text-xs font-medium ${sub.productType === 'Primary' ? 'bg-sky-900/30 border-sky-700/40 text-sky-400' : 'bg-purple-900/30 border-purple-700/40 text-purple-400'}`}>
+                                                    {sub.productType === 'Primary' ? 'Primary' : 'Add-on'}
+                                                </span>
+                                                <TestPill visible={sub.isTest} />
+                                            </div>
+                                            <p className="text-xs text-gray-500 mt-0.5">
+                                                {formatNok(effectivePriceInOre(sub.priceInOre, vatEnabled))} / {sub.interval === 'Monthly' ? 'month' : 'year'} · {vatLabel(vatEnabled)}
+                                            </p>
+                                        </div>
+                                        <span className={`px-2 py-0.5 border rounded text-xs font-medium ${statusColor(sub.status)}`}>
+                                            {sub.status}
+                                        </span>
+                                    </div>
+
+                                    {isStoppedGrace && sub.nextChargeDate && (
+                                        <p className="text-xs text-amber-400">
+                                            Cancelled. You keep access until {formatDate(sub.nextChargeDate)}.
+                                        </p>
+                                    )}
+
+                                    <div className="grid grid-cols-2 gap-2 text-xs">
+                                        <div>
+                                            <p className="text-gray-600">Start date</p>
+                                            <p className="text-gray-400 mt-0.5">{sub.startDate ? formatDate(sub.startDate) : '—'}</p>
+                                        </div>
+                                        <div>
+                                            <p className="text-gray-600">{isStoppedGrace ? 'Access until' : 'Next charge'}</p>
+                                            <p className="text-gray-400 mt-0.5">{sub.nextChargeDate ? formatDate(sub.nextChargeDate) : '—'}</p>
+                                        </div>
+                                    </div>
+
+                                    {sub.status === 'Pending' && (
+                                        <button
+                                            onClick={() => handleResume(sub)}
+                                            disabled={resuming === sub.id}
+                                            className="mt-1 px-3 py-1.5 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 text-white text-xs font-medium rounded-lg transition-colors flex items-center gap-1.5"
+                                        >
+                                            <ArrowTopRightOnSquareIcon className="h-3.5 w-3.5" aria-hidden />
+                                            {resuming === sub.id ? 'Opening Vipps…' : 'Complete in Vipps'}
+                                        </button>
+                                    )}
+
+                                    {sub.status === 'Active' && (
+                                        <button
+                                            onClick={() => setCancelTarget(sub)}
+                                            className="mt-1 px-3 py-1.5 bg-gray-700/60 hover:bg-red-900/40 hover:border-red-700/50 border border-gray-600/40 text-gray-400 hover:text-red-400 text-xs rounded-lg transition-all"
+                                        >
+                                            Cancel
+                                        </button>
+                                    )}
+                                </li>
+                            );
+                        })}
+                    </ul>
                 ) : (
                     <div className="flex flex-col items-start gap-3 py-1">
                         <p className="text-sm text-gray-500">No active subscription.</p>
@@ -126,7 +194,13 @@ export default function BillingPage() {
                         {orders.map(order => (
                             <li key={order.id} className="bg-gray-900/40 border border-gray-700/30 rounded-xl p-4 space-y-2">
                                 <div className="flex items-center justify-between gap-2">
-                                    <p className="text-xs text-gray-500">{formatDate(order.createdAt)}</p>
+                                    <div className="flex items-center gap-2">
+                                        <Link href={`/profile/orders/${order.id}`} className="text-xs font-medium text-gray-300 hover:text-sky-400 transition-colors">
+                                            Order #{order.id}
+                                        </Link>
+                                        <span className="text-xs text-gray-500">{formatDate(order.createdAt)}</span>
+                                        <TestPill visible={order.isTest} />
+                                    </div>
                                     <div className="flex items-center gap-2">
                                         <span className="text-xs font-medium text-gray-300">{formatNok(order.totalInOre)}</span>
                                         <span className={`px-2 py-0.5 border rounded text-xs font-medium ${statusColor(order.status)}`}>
@@ -142,21 +216,42 @@ export default function BillingPage() {
                                         </li>
                                     ))}
                                 </ul>
+                                {order.status === 'Paid' && (
+                                    <button
+                                        onClick={() => handleInvoiceDownload(order.id)}
+                                        disabled={downloading === order.id}
+                                        className="mt-1 inline-flex items-center gap-1.5 px-2.5 py-1 bg-gray-700/40 hover:bg-gray-700 border border-gray-600/40 text-gray-300 text-xs rounded-lg transition-colors disabled:opacity-50"
+                                    >
+                                        <ArrowDownTrayIcon className="h-3.5 w-3.5" aria-hidden />
+                                        {downloading === order.id ? 'Downloading…' : 'Download invoice'}
+                                    </button>
+                                )}
                             </li>
                         ))}
                     </ul>
                 </Section>
             )}
 
-            {cancelConfirm && (
+            {cancelTarget && (
                 <ConfirmModal
                     title="Cancel subscription"
-                    message={`Cancel your subscription? You keep access until ${subscription?.nextChargeDate ? formatDate(subscription.nextChargeDate) : 'the end of the current period'}.`}
+                    message={
+                        <>
+                            <p>Cancel <span className="font-medium text-gray-100">{cancelTarget.productName}</span>? You keep access until {deriveCancelEndDate(cancelTarget)}.</p>
+                            {cancelTarget.productType === 'Primary' && (
+                                <p className="mt-2 text-xs text-amber-400">
+                                    Cancelling Primary also cancels any active add-on subscriptions.
+                                </p>
+                            )}
+                        </>
+                    }
                     confirmLabel="Cancel subscription"
                     onConfirm={handleCancel}
-                    onCancel={() => setCancelConfirm(false)}
+                    onCancel={() => setCancelTarget(null)}
                 />
             )}
+
+            {redirecting && <RedirectingOverlay />}
         </div>
     );
 }

--- a/src/app/(protected)/profile/billing/page.tsx
+++ b/src/app/(protected)/profile/billing/page.tsx
@@ -71,6 +71,12 @@ export default function BillingPage() {
                 <h1 className="text-xl font-display font-bold text-gray-100">Billing</h1>
             </div>
 
+            {appSettings?.vippsTestMode && (
+                <div className="bg-amber-500/10 border border-amber-500/30 rounded-xl px-4 py-3">
+                    <p className="text-xs font-medium text-amber-400">Vipps test mode is active — no real payments will be processed</p>
+                </div>
+            )}
+
             <Section title="Subscription">
                 {hasActive && subscription ? (
                     <div className="bg-gray-900/40 border border-gray-700/30 rounded-xl p-4 space-y-3">

--- a/src/app/(protected)/profile/billing/return/page.tsx
+++ b/src/app/(protected)/profile/billing/return/page.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
+import { CheckCircleIcon, ClockIcon, XCircleIcon } from '@heroicons/react/24/outline';
+import LoadingDots from '@/components/LoadingDots';
+import SubscriptionService, { Subscription } from '@/services/subscriptionService';
+
+export default function BillingReturnPage() {
+    const [subscription, setSubscription] = useState<Subscription | null>(null);
+    const [loading, setLoading] = useState(true);
+    const retried = useRef(false);
+    const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+    useEffect(() => {
+        async function check() {
+            try {
+                const sub = await SubscriptionService.getMySubscription();
+                setSubscription(sub);
+                if (sub?.status === 'Pending' && !retried.current) {
+                    retried.current = true;
+                    timeoutRef.current = setTimeout(async () => {
+                        const sub2 = await SubscriptionService.getMySubscription();
+                        setSubscription(sub2);
+                        setLoading(false);
+                    }, 3000);
+                } else {
+                    setLoading(false);
+                }
+            } catch {
+                setLoading(false);
+            }
+        }
+        check();
+        return () => clearTimeout(timeoutRef.current);
+    }, []);
+
+    if (loading) return <LoadingDots height="h-64" />;
+
+    const status = subscription?.status;
+
+    return (
+        <div className="max-w-md mx-auto px-4 py-12 flex flex-col items-center gap-5 text-center pb-32">
+            {status === 'Active' ? (
+                <>
+                    <CheckCircleIcon className="h-16 w-16 text-green-400" />
+                    <p className="text-xl font-display font-bold text-gray-100">Subscription active!</p>
+                    <p className="text-sm text-gray-500">You now have full access to Garge.</p>
+                    <Link href="/" className="px-5 py-2.5 bg-sky-600 hover:bg-sky-500 text-white text-sm font-medium rounded-lg transition-colors">
+                        Go to dashboard
+                    </Link>
+                </>
+            ) : status === 'Pending' ? (
+                <>
+                    <ClockIcon className="h-16 w-16 text-amber-400" />
+                    <p className="text-xl font-display font-bold text-gray-100">Pending confirmation</p>
+                    <p className="text-sm text-gray-500">Your subscription is being confirmed by Vipps. This usually takes a moment.</p>
+                    <Link href="/profile/billing" className="px-5 py-2.5 bg-gray-700/60 hover:bg-gray-700 text-gray-300 text-sm rounded-lg transition-colors">
+                        Back to billing
+                    </Link>
+                </>
+            ) : (
+                <>
+                    <XCircleIcon className="h-16 w-16 text-red-400" />
+                    <p className="text-xl font-display font-bold text-gray-100">Subscription not found</p>
+                    <p className="text-sm text-gray-500">Something went wrong or the agreement was not completed.</p>
+                    <Link href="/profile/billing" className="px-5 py-2.5 bg-gray-700/60 hover:bg-gray-700 text-gray-300 text-sm rounded-lg transition-colors">
+                        Try again
+                    </Link>
+                </>
+            )}
+        </div>
+    );
+}

--- a/src/app/(protected)/profile/billing/return/page.tsx
+++ b/src/app/(protected)/profile/billing/return/page.tsx
@@ -1,74 +1,45 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
-import Link from 'next/link';
-import { CheckCircleIcon, ClockIcon, XCircleIcon } from '@heroicons/react/24/outline';
 import LoadingDots from '@/components/LoadingDots';
+import ReturnStatusPage from '@/components/ReturnStatusPage';
 import SubscriptionService, { Subscription } from '@/services/subscriptionService';
+import { usePollUntilFinal } from '@/lib/usePollUntilFinal';
 
 export default function BillingReturnPage() {
-    const [subscription, setSubscription] = useState<Subscription | null>(null);
-    const [loading, setLoading] = useState(true);
-    const retried = useRef(false);
-    const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
-
-    useEffect(() => {
-        async function check() {
-            try {
-                const sub = await SubscriptionService.getMySubscription();
-                setSubscription(sub);
-                if (sub?.status === 'Pending' && !retried.current) {
-                    retried.current = true;
-                    timeoutRef.current = setTimeout(async () => {
-                        const sub2 = await SubscriptionService.getMySubscription();
-                        setSubscription(sub2);
-                        setLoading(false);
-                    }, 3000);
-                } else {
-                    setLoading(false);
-                }
-            } catch {
-                setLoading(false);
-            }
-        }
-        check();
-        return () => clearTimeout(timeoutRef.current);
-    }, []);
+    const { data: subscription, loading, refresh } = usePollUntilFinal<Subscription | null>(
+        async () => {
+            const subs = await SubscriptionService.getMySubscriptions();
+            return subs.at(-1) ?? null;
+        },
+        (s) => s != null && s.status !== 'Pending',
+    );
 
     if (loading) return <LoadingDots height="h-64" />;
 
     const status = subscription?.status;
+    const variant = status === 'Active'
+        ? 'success'
+        : status === 'Pending'
+            ? 'pending'
+            : 'failed';
 
     return (
-        <div className="max-w-md mx-auto px-4 py-12 flex flex-col items-center gap-5 text-center pb-32">
-            {status === 'Active' ? (
-                <>
-                    <CheckCircleIcon className="h-16 w-16 text-green-400" />
-                    <p className="text-xl font-display font-bold text-gray-100">Subscription active!</p>
-                    <p className="text-sm text-gray-500">You now have full access to Garge.</p>
-                    <Link href="/" className="px-5 py-2.5 bg-sky-600 hover:bg-sky-500 text-white text-sm font-medium rounded-lg transition-colors">
-                        Go to dashboard
-                    </Link>
-                </>
-            ) : status === 'Pending' ? (
-                <>
-                    <ClockIcon className="h-16 w-16 text-amber-400" />
-                    <p className="text-xl font-display font-bold text-gray-100">Pending confirmation</p>
-                    <p className="text-sm text-gray-500">Your subscription is being confirmed by Vipps. This usually takes a moment.</p>
-                    <Link href="/profile/billing" className="px-5 py-2.5 bg-gray-700/60 hover:bg-gray-700 text-gray-300 text-sm rounded-lg transition-colors">
-                        Back to billing
-                    </Link>
-                </>
-            ) : (
-                <>
-                    <XCircleIcon className="h-16 w-16 text-red-400" />
-                    <p className="text-xl font-display font-bold text-gray-100">Subscription not found</p>
-                    <p className="text-sm text-gray-500">Something went wrong or the agreement was not completed.</p>
-                    <Link href="/profile/billing" className="px-5 py-2.5 bg-gray-700/60 hover:bg-gray-700 text-gray-300 text-sm rounded-lg transition-colors">
-                        Try again
-                    </Link>
-                </>
-            )}
-        </div>
+        <ReturnStatusPage
+            variant={variant}
+            successTitle="Subscription active!"
+            successBody="You now have full access to Garge."
+            successHref="/"
+            successCta="Go to dashboard"
+            pendingTitle="Pending confirmation"
+            pendingBody="Your subscription is being confirmed by Vipps."
+            pendingEmailNote="We'll send a confirmation as soon as Vipps responds."
+            pendingHref="/profile/billing"
+            pendingCta="View billing"
+            onRefresh={refresh}
+            failedTitle="Subscription not found"
+            failedBody="Something went wrong or the agreement was not completed."
+            failedHref="/profile/billing"
+            failedCta="Try again"
+        />
     );
 }

--- a/src/app/(protected)/profile/orders/[id]/page.tsx
+++ b/src/app/(protected)/profile/orders/[id]/page.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { use, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { ArrowLeftIcon, ArrowDownTrayIcon, CheckCircleIcon, ClockIcon, TruckIcon, XCircleIcon } from '@heroicons/react/24/outline';
+import Section from '@/components/Section';
+import LoadingDots from '@/components/LoadingDots';
+import TestPill from '@/components/TestPill';
+import { toast } from 'sonner';
+import ShopService, { Order } from '@/services/shopService';
+import { formatNok } from '@/lib/formatUtils';
+import { formatDate } from '@/lib/dateUtils';
+import { statusColor } from '@/lib/statusUtils';
+import { formatApiError } from '@/lib/errorMessages';
+
+interface TimelineEntry {
+    label: string;
+    timestamp: string | null;
+    icon: typeof CheckCircleIcon;
+    active: boolean;
+}
+
+function buildTimeline(order: Order): TimelineEntry[] {
+    const reachedReserved = ['Reserved', 'Paid', 'Refunded'].includes(order.status);
+    const reachedPaid = ['Paid', 'Refunded'].includes(order.status);
+    const reachedShipped = order.shippedAt != null;
+    const failed = ['Failed', 'Cancelled'].includes(order.status);
+
+    return [
+        { label: 'Order placed',     timestamp: order.createdAt, icon: ClockIcon,        active: true },
+        { label: 'Payment reserved', timestamp: reachedReserved ? order.updatedAt : null, icon: CheckCircleIcon, active: reachedReserved && !failed },
+        { label: 'Payment captured', timestamp: reachedPaid ? order.updatedAt : null,    icon: CheckCircleIcon, active: reachedPaid && !failed },
+        { label: 'Shipped',          timestamp: order.shippedAt,                          icon: TruckIcon,       active: reachedShipped && !failed },
+        ...(failed ? [{ label: order.status, timestamp: order.updatedAt, icon: XCircleIcon, active: true }] : []),
+    ];
+}
+
+export default function OrderDetailPage({ params }: { params: Promise<{ id: string }> }) {
+    const { id } = use(params);
+    const orderId = parseInt(id, 10);
+    const [order, setOrder] = useState<Order | null>(null);
+    const [loading, setLoading] = useState(true);
+    const [downloading, setDownloading] = useState(false);
+
+    useEffect(() => {
+        if (isNaN(orderId)) { setLoading(false); return; }
+        ShopService.getMyOrders()
+            .then(orders => setOrder(orders.find(o => o.id === orderId) ?? null))
+            .catch(err => toast.error(formatApiError(err, 'Failed to load order')))
+            .finally(() => setLoading(false));
+    }, [orderId]);
+
+    async function downloadInvoice() {
+        if (!order) return;
+        setDownloading(true);
+        try {
+            await ShopService.downloadInvoice(order.id);
+        } catch (err) {
+            toast.error(formatApiError(err, 'Failed to download invoice'));
+        } finally {
+            setDownloading(false);
+        }
+    }
+
+    if (loading) return <LoadingDots height="h-64" />;
+
+    if (!order) {
+        return (
+            <div className="max-w-md mx-auto px-4 py-12 text-center space-y-4 pb-32">
+                <p className="text-sm text-gray-400">Order not found.</p>
+                <Link href="/profile/billing" className="text-sky-400 text-sm hover:text-sky-300">Back to billing</Link>
+            </div>
+        );
+    }
+
+    const timeline = buildTimeline(order);
+
+    return (
+        <div className="max-w-2xl mx-auto px-4 py-6 space-y-5 pb-32">
+            <div className="flex items-center gap-3">
+                <Link href="/profile/billing" className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-gray-700/60 transition-all" aria-label="Back to billing">
+                    <ArrowLeftIcon className="h-4 w-4" aria-hidden />
+                </Link>
+                <h1 className="text-xl font-display font-bold text-gray-100">Order #{order.id}</h1>
+                <TestPill visible={order.isTest} />
+                <span className={`ml-auto px-2 py-0.5 border rounded text-xs font-medium ${statusColor(order.status)}`}>
+                    {order.status}
+                </span>
+            </div>
+
+            <Section title="Items">
+                <ul className="space-y-1">
+                    {order.items.map(oi => (
+                        <li key={oi.id} className="flex justify-between text-sm text-gray-300">
+                            <span>{oi.shopItemName} × {oi.quantity}</span>
+                            <span className="tabular-nums">{formatNok(oi.priceAtPurchaseInOre * oi.quantity)}</span>
+                        </li>
+                    ))}
+                </ul>
+                <div className="border-t border-gray-700/40 mt-3 pt-3 flex justify-between text-sm font-semibold text-gray-100">
+                    <span>Total</span>
+                    <span className="tabular-nums">{formatNok(order.totalInOre)}</span>
+                </div>
+            </Section>
+
+            <Section title="Timeline">
+                <ol className="space-y-3">
+                    {timeline.map((entry, i) => {
+                        const Icon = entry.icon;
+                        return (
+                            <li key={i} className="flex items-start gap-3">
+                                <Icon className={`h-5 w-5 shrink-0 ${entry.active ? 'text-green-400' : 'text-gray-700'}`} aria-hidden />
+                                <div>
+                                    <p className={`text-sm font-medium ${entry.active ? 'text-gray-100' : 'text-gray-500'}`}>{entry.label}</p>
+                                    {entry.timestamp && (
+                                        <p className="text-xs text-gray-500 mt-0.5">{formatDate(entry.timestamp)}</p>
+                                    )}
+                                </div>
+                            </li>
+                        );
+                    })}
+                </ol>
+            </Section>
+
+            {order.shippingAddress && (
+                <Section title="Shipping">
+                    <p className="text-sm text-gray-300">{order.shippingAddress}</p>
+                </Section>
+            )}
+
+            {order.vippsOrderId && (
+                <Section title="Payment reference">
+                    <p className="text-xs text-gray-500 break-all">{order.vippsOrderId}</p>
+                </Section>
+            )}
+
+            {order.status === 'Paid' && (
+                <button
+                    onClick={downloadInvoice}
+                    disabled={downloading}
+                    className="inline-flex items-center gap-2 px-4 py-2 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors"
+                >
+                    <ArrowDownTrayIcon className="h-4 w-4" aria-hidden />
+                    {downloading ? 'Downloading…' : 'Download invoice'}
+                </button>
+            )}
+        </div>
+    );
+}

--- a/src/app/(protected)/profile/page.tsx
+++ b/src/app/(protected)/profile/page.tsx
@@ -289,6 +289,22 @@ const Profile: React.FC = () => {
                     )}
                 </Section>
 
+                <Section title="Billing">
+                    <Link
+                        href="/profile/billing"
+                        className="flex items-center justify-between p-3 rounded-xl bg-gray-900/50 border border-gray-700/40 hover:border-gray-600/60 hover:bg-gray-800/50 transition-all group"
+                    >
+                        <div className="flex items-center gap-3">
+                            <span className="text-lg">💳</span>
+                            <div>
+                                <p className="text-sm font-medium text-gray-100">Subscription & orders</p>
+                                <p className="text-xs text-gray-500">Manage plan and view purchase history</p>
+                            </div>
+                        </div>
+                        <ChevronRightIcon className="h-4 w-4 text-gray-600 group-hover:text-gray-400 transition-colors" />
+                    </Link>
+                </Section>
+
                 <Section title="Devices">
                     <div className="space-y-4">
                         <div>

--- a/src/app/(protected)/shop/page.tsx
+++ b/src/app/(protected)/shop/page.tsx
@@ -1,0 +1,249 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import Section from '@/components/Section';
+import LoadingDots from '@/components/LoadingDots';
+import { toast } from 'sonner';
+import AdminService, { AppSettings } from '@/services/adminService';
+import ProductService, { Product } from '@/services/productService';
+import ShopService, { ShopItem } from '@/services/shopService';
+import SubscriptionService from '@/services/subscriptionService';
+import { formatNok } from '@/lib/formatUtils';
+
+function effectivePrice(priceInOre: number, vatEnabled: boolean): number {
+    return vatEnabled ? Math.round(priceInOre * 1.25) : priceInOre;
+}
+
+function vatLabel(vatEnabled: boolean): string {
+    return vatEnabled ? 'inkl. mva' : 'ekskl. mva';
+}
+
+function normalizePhone(raw: string): string {
+    const digits = raw.replace(/\D/g, '');
+    if (digits.startsWith('47') && digits.length >= 10) return digits;
+    if (digits.length === 8) return `47${digits}`;
+    return digits;
+}
+
+export default function ShopPage() {
+    const [items, setItems] = useState<ShopItem[]>([]);
+    const [products, setProducts] = useState<Product[]>([]);
+    const [appSettings, setAppSettings] = useState<AppSettings | null>(null);
+    const [loading, setLoading] = useState(true);
+
+    const [phoneItemModal, setPhoneItemModal] = useState<ShopItem | null>(null);
+    const [phoneSubModal, setPhoneSubModal] = useState<Product | null>(null);
+    const [phone, setPhone] = useState('');
+    const [agreedWithdrawal, setAgreedWithdrawal] = useState(false);
+    const [purchasing, setPurchasing] = useState(false);
+
+    useEffect(() => {
+        Promise.all([
+            ShopService.getShopItems(),
+            ProductService.getProducts(),
+            AdminService.getAppSettings(),
+        ])
+            .then(([shopItems, prods, settings]) => {
+                setItems(shopItems);
+                setProducts(prods);
+                setAppSettings(settings);
+            })
+            .catch(() => toast.error('Failed to load shop'))
+            .finally(() => setLoading(false));
+    }, []);
+
+    const vatEnabled = appSettings?.vatEnabled ?? false;
+
+    async function handleCheckout(item: ShopItem) {
+        if (!phone.trim()) { toast.error('Phone number required'); return; }
+        setPurchasing(true);
+        try {
+            const res = await ShopService.checkout({
+                items: [{ shopItemId: item.id, quantity: 1 }],
+                phoneNumber: phone.trim(),
+                redirectUrl: `${window.location.origin}/shop/return`,
+            });
+            window.location.href = res.redirectUrl;
+        } catch {
+            toast.error('Failed to initiate payment');
+            setPurchasing(false);
+        }
+    }
+
+    async function handleInitiate(product: Product) {
+        if (!phone.trim()) { toast.error('Phone number required'); return; }
+        setPurchasing(true);
+        try {
+            const res = await SubscriptionService.initiateSubscription({
+                productId: product.id,
+                phoneNumber: normalizePhone(phone),
+                redirectUrl: `${window.location.origin}/profile/billing/return`,
+            });
+            window.location.href = res.vippsConfirmationUrl;
+        } catch {
+            toast.error('Failed to initiate subscription');
+            setPurchasing(false);
+        }
+    }
+
+    if (loading) return <LoadingDots height="h-64" />;
+
+    return (
+        <div className="max-w-2xl mx-auto px-4 py-6 space-y-5 pb-32">
+            <h1 className="text-xl font-display font-bold text-gray-100">Shop</h1>
+
+            {items.length > 0 && (
+                <Section title="Products">
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                        {items.map(item => (
+                            <div
+                                key={item.id}
+                                className="bg-gray-900/40 border border-gray-700/30 rounded-xl p-4 flex flex-col gap-3"
+                            >
+                                <div className="flex-1">
+                                    <p className="text-sm font-semibold text-gray-100">{item.name}</p>
+                                    <p className="text-lg font-bold text-sky-400 mt-1">
+                                        {formatNok(effectivePrice(item.priceInOre, vatEnabled))}
+                                        <span className="text-xs font-normal text-gray-500 ml-1">{vatLabel(vatEnabled)}</span>
+                                    </p>
+                                    {item.description && (
+                                        <p className="text-xs text-gray-500 mt-1">{item.description}</p>
+                                    )}
+                                    {item.stockCount !== -1 && item.stockCount > 0 && item.stockCount <= 5 && (
+                                        <p className="text-xs text-amber-400 mt-1">Only {item.stockCount} left</p>
+                                    )}
+                                    {item.stockCount === 0 && (
+                                        <p className="text-xs text-red-400 mt-1">Out of stock</p>
+                                    )}
+                                </div>
+                                <button
+                                    onClick={() => { setPhoneItemModal(item); setPhone(''); }}
+                                    disabled={item.stockCount === 0}
+                                    className="w-full px-4 py-2 bg-sky-600 hover:bg-sky-500 disabled:opacity-40 disabled:cursor-not-allowed text-white text-sm font-medium rounded-lg transition-colors"
+                                >
+                                    Buy
+                                </button>
+                            </div>
+                        ))}
+                    </div>
+                </Section>
+            )}
+
+            <Section title="Subscription plans">
+                {products.length === 0 ? (
+                    <p className="text-sm text-gray-500">No plans available.</p>
+                ) : (
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                        {products.map(p => (
+                            <div key={p.id} className="bg-gray-900/40 border border-gray-700/30 rounded-xl p-4 flex flex-col gap-3">
+                                <div className="flex-1">
+                                    <p className="text-sm font-semibold text-gray-100">{p.name}</p>
+                                    <p className="text-lg font-bold text-sky-400 mt-1">
+                                        {formatNok(effectivePrice(p.priceInOre, vatEnabled))}
+                                        <span className="text-xs font-normal text-gray-500 ml-1">
+                                            / {p.interval === 'Monthly' ? 'month' : 'year'} · {vatLabel(vatEnabled)}
+                                        </span>
+                                    </p>
+                                    {p.description && <p className="text-xs text-gray-500 mt-1">{p.description}</p>}
+                                </div>
+                                <button
+                                    onClick={() => { setPhoneSubModal(p); setPhone(''); setAgreedWithdrawal(false); }}
+                                    className="w-full px-4 py-2 bg-sky-600 hover:bg-sky-500 text-white text-sm font-medium rounded-lg transition-colors"
+                                >
+                                    Subscribe
+                                </button>
+                            </div>
+                        ))}
+                    </div>
+                )}
+            </Section>
+
+            {/* Hardware purchase modal */}
+            {phoneItemModal && (
+                <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
+                    <div className="bg-gray-900 border border-gray-700/60 rounded-2xl p-5 w-full max-w-sm space-y-4">
+                        <p className="text-sm font-semibold text-gray-100">Pay with Vipps</p>
+                        <p className="text-xs text-gray-500">
+                            <span className="text-gray-300">{phoneItemModal.name}</span> — {formatNok(effectivePrice(phoneItemModal.priceInOre, vatEnabled))} {vatLabel(vatEnabled)}
+                        </p>
+                        <input
+                            type="tel"
+                            value={phone}
+                            onChange={e => setPhone(e.target.value)}
+                            placeholder="Phone number"
+                            className="w-full bg-gray-800/60 border border-gray-700/60 rounded-lg px-3 py-2 text-sm text-gray-100 placeholder-gray-600 focus:outline-none focus:border-sky-500/60"
+                        />
+                        <div className="flex gap-2">
+                            <button
+                                onClick={() => handleCheckout(phoneItemModal)}
+                                disabled={purchasing}
+                                className="flex-1 px-4 py-2 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors"
+                            >
+                                {purchasing ? 'Redirecting…' : 'Continue to Vipps'}
+                            </button>
+                            <button
+                                onClick={() => setPhoneItemModal(null)}
+                                className="px-4 py-2 bg-gray-700/60 hover:bg-gray-700 text-gray-300 text-sm rounded-lg transition-colors"
+                            >
+                                Cancel
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {/* Subscription purchase modal */}
+            {phoneSubModal && (
+                <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
+                    <div className="bg-gray-900 border border-gray-700/60 rounded-2xl p-5 w-full max-w-sm space-y-4">
+                        <p className="text-sm font-semibold text-gray-100">Pay with Vipps</p>
+                        <p className="text-xs text-gray-500">
+                            <span className="text-gray-300">{phoneSubModal.name}</span>
+                            {' — '}
+                            {formatNok(effectivePrice(phoneSubModal.priceInOre, vatEnabled))} / {phoneSubModal.interval === 'Monthly' ? 'month' : 'year'}
+                            {' '}· {vatLabel(vatEnabled)}
+                        </p>
+                        <input
+                            type="tel"
+                            value={phone}
+                            onChange={e => setPhone(e.target.value)}
+                            placeholder="Phone number"
+                            className="w-full bg-gray-800/60 border border-gray-700/60 rounded-lg px-3 py-2 text-sm text-gray-100 placeholder-gray-600 focus:outline-none focus:border-sky-500/60"
+                        />
+                        <label className="flex items-start gap-2.5 cursor-pointer">
+                            <input
+                                type="checkbox"
+                                checked={agreedWithdrawal}
+                                onChange={e => setAgreedWithdrawal(e.target.checked)}
+                                className="mt-0.5 accent-sky-500 shrink-0"
+                            />
+                            <span className="text-xs text-gray-500 leading-relaxed">
+                                I request immediate access and waive my 14-day right of withdrawal (angrerettloven).
+                            </span>
+                        </label>
+                        <p className="text-xs text-gray-600">
+                            By continuing you accept our{' '}
+                            <Link href="/terms" className="text-sky-500 hover:text-sky-400 transition-colors">Terms of Service</Link>.
+                        </p>
+                        <div className="flex gap-2">
+                            <button
+                                onClick={() => handleInitiate(phoneSubModal)}
+                                disabled={purchasing || !agreedWithdrawal}
+                                className="flex-1 px-4 py-2 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors"
+                            >
+                                {purchasing ? 'Redirecting…' : 'Continue to Vipps'}
+                            </button>
+                            <button
+                                onClick={() => setPhoneSubModal(null)}
+                                className="px-4 py-2 bg-gray-700/60 hover:bg-gray-700 text-gray-300 text-sm rounded-lg transition-colors"
+                            >
+                                Cancel
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/app/(protected)/shop/page.tsx
+++ b/src/app/(protected)/shop/page.tsx
@@ -93,6 +93,12 @@ export default function ShopPage() {
         <div className="max-w-2xl mx-auto px-4 py-6 space-y-5 pb-32">
             <h1 className="text-xl font-display font-bold text-gray-100">Shop</h1>
 
+            {appSettings?.vippsTestMode && (
+                <div className="bg-amber-500/10 border border-amber-500/30 rounded-xl px-4 py-3">
+                    <p className="text-xs font-medium text-amber-400">Vipps test mode is active — no real payments will be processed</p>
+                </div>
+            )}
+
             {items.length > 0 && (
                 <Section title="Products">
                     <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">

--- a/src/app/(protected)/shop/page.tsx
+++ b/src/app/(protected)/shop/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import Section from '@/components/Section';
 import LoadingDots from '@/components/LoadingDots';
+import TestModeBanner from '@/components/TestModeBanner';
 import { toast } from 'sonner';
 import AdminService, { AppSettings } from '@/services/adminService';
 import ProductService, { Product } from '@/services/productService';
@@ -93,11 +94,7 @@ export default function ShopPage() {
         <div className="max-w-2xl mx-auto px-4 py-6 space-y-5 pb-32">
             <h1 className="text-xl font-display font-bold text-gray-100">Shop</h1>
 
-            {appSettings?.vippsTestMode && (
-                <div className="bg-amber-500/10 border border-amber-500/30 rounded-xl px-4 py-3">
-                    <p className="text-xs font-medium text-amber-400">Vipps test mode is active — no real payments will be processed</p>
-                </div>
-            )}
+            <TestModeBanner settings={appSettings} />
 
             {items.length > 0 && (
                 <Section title="Products">

--- a/src/app/(protected)/shop/page.tsx
+++ b/src/app/(protected)/shop/page.tsx
@@ -1,31 +1,21 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import Link from 'next/link';
+import { MinusIcon, PlusIcon } from '@heroicons/react/24/outline';
 import Section from '@/components/Section';
 import LoadingDots from '@/components/LoadingDots';
 import TestModeBanner from '@/components/TestModeBanner';
+import PaymentPhoneModal from '@/components/PaymentPhoneModal';
+import RedirectingOverlay from '@/components/RedirectingOverlay';
 import { toast } from 'sonner';
 import AdminService, { AppSettings } from '@/services/adminService';
 import ProductService, { Product } from '@/services/productService';
 import ShopService, { ShopItem } from '@/services/shopService';
 import SubscriptionService from '@/services/subscriptionService';
 import { formatNok } from '@/lib/formatUtils';
-
-function effectivePrice(priceInOre: number, vatEnabled: boolean): number {
-    return vatEnabled ? Math.round(priceInOre * 1.25) : priceInOre;
-}
-
-function vatLabel(vatEnabled: boolean): string {
-    return vatEnabled ? 'inkl. mva' : 'ekskl. mva';
-}
-
-function normalizePhone(raw: string): string {
-    const digits = raw.replace(/\D/g, '');
-    if (digits.startsWith('47') && digits.length >= 10) return digits;
-    if (digits.length === 8) return `47${digits}`;
-    return digits;
-}
+import { effectivePriceInOre, vatLabel } from '@/lib/pricing';
+import { useLocalStorage } from '@/lib/useLocalStorage';
+import { formatApiError } from '@/lib/errorMessages';
 
 export default function ShopPage() {
     const [items, setItems] = useState<ShopItem[]>([]);
@@ -33,11 +23,14 @@ export default function ShopPage() {
     const [appSettings, setAppSettings] = useState<AppSettings | null>(null);
     const [loading, setLoading] = useState(true);
 
-    const [phoneItemModal, setPhoneItemModal] = useState<ShopItem | null>(null);
+    const [phoneItemModal, setPhoneItemModal] = useState<{ item: ShopItem; quantity: number } | null>(null);
     const [phoneSubModal, setPhoneSubModal] = useState<Product | null>(null);
-    const [phone, setPhone] = useState('');
-    const [agreedWithdrawal, setAgreedWithdrawal] = useState(false);
+    const [savedPhone, setSavedPhone] = useLocalStorage('garge-phone', '');
+    const [savedAddress, setSavedAddress] = useLocalStorage('garge-shipping-address', '');
+    const [pendingAddress, setPendingAddress] = useState('');
     const [purchasing, setPurchasing] = useState(false);
+    const [redirecting, setRedirecting] = useState(false);
+    const [quantities, setQuantities] = useState<Record<number, number>>({});
 
     useEffect(() => {
         Promise.all([
@@ -50,40 +43,70 @@ export default function ShopPage() {
                 setProducts(prods);
                 setAppSettings(settings);
             })
-            .catch(() => toast.error('Failed to load shop'))
+            .catch(err => toast.error(formatApiError(err, 'Failed to load shop')))
             .finally(() => setLoading(false));
     }, []);
 
     const vatEnabled = appSettings?.vatEnabled ?? false;
 
-    async function handleCheckout(item: ShopItem) {
-        if (!phone.trim()) { toast.error('Phone number required'); return; }
+    function getQty(itemId: number): number {
+        return quantities[itemId] ?? 1;
+    }
+
+    function setQty(itemId: number, q: number, max: number) {
+        const clamped = Math.max(1, Math.min(q, max === -1 ? 99 : max));
+        setQuantities(prev => ({ ...prev, [itemId]: clamped }));
+    }
+
+    function openItemModal(item: ShopItem) {
+        setPhoneItemModal({ item, quantity: getQty(item.id) });
+        setPendingAddress(savedAddress);
+    }
+
+    function openSubModal(product: Product) {
+        const hasPrimary = false;
+        if (product.type === 'AddOn' && !hasPrimary) {
+            // Server enforces this; UI nudge here too.
+        }
+        setPhoneSubModal(product);
+    }
+
+    async function handleCheckout(item: ShopItem, quantity: number, msisdn: string) {
+        const address = pendingAddress.trim();
+        if (!address) {
+            toast.error('Shipping address required');
+            return;
+        }
         setPurchasing(true);
         try {
             const res = await ShopService.checkout({
-                items: [{ shopItemId: item.id, quantity: 1 }],
-                phoneNumber: phone.trim(),
-                redirectUrl: `${window.location.origin}/shop/return`,
+                items: [{ shopItemId: item.id, quantity }],
+                phoneNumber: msisdn,
+                shippingAddress: address,
             });
+            setSavedPhone(msisdn);
+            setSavedAddress(address);
+            setRedirecting(true);
             window.location.href = res.redirectUrl;
-        } catch {
-            toast.error('Failed to initiate payment');
+        } catch (err) {
+            toast.error(formatApiError(err, 'Failed to initiate payment'));
             setPurchasing(false);
         }
     }
 
-    async function handleInitiate(product: Product) {
-        if (!phone.trim()) { toast.error('Phone number required'); return; }
+    async function handleInitiate(product: Product, msisdn: string) {
         setPurchasing(true);
         try {
             const res = await SubscriptionService.initiateSubscription({
                 productId: product.id,
-                phoneNumber: normalizePhone(phone),
-                redirectUrl: `${window.location.origin}/profile/billing/return`,
+                phoneNumber: msisdn,
+                consentToWaiveWithdrawal: true,
             });
+            setSavedPhone(msisdn);
+            setRedirecting(true);
             window.location.href = res.vippsConfirmationUrl;
-        } catch {
-            toast.error('Failed to initiate subscription');
+        } catch (err) {
+            toast.error(formatApiError(err, 'Failed to initiate subscription'));
             setPurchasing(false);
         }
     }
@@ -99,36 +122,68 @@ export default function ShopPage() {
             {items.length > 0 && (
                 <Section title="Products">
                     <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                        {items.map(item => (
-                            <div
-                                key={item.id}
-                                className="bg-gray-900/40 border border-gray-700/30 rounded-xl p-4 flex flex-col gap-3"
-                            >
-                                <div className="flex-1">
-                                    <p className="text-sm font-semibold text-gray-100">{item.name}</p>
-                                    <p className="text-lg font-bold text-sky-400 mt-1">
-                                        {formatNok(effectivePrice(item.priceInOre, vatEnabled))}
-                                        <span className="text-xs font-normal text-gray-500 ml-1">{vatLabel(vatEnabled)}</span>
-                                    </p>
-                                    {item.description && (
-                                        <p className="text-xs text-gray-500 mt-1">{item.description}</p>
+                        {items.map(item => {
+                            const outOfStock = item.stockCount === 0;
+                            const qty = getQty(item.id);
+                            const max = item.stockCount === -1 ? 99 : item.stockCount;
+                            return (
+                                <div
+                                    key={item.id}
+                                    className={`relative bg-gray-900/40 border border-gray-700/30 rounded-xl p-4 flex flex-col gap-3 ${
+                                        outOfStock ? 'opacity-60 grayscale' : ''
+                                    }`}
+                                >
+                                    {outOfStock && (
+                                        <span className="absolute top-2 right-2 px-1.5 py-0.5 bg-red-500/20 border border-red-500/40 text-red-400 text-[10px] font-bold uppercase tracking-wider rounded">
+                                            Out of stock
+                                        </span>
                                     )}
-                                    {item.stockCount !== -1 && item.stockCount > 0 && item.stockCount <= 5 && (
-                                        <p className="text-xs text-amber-400 mt-1">Only {item.stockCount} left</p>
-                                    )}
-                                    {item.stockCount === 0 && (
-                                        <p className="text-xs text-red-400 mt-1">Out of stock</p>
+                                    <div className="flex-1">
+                                        <p className="text-sm font-semibold text-gray-100">{item.name}</p>
+                                        <p className="text-lg font-bold text-sky-400 mt-1">
+                                            {formatNok(effectivePriceInOre(item.priceInOre, vatEnabled) * qty)}
+                                            <span className="text-xs font-normal text-gray-500 ml-1">{vatLabel(vatEnabled)}</span>
+                                        </p>
+                                        {item.description && (
+                                            <p className="text-xs text-gray-500 mt-1">{item.description}</p>
+                                        )}
+                                        {item.stockCount !== -1 && item.stockCount > 0 && item.stockCount <= 5 && (
+                                            <p className="text-xs text-amber-400 mt-1">Only {item.stockCount} left</p>
+                                        )}
+                                    </div>
+
+                                    {!outOfStock && (
+                                        <div className="flex items-center gap-2">
+                                            <div className="flex items-center gap-1 bg-gray-800/60 border border-gray-700/40 rounded-lg p-0.5">
+                                                <button
+                                                    onClick={() => setQty(item.id, qty - 1, max)}
+                                                    disabled={qty <= 1}
+                                                    aria-label="Decrease quantity"
+                                                    className="p-1.5 rounded text-gray-400 hover:text-gray-200 hover:bg-gray-700 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                                                >
+                                                    <MinusIcon className="h-3.5 w-3.5" />
+                                                </button>
+                                                <span className="text-sm font-medium text-gray-100 w-6 text-center tabular-nums">{qty}</span>
+                                                <button
+                                                    onClick={() => setQty(item.id, qty + 1, max)}
+                                                    disabled={qty >= max}
+                                                    aria-label="Increase quantity"
+                                                    className="p-1.5 rounded text-gray-400 hover:text-gray-200 hover:bg-gray-700 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                                                >
+                                                    <PlusIcon className="h-3.5 w-3.5" />
+                                                </button>
+                                            </div>
+                                            <button
+                                                onClick={() => openItemModal(item)}
+                                                className="flex-1 px-4 py-2 bg-sky-600 hover:bg-sky-500 text-white text-sm font-medium rounded-lg transition-colors"
+                                            >
+                                                Buy
+                                            </button>
+                                        </div>
                                     )}
                                 </div>
-                                <button
-                                    onClick={() => { setPhoneItemModal(item); setPhone(''); }}
-                                    disabled={item.stockCount === 0}
-                                    className="w-full px-4 py-2 bg-sky-600 hover:bg-sky-500 disabled:opacity-40 disabled:cursor-not-allowed text-white text-sm font-medium rounded-lg transition-colors"
-                                >
-                                    Buy
-                                </button>
-                            </div>
-                        ))}
+                            );
+                        })}
                     </div>
                 </Section>
             )}
@@ -143,7 +198,7 @@ export default function ShopPage() {
                                 <div className="flex-1">
                                     <p className="text-sm font-semibold text-gray-100">{p.name}</p>
                                     <p className="text-lg font-bold text-sky-400 mt-1">
-                                        {formatNok(effectivePrice(p.priceInOre, vatEnabled))}
+                                        {formatNok(effectivePriceInOre(p.priceInOre, vatEnabled))}
                                         <span className="text-xs font-normal text-gray-500 ml-1">
                                             / {p.interval === 'Monthly' ? 'month' : 'year'} · {vatLabel(vatEnabled)}
                                         </span>
@@ -151,7 +206,7 @@ export default function ShopPage() {
                                     {p.description && <p className="text-xs text-gray-500 mt-1">{p.description}</p>}
                                 </div>
                                 <button
-                                    onClick={() => { setPhoneSubModal(p); setPhone(''); setAgreedWithdrawal(false); }}
+                                    onClick={() => openSubModal(p)}
                                     className="w-full px-4 py-2 bg-sky-600 hover:bg-sky-500 text-white text-sm font-medium rounded-lg transition-colors"
                                 >
                                     Subscribe
@@ -162,91 +217,54 @@ export default function ShopPage() {
                 )}
             </Section>
 
-            {/* Hardware purchase modal */}
             {phoneItemModal && (
-                <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
-                    <div className="bg-gray-900 border border-gray-700/60 rounded-2xl p-5 w-full max-w-sm space-y-4">
-                        <p className="text-sm font-semibold text-gray-100">Pay with Vipps</p>
-                        <p className="text-xs text-gray-500">
-                            <span className="text-gray-300">{phoneItemModal.name}</span> — {formatNok(effectivePrice(phoneItemModal.priceInOre, vatEnabled))} {vatLabel(vatEnabled)}
-                        </p>
+                <PaymentPhoneModal
+                    title="Pay with Vipps"
+                    summary={
+                        <>
+                            <span className="text-gray-300">{phoneItemModal.item.name}</span>
+                            {' × '}{phoneItemModal.quantity}
+                            {' — '}
+                            {formatNok(effectivePriceInOre(phoneItemModal.item.priceInOre, vatEnabled) * phoneItemModal.quantity)} {vatLabel(vatEnabled)}
+                        </>
+                    }
+                    extraField={
                         <input
-                            type="tel"
-                            value={phone}
-                            onChange={e => setPhone(e.target.value)}
-                            placeholder="Phone number"
+                            type="text"
+                            value={pendingAddress}
+                            onChange={e => setPendingAddress(e.target.value)}
+                            placeholder="Shipping address"
+                            aria-label="Shipping address"
+                            autoComplete="street-address"
                             className="w-full bg-gray-800/60 border border-gray-700/60 rounded-lg px-3 py-2 text-sm text-gray-100 placeholder-gray-600 focus:outline-none focus:border-sky-500/60"
                         />
-                        <div className="flex gap-2">
-                            <button
-                                onClick={() => handleCheckout(phoneItemModal)}
-                                disabled={purchasing}
-                                className="flex-1 px-4 py-2 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors"
-                            >
-                                {purchasing ? 'Redirecting…' : 'Continue to Vipps'}
-                            </button>
-                            <button
-                                onClick={() => setPhoneItemModal(null)}
-                                className="px-4 py-2 bg-gray-700/60 hover:bg-gray-700 text-gray-300 text-sm rounded-lg transition-colors"
-                            >
-                                Cancel
-                            </button>
-                        </div>
-                    </div>
-                </div>
+                    }
+                    initialPhone={savedPhone}
+                    submitting={purchasing}
+                    onSubmit={(msisdn) => handleCheckout(phoneItemModal.item, phoneItemModal.quantity, msisdn)}
+                    onCancel={() => setPhoneItemModal(null)}
+                />
             )}
 
-            {/* Subscription purchase modal */}
             {phoneSubModal && (
-                <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
-                    <div className="bg-gray-900 border border-gray-700/60 rounded-2xl p-5 w-full max-w-sm space-y-4">
-                        <p className="text-sm font-semibold text-gray-100">Pay with Vipps</p>
-                        <p className="text-xs text-gray-500">
+                <PaymentPhoneModal
+                    title="Pay with Vipps"
+                    summary={
+                        <>
                             <span className="text-gray-300">{phoneSubModal.name}</span>
                             {' — '}
-                            {formatNok(effectivePrice(phoneSubModal.priceInOre, vatEnabled))} / {phoneSubModal.interval === 'Monthly' ? 'month' : 'year'}
-                            {' '}· {vatLabel(vatEnabled)}
-                        </p>
-                        <input
-                            type="tel"
-                            value={phone}
-                            onChange={e => setPhone(e.target.value)}
-                            placeholder="Phone number"
-                            className="w-full bg-gray-800/60 border border-gray-700/60 rounded-lg px-3 py-2 text-sm text-gray-100 placeholder-gray-600 focus:outline-none focus:border-sky-500/60"
-                        />
-                        <label className="flex items-start gap-2.5 cursor-pointer">
-                            <input
-                                type="checkbox"
-                                checked={agreedWithdrawal}
-                                onChange={e => setAgreedWithdrawal(e.target.checked)}
-                                className="mt-0.5 accent-sky-500 shrink-0"
-                            />
-                            <span className="text-xs text-gray-500 leading-relaxed">
-                                I request immediate access and waive my 14-day right of withdrawal (angrerettloven).
-                            </span>
-                        </label>
-                        <p className="text-xs text-gray-600">
-                            By continuing you accept our{' '}
-                            <Link href="/terms" className="text-sky-500 hover:text-sky-400 transition-colors">Terms of Service</Link>.
-                        </p>
-                        <div className="flex gap-2">
-                            <button
-                                onClick={() => handleInitiate(phoneSubModal)}
-                                disabled={purchasing || !agreedWithdrawal}
-                                className="flex-1 px-4 py-2 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors"
-                            >
-                                {purchasing ? 'Redirecting…' : 'Continue to Vipps'}
-                            </button>
-                            <button
-                                onClick={() => setPhoneSubModal(null)}
-                                className="px-4 py-2 bg-gray-700/60 hover:bg-gray-700 text-gray-300 text-sm rounded-lg transition-colors"
-                            >
-                                Cancel
-                            </button>
-                        </div>
-                    </div>
-                </div>
+                            {formatNok(effectivePriceInOre(phoneSubModal.priceInOre, vatEnabled))} / {phoneSubModal.interval === 'Monthly' ? 'month' : 'year'} · {vatLabel(vatEnabled)}
+                        </>
+                    }
+                    requireConsent
+                    initialPhone={savedPhone}
+                    submitting={purchasing}
+                    onSubmit={(msisdn) => handleInitiate(phoneSubModal, msisdn)}
+                    onCancel={() => setPhoneSubModal(null)}
+                />
             )}
+
+            {redirecting && <RedirectingOverlay />}
         </div>
     );
 }

--- a/src/app/(protected)/shop/return/page.tsx
+++ b/src/app/(protected)/shop/return/page.tsx
@@ -1,83 +1,52 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
-import Link from 'next/link';
-import { CheckCircleIcon, ClockIcon, XCircleIcon } from '@heroicons/react/24/outline';
 import LoadingDots from '@/components/LoadingDots';
+import ReturnStatusPage from '@/components/ReturnStatusPage';
 import ShopService, { Order } from '@/services/shopService';
+import { usePollUntilFinal } from '@/lib/usePollUntilFinal';
 
 export default function ShopReturnPage() {
     const searchParams = useSearchParams();
     const orderId = searchParams.get('orderId');
-    const [order, setOrder] = useState<Order | null>(null);
-    const [loading, setLoading] = useState(true);
-    const retried = useRef(false);
-    const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+    const parsedId = orderId ? parseInt(orderId, 10) : NaN;
 
-    useEffect(() => {
-        const parsedId = orderId ? parseInt(orderId, 10) : NaN;
-
-        async function findOrder(orders: Order[]) {
-            return !isNaN(parsedId) ? (orders.find(o => o.id === parsedId) ?? null) : (orders[0] ?? null);
-        }
-
-        async function check() {
-            try {
-                const target = await findOrder(await ShopService.getMyOrders());
-                setOrder(target);
-                if (target?.status === 'Pending' && !retried.current) {
-                    retried.current = true;
-                    timeoutRef.current = setTimeout(async () => {
-                        const target2 = await findOrder(await ShopService.getMyOrders());
-                        setOrder(target2);
-                        setLoading(false);
-                    }, 3000);
-                } else {
-                    setLoading(false);
-                }
-            } catch {
-                setLoading(false);
-            }
-        }
-        check();
-        return () => clearTimeout(timeoutRef.current);
-    }, [orderId]);
+    const { data: order, loading, refresh } = usePollUntilFinal<Order | null>(
+        async () => {
+            const orders = await ShopService.getMyOrders();
+            return !isNaN(parsedId)
+                ? (orders.find(o => o.id === parsedId) ?? null)
+                : (orders[0] ?? null);
+        },
+        (o) => o != null && o.status !== 'Pending',
+    );
 
     if (loading) return <LoadingDots height="h-64" />;
 
     const status = order?.status;
+    const variant = status === 'Paid' || status === 'Reserved'
+        ? 'success'
+        : status === 'Pending'
+            ? 'pending'
+            : 'failed';
 
     return (
-        <div className="max-w-md mx-auto px-4 py-12 flex flex-col items-center gap-5 text-center pb-32">
-            {status === 'Paid' ? (
-                <>
-                    <CheckCircleIcon className="h-16 w-16 text-green-400" />
-                    <p className="text-xl font-display font-bold text-gray-100">Payment received!</p>
-                    <p className="text-sm text-gray-500">Your order is confirmed. We&apos;ll ship your sensor soon.</p>
-                    <Link href="/shop" className="px-5 py-2.5 bg-sky-600 hover:bg-sky-500 text-white text-sm font-medium rounded-lg transition-colors">
-                        Back to shop
-                    </Link>
-                </>
-            ) : status === 'Pending' ? (
-                <>
-                    <ClockIcon className="h-16 w-16 text-amber-400" />
-                    <p className="text-xl font-display font-bold text-gray-100">Payment pending</p>
-                    <p className="text-sm text-gray-500">Your payment is being confirmed by Vipps. This usually takes a moment.</p>
-                    <Link href="/shop" className="px-5 py-2.5 bg-gray-700/60 hover:bg-gray-700 text-gray-300 text-sm rounded-lg transition-colors">
-                        Back to shop
-                    </Link>
-                </>
-            ) : (
-                <>
-                    <XCircleIcon className="h-16 w-16 text-red-400" />
-                    <p className="text-xl font-display font-bold text-gray-100">Payment failed</p>
-                    <p className="text-sm text-gray-500">The payment was not completed. No charge was made.</p>
-                    <Link href="/shop" className="px-5 py-2.5 bg-gray-700/60 hover:bg-gray-700 text-gray-300 text-sm rounded-lg transition-colors">
-                        Try again
-                    </Link>
-                </>
-            )}
-        </div>
+        <ReturnStatusPage
+            variant={variant}
+            successTitle="Payment received!"
+            successBody="Your order is confirmed. We'll ship your sensor soon."
+            successHref="/shop"
+            successCta="Back to shop"
+            pendingTitle="Payment pending"
+            pendingBody="Your payment is being confirmed by Vipps."
+            pendingEmailNote="We'll email you a receipt once it's captured."
+            pendingHref="/profile/billing"
+            pendingCta="View billing"
+            onRefresh={refresh}
+            failedTitle="Payment failed"
+            failedBody="The payment was not completed. No charge was made."
+            failedHref="/shop"
+            failedCta="Try again"
+        />
     );
 }

--- a/src/app/(protected)/shop/return/page.tsx
+++ b/src/app/(protected)/shop/return/page.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import Link from 'next/link';
+import { CheckCircleIcon, ClockIcon, XCircleIcon } from '@heroicons/react/24/outline';
+import LoadingDots from '@/components/LoadingDots';
+import ShopService, { Order } from '@/services/shopService';
+
+export default function ShopReturnPage() {
+    const searchParams = useSearchParams();
+    const orderId = searchParams.get('orderId');
+    const [order, setOrder] = useState<Order | null>(null);
+    const [loading, setLoading] = useState(true);
+    const retried = useRef(false);
+    const timeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+    useEffect(() => {
+        const parsedId = orderId ? parseInt(orderId, 10) : NaN;
+
+        async function findOrder(orders: Order[]) {
+            return !isNaN(parsedId) ? (orders.find(o => o.id === parsedId) ?? null) : (orders[0] ?? null);
+        }
+
+        async function check() {
+            try {
+                const target = await findOrder(await ShopService.getMyOrders());
+                setOrder(target);
+                if (target?.status === 'Pending' && !retried.current) {
+                    retried.current = true;
+                    timeoutRef.current = setTimeout(async () => {
+                        const target2 = await findOrder(await ShopService.getMyOrders());
+                        setOrder(target2);
+                        setLoading(false);
+                    }, 3000);
+                } else {
+                    setLoading(false);
+                }
+            } catch {
+                setLoading(false);
+            }
+        }
+        check();
+        return () => clearTimeout(timeoutRef.current);
+    }, [orderId]);
+
+    if (loading) return <LoadingDots height="h-64" />;
+
+    const status = order?.status;
+
+    return (
+        <div className="max-w-md mx-auto px-4 py-12 flex flex-col items-center gap-5 text-center pb-32">
+            {status === 'Paid' ? (
+                <>
+                    <CheckCircleIcon className="h-16 w-16 text-green-400" />
+                    <p className="text-xl font-display font-bold text-gray-100">Payment received!</p>
+                    <p className="text-sm text-gray-500">Your order is confirmed. We&apos;ll ship your sensor soon.</p>
+                    <Link href="/shop" className="px-5 py-2.5 bg-sky-600 hover:bg-sky-500 text-white text-sm font-medium rounded-lg transition-colors">
+                        Back to shop
+                    </Link>
+                </>
+            ) : status === 'Pending' ? (
+                <>
+                    <ClockIcon className="h-16 w-16 text-amber-400" />
+                    <p className="text-xl font-display font-bold text-gray-100">Payment pending</p>
+                    <p className="text-sm text-gray-500">Your payment is being confirmed by Vipps. This usually takes a moment.</p>
+                    <Link href="/shop" className="px-5 py-2.5 bg-gray-700/60 hover:bg-gray-700 text-gray-300 text-sm rounded-lg transition-colors">
+                        Back to shop
+                    </Link>
+                </>
+            ) : (
+                <>
+                    <XCircleIcon className="h-16 w-16 text-red-400" />
+                    <p className="text-xl font-display font-bold text-gray-100">Payment failed</p>
+                    <p className="text-sm text-gray-500">The payment was not completed. No charge was made.</p>
+                    <Link href="/shop" className="px-5 py-2.5 bg-gray-700/60 hover:bg-gray-700 text-gray-300 text-sm rounded-lg transition-colors">
+                        Try again
+                    </Link>
+                </>
+            )}
+        </div>
+    );
+}

--- a/src/app/FloatingNav.tsx
+++ b/src/app/FloatingNav.tsx
@@ -7,12 +7,14 @@ import {
     BoltIcon,
     WrenchScrewdriverIcon,
     UserCircleIcon,
+    ShoppingBagIcon,
 } from '@heroicons/react/24/outline';
 
 const navItems = [
     { href: '/',            label: 'Devices',     Icon: HomeIcon },
     { href: '/electricity', label: 'Electricity', Icon: BoltIcon },
     { href: '/automations', label: 'Auto',        Icon: WrenchScrewdriverIcon },
+    { href: '/shop',        label: 'Shop',        Icon: ShoppingBagIcon },
     { href: '/profile',     label: 'Profile',     Icon: UserCircleIcon },
 ];
 

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { EnvelopeIcon } from "@heroicons/react/24/outline";
+import { COMPANY } from "@/lib/company";
 
 export default function ContactPage() {
     return (
@@ -17,8 +18,8 @@ export default function ContactPage() {
                     </div>
                     <div>
                         <p className="text-xs text-gray-500 mb-0.5">Email us at</p>
-                        <a href="mailto:sondresjoelyst@gmail.com" className="text-sm font-medium text-sky-400 hover:text-sky-300 transition-colors">
-                            sondresjoelyst@gmail.com
+                        <a href={`mailto:${COMPANY.email}`} className="text-sm font-medium text-sky-400 hover:text-sky-300 transition-colors">
+                            {COMPANY.email}
                         </a>
                     </div>
                 </div>

--- a/src/app/footer.tsx
+++ b/src/app/footer.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import Link from 'next/link';
 import Image from 'next/image';
+import { COMPANY } from '@/lib/company';
 
 export default function Footer() {
     return (
@@ -30,7 +31,7 @@ export default function Footer() {
                 </nav>
 
                 {/* Bottom */}
-                <p className="text-xs text-gray-600">© 2026 Sjølyst Innovations · Org. nr. 934 531 035</p>
+                <p className="text-xs text-gray-600">© 2026 {COMPANY.legalName} · Org. nr. {COMPANY.orgNumber}</p>
 
             </div>
         </footer>

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,44 +1,116 @@
 import Link from "next/link";
+import { COMPANY } from "@/lib/company";
 
 export default function TermsPage() {
     return (
         <div className="max-w-2xl mx-auto px-4 py-10 space-y-6">
             <h1 className="text-3xl font-display font-bold text-gray-100">Terms of Service</h1>
-            <p className="text-xs text-gray-500">Last updated: April 2026</p>
+            <p className="text-xs text-gray-500">Last updated: May 2026</p>
 
             <div className="bg-gray-800/60 backdrop-blur-xl border border-gray-700/40 rounded-2xl p-6 shadow-lg space-y-6 text-sm text-gray-400 leading-relaxed">
                 <section className="space-y-2">
-                    <h2 className="text-base font-semibold text-gray-100">1. Acceptance of terms</h2>
+                    <h2 className="text-base font-semibold text-gray-100">1. About us (seller)</h2>
+                    <p>The seller is:</p>
+                    <ul className="list-none space-y-0.5 pl-2">
+                        <li><span className="text-gray-300">Company name:</span> {COMPANY.legalName}</li>
+                        <li><span className="text-gray-300">Organisation number:</span> {COMPANY.orgNumber}</li>
+                        <li><span className="text-gray-300">Address:</span> {COMPANY.address}</li>
+                        <li><span className="text-gray-300">Email:</span> {COMPANY.email}</li>
+                    </ul>
+                    <p>By placing an order or activating a subscription you confirm that you are a private consumer and that you have read and accepted these terms.</p>
+                </section>
+
+                <section className="space-y-2">
+                    <h2 className="text-base font-semibold text-gray-100">2. Acceptance of terms</h2>
                     <p>By using Garge you agree to these terms. If you do not agree, please do not use the service.</p>
                 </section>
 
                 <section className="space-y-2">
-                    <h2 className="text-base font-semibold text-gray-100">2. Use of the service</h2>
+                    <h2 className="text-base font-semibold text-gray-100">3. Use of the service</h2>
                     <p>Garge provides a platform for monitoring sensor data from devices registered to your account. You are responsible for keeping your login credentials secure.</p>
                 </section>
 
                 <section className="space-y-2">
-                    <h2 className="text-base font-semibold text-gray-100">3. Device ownership</h2>
-                    <p>You may only claim devices you own or have been given permission to register. Claiming a device does not transfer hardware ownership.</p>
+                    <h2 className="text-base font-semibold text-gray-100">4. Device ownership</h2>
+                    <p>You may only register devices you own or have been given explicit permission to register. Registering a device does not transfer hardware ownership.</p>
                 </section>
 
                 <section className="space-y-2">
-                    <h2 className="text-base font-semibold text-gray-100">4. Data</h2>
-                    <p>Sensor readings are stored and associated with your account. We do not sell your data to third parties. See our <Link href="/privacy" className="text-sky-400 hover:text-sky-300">Privacy Policy</Link> for details.</p>
+                    <h2 className="text-base font-semibold text-gray-100">5. Data and privacy</h2>
+                    <p>Sensor readings are stored and associated with your account. We do not sell your data to third parties. See our <Link href="/privacy" className="text-sky-400 hover:text-sky-300">Privacy Policy</Link> for full details on how we collect, use, and protect your personal data.</p>
                 </section>
 
                 <section className="space-y-2">
-                    <h2 className="text-base font-semibold text-gray-100">5. Availability</h2>
+                    <h2 className="text-base font-semibold text-gray-100">6. Availability</h2>
                     <p>We aim for high availability but do not guarantee uninterrupted access. The service may be updated or taken offline for maintenance at any time.</p>
                 </section>
 
                 <section className="space-y-2">
-                    <h2 className="text-base font-semibold text-gray-100">6. Changes to terms</h2>
+                    <h2 className="text-base font-semibold text-gray-100">7. Subscription service</h2>
+                    <p>A Garge subscription gives you access to all platform features: live sensor monitoring, automation rules, socket control, push notifications, and historical data. Without an active subscription you can log in but cannot access sensor data or other features.</p>
+                    <p>Subscriptions are available on a monthly or yearly basis. Access begins immediately upon confirmation in Vipps.</p>
+                </section>
+
+                <section className="space-y-2">
+                    <h2 className="text-base font-semibold text-gray-100">8. Subscription pricing and billing</h2>
+                    <p>Prices are shown in NOK. Recurring charges are processed through Vipps at the start of each billing period. We will give you at least 30 days&apos; notice by email before any price change takes effect.</p>
+                    <p>Your current plan and next charge date are shown on the <Link href="/profile/billing" className="text-sky-400 hover:text-sky-300">Billing page</Link>.</p>
+                </section>
+
+                <section className="space-y-2">
+                    <h2 className="text-base font-semibold text-gray-100">9. Subscription cancellation</h2>
+                    <p>You may cancel your subscription at any time from the Billing page. Cancellation takes effect at the end of the current billing period — you retain full access until that date and will not be charged again. No partial refunds are issued for unused time in the current period.</p>
+                </section>
+
+                <section className="space-y-2">
+                    <h2 className="text-base font-semibold text-gray-100">10. Right of withdrawal — subscription</h2>
+                    <p>Under the Norwegian Right of Cancellation Act (angrerettloven), consumers generally have a 14-day right of withdrawal from digital service agreements. Because Garge subscriptions grant immediate access upon activation, we ask you to explicitly waive this right during checkout. By checking the confirmation box at checkout you acknowledge that the service has started and that the right of withdrawal is waived accordingly.</p>
+                    <p>If you prefer not to waive this right, do not activate the service during the 14-day period and <Link href="/contact" className="text-sky-400 hover:text-sky-300">contact us</Link> to cancel before first use.</p>
+                </section>
+
+                <section className="space-y-2">
+                    <h2 className="text-base font-semibold text-gray-100">11. Physical products — purchase agreement</h2>
+                    <p>A binding purchase agreement for physical products is formed when you receive an order confirmation. Payment is reserved via Vipps at checkout and only captured when we ship your order — you are not charged before dispatch.</p>
+                    <p>We reserve the right to cancel or refuse an order in whole or in part for any reason, including but not limited to: the item being out of stock or discontinued; a pricing or product description error; inability to verify payment; suspected fraudulent or abusive activity; or other circumstances that make fulfilment impossible or unlawful. If we cancel your order we will notify you promptly and issue a full refund of any reserved or captured amount.</p>
+                </section>
+
+                <section className="space-y-2">
+                    <h2 className="text-base font-semibold text-gray-100">12. Pricing</h2>
+                    <p>All prices are shown in NOK. Prices include or exclude VAT as indicated at checkout. No additional fees are added beyond the total shown at the time of purchase.</p>
+                </section>
+
+                <section className="space-y-2">
+                    <h2 className="text-base font-semibold text-gray-100">13. Delivery</h2>
+                    <p>We aim to ship physical orders within 5 business days. Delivery will always occur within 30 days of the order date unless otherwise agreed in writing. If we cannot deliver within 30 days we will notify you promptly, and you may cancel the order for a full refund. Risk of loss transfers to you once the goods are delivered to your address.</p>
+                </section>
+
+                <section className="space-y-2">
+                    <h2 className="text-base font-semibold text-gray-100">14. Right of withdrawal — physical goods</h2>
+                    <p>You have a 14-day right of withdrawal for physical products under the Right of Cancellation Act (angrerettloven), starting from the day you receive the item. You do not need to give a reason. To exercise this right, <Link href="/contact" className="text-sky-400 hover:text-sky-300">contact us</Link> within 14 days of receipt. Return shipping costs are at your expense. We will issue a full refund within 14 days of receiving the returned goods in acceptable condition.</p>
+                </section>
+
+                <section className="space-y-2">
+                    <h2 className="text-base font-semibold text-gray-100">15. Defects and complaints</h2>
+                    <p>Physical products carry a statutory complaints period of at least 2 years from delivery under the Norwegian Consumer Purchases Act (forbrukerkjøpsloven). For goods expected to last significantly longer this period may extend to 5 years. If your product has a defect, <Link href="/contact" className="text-sky-400 hover:text-sky-300">contact us</Link> as soon as possible after discovery — a complaint must be raised within a reasonable time (generally within 2 months of discovering the defect) and no later than the end of the applicable complaints period. We will offer repair, replacement, or a refund as appropriate.</p>
+                </section>
+
+                <section className="space-y-2">
+                    <h2 className="text-base font-semibold text-gray-100">16. Non-payment</h2>
+                    <p>If a subscription payment fails, access may be suspended until the outstanding amount is settled. If payment is reversed fraudulently, Garge reserves the right to recover the outstanding amount through appropriate means.</p>
+                </section>
+
+                <section className="space-y-2">
+                    <h2 className="text-base font-semibold text-gray-100">17. Dispute resolution</h2>
+                    <p>If a complaint cannot be resolved directly with us, you may contact the Norwegian Consumer Authority (Forbrukertilsynet) or the Consumer Council of Norway (Forbrukerrådet) for assistance. EU-based consumers may also use the European Commission&apos;s Online Dispute Resolution platform at <a href="https://ec.europa.eu/consumers/odr" className="text-sky-400 hover:text-sky-300" target="_blank" rel="noopener noreferrer">ec.europa.eu/consumers/odr</a>. Norwegian law applies to these terms.</p>
+                </section>
+
+                <section className="space-y-2">
+                    <h2 className="text-base font-semibold text-gray-100">18. Changes to terms</h2>
                     <p>We may update these terms from time to time. We will notify you of material changes by email. Continued use of Garge after notification constitutes acceptance of the updated terms.</p>
                 </section>
 
                 <section className="space-y-2">
-                    <h2 className="text-base font-semibold text-gray-100">7. Contact</h2>
+                    <h2 className="text-base font-semibold text-gray-100">19. Contact</h2>
                     <p>Questions about these terms? <Link href="/contact" className="text-sky-400 hover:text-sky-300">Contact us</Link>.</p>
                 </section>
             </div>

--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react';
 import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
+import { useEscapeKey } from '@/lib/useEscapeKey';
 
 interface ConfirmModalProps {
     title: string;
@@ -24,6 +25,8 @@ const ConfirmModal: React.FC<ConfirmModalProps> = ({
 }) => {
     const [loading, setLoading] = useState(false);
 
+    useEscapeKey(!loading, onCancel);
+
     const handleConfirm = async () => {
         setLoading(true);
         try {
@@ -34,23 +37,29 @@ const ConfirmModal: React.FC<ConfirmModalProps> = ({
     };
 
     return (
-        <div className="fixed inset-0 z-[200] flex items-center justify-center px-4">
-            <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={onCancel} />
+        <div
+            role="alertdialog"
+            aria-modal="true"
+            aria-labelledby="confirm-modal-title"
+            className="fixed inset-0 z-[200] flex items-center justify-center px-4"
+        >
+            <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={() => { if (!loading) onCancel(); }} />
             <div className="relative bg-gray-800 border border-gray-700/60 rounded-2xl p-6 max-w-sm w-full shadow-2xl">
                 <div className="flex items-center gap-3 mb-4">
                     <div className="w-10 h-10 rounded-xl bg-red-500/15 flex items-center justify-center flex-shrink-0">
-                        <ExclamationTriangleIcon className="h-5 w-5 text-red-400" />
+                        <ExclamationTriangleIcon className="h-5 w-5 text-red-400" aria-hidden />
                     </div>
                     <div>
-                        <h3 className="text-sm font-semibold text-gray-100">{title}</h3>
+                        <h3 id="confirm-modal-title" className="text-sm font-semibold text-gray-100">{title}</h3>
                         {subtitle && <p className="text-xs text-gray-400">{subtitle}</p>}
                     </div>
                 </div>
-                <p className="text-sm text-gray-300 mb-6">{message}</p>
+                <div className="text-sm text-gray-300 mb-6">{message}</div>
                 <div className="flex gap-3">
                     <button
                         onClick={onCancel}
                         disabled={loading}
+                        aria-label={cancelLabel}
                         className="flex-1 py-2 rounded-xl bg-gray-700 hover:bg-gray-600 text-gray-200 text-sm font-medium transition-all disabled:opacity-50"
                     >
                         {cancelLabel}
@@ -58,10 +67,11 @@ const ConfirmModal: React.FC<ConfirmModalProps> = ({
                     <button
                         onClick={handleConfirm}
                         disabled={loading}
+                        aria-label={confirmLabel}
                         className="flex-1 py-2 rounded-xl bg-red-500/20 hover:bg-red-500/30 border border-red-500/30 text-red-300 text-sm font-medium transition-all disabled:opacity-50 flex items-center justify-center gap-2"
                     >
                         {loading && (
-                            <span className="w-3.5 h-3.5 border-2 border-current border-t-transparent rounded-full animate-spin" />
+                            <span className="w-3.5 h-3.5 border-2 border-current border-t-transparent rounded-full animate-spin" aria-hidden />
                         )}
                         {confirmLabel}
                     </button>

--- a/src/components/PaymentPhoneModal.tsx
+++ b/src/components/PaymentPhoneModal.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useRef, useState } from 'react';
+import { CheckIcon } from '@heroicons/react/24/outline';
+import { normalizeNoPhone } from '@/lib/phone';
+import { useEscapeKey } from '@/lib/useEscapeKey';
+
+export interface PaymentPhoneModalProps {
+    title: string;
+    summary: React.ReactNode;
+    requireConsent?: boolean;
+    extraField?: React.ReactNode;
+    submitting: boolean;
+    initialPhone?: string;
+    onSubmit: (phoneMsisdn: string) => void;
+    onCancel: () => void;
+}
+
+export default function PaymentPhoneModal({
+    title,
+    summary,
+    requireConsent = false,
+    extraField,
+    submitting,
+    initialPhone = '',
+    onSubmit,
+    onCancel,
+}: PaymentPhoneModalProps) {
+    const [phone, setPhone] = useState(initialPhone);
+    const [agreed, setAgreed] = useState(false);
+    const phoneRef = useRef<HTMLInputElement>(null);
+
+    useEscapeKey(!submitting, onCancel);
+
+    useEffect(() => {
+        phoneRef.current?.focus();
+    }, []);
+
+    const normalized = normalizeNoPhone(phone);
+    const phoneValid = normalized !== null;
+    const phoneTouched = phone.length > 0;
+
+    const consentOk = !requireConsent || agreed;
+    const canSubmit = phoneValid && consentOk && !submitting;
+
+    function handleSubmit() {
+        if (!canSubmit || !normalized) return;
+        onSubmit(normalized);
+    }
+
+    return (
+        <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="payment-modal-title"
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+        >
+            <div className="absolute inset-0" aria-hidden onClick={() => { if (!submitting) onCancel(); }} />
+            <div className="relative bg-gray-900 border border-gray-700/60 rounded-2xl p-5 w-full max-w-sm space-y-4 shadow-2xl">
+                <p id="payment-modal-title" className="text-sm font-semibold text-gray-100">{title}</p>
+                <div className="text-xs text-gray-500">{summary}</div>
+
+                <div className="space-y-1">
+                    <div className="relative">
+                        <input
+                            ref={phoneRef}
+                            type="tel"
+                            inputMode="tel"
+                            autoComplete="tel"
+                            value={phone}
+                            onChange={e => setPhone(e.target.value)}
+                            onKeyDown={e => { if (e.key === 'Enter') handleSubmit(); }}
+                            placeholder="91 23 45 67"
+                            aria-invalid={phoneTouched && !phoneValid}
+                            aria-describedby="phone-hint"
+                            className={`w-full bg-gray-800/60 border rounded-lg pl-3 pr-9 py-2 text-sm text-gray-100 placeholder-gray-600 focus:outline-none transition-colors ${
+                                phoneTouched && !phoneValid
+                                    ? 'border-red-600/60 focus:border-red-500'
+                                    : phoneValid
+                                        ? 'border-green-600/40 focus:border-green-500'
+                                        : 'border-gray-700/60 focus:border-sky-500/60'
+                            }`}
+                        />
+                        {phoneValid && (
+                            <CheckIcon className="absolute right-2.5 top-2.5 h-4 w-4 text-green-400" aria-hidden />
+                        )}
+                    </div>
+                    <p id="phone-hint" className="text-[11px] text-gray-600">
+                        {phoneTouched && !phoneValid
+                            ? 'Use a Norwegian number (8 digits, optionally prefixed with +47).'
+                            : 'Norwegian mobile or landline. Spaces and +47 OK.'}
+                    </p>
+                </div>
+
+                {extraField}
+
+                {requireConsent && (
+                    <label className="flex items-start gap-2.5 cursor-pointer">
+                        <input
+                            type="checkbox"
+                            checked={agreed}
+                            onChange={e => setAgreed(e.target.checked)}
+                            className="mt-0.5 accent-sky-500 shrink-0"
+                        />
+                        <span className="text-xs text-gray-500 leading-relaxed">
+                            I request immediate access and waive my 14-day right of withdrawal.
+                        </span>
+                    </label>
+                )}
+                {requireConsent && (
+                    <p className="text-xs text-gray-600">
+                        By continuing you accept our{' '}
+                        <Link href="/terms" target="_blank" className="text-sky-500 hover:text-sky-400 transition-colors">Terms of Service</Link>.
+                    </p>
+                )}
+
+                <div className="flex gap-2">
+                    <button
+                        onClick={handleSubmit}
+                        disabled={!canSubmit}
+                        className="flex-1 px-4 py-2 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded-lg transition-colors"
+                    >
+                        {submitting ? 'Redirecting…' : 'Continue to Vipps'}
+                    </button>
+                    <button
+                        onClick={onCancel}
+                        aria-label="Cancel payment"
+                        disabled={submitting}
+                        className="px-4 py-2 bg-gray-700/60 hover:bg-gray-700 text-gray-300 text-sm rounded-lg transition-colors disabled:opacity-50"
+                    >
+                        Cancel
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/RedirectingOverlay.tsx
+++ b/src/components/RedirectingOverlay.tsx
@@ -1,0 +1,12 @@
+export default function RedirectingOverlay({ message = 'Redirecting to Vipps…' }: { message?: string }) {
+    return (
+        <div
+            role="status"
+            aria-live="polite"
+            className="fixed inset-0 z-[300] flex flex-col items-center justify-center gap-4 bg-black/80 backdrop-blur-sm"
+        >
+            <div className="w-12 h-12 border-4 border-sky-500 border-t-transparent rounded-full animate-spin" />
+            <p className="text-sm text-gray-200 font-medium">{message}</p>
+        </div>
+    );
+}

--- a/src/components/ReturnStatusPage.tsx
+++ b/src/components/ReturnStatusPage.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import Link from 'next/link';
+import { ArrowPathIcon, CheckCircleIcon, ClockIcon, XCircleIcon } from '@heroicons/react/24/outline';
+
+export type ReturnVariant = 'success' | 'pending' | 'failed';
+
+export interface ReturnStatusPageProps {
+    variant: ReturnVariant;
+    successTitle: string;
+    successBody: string;
+    successHref: string;
+    successCta: string;
+    successExtra?: React.ReactNode;
+    pendingTitle: string;
+    pendingBody: string;
+    pendingHref: string;
+    pendingCta: string;
+    pendingEmailNote?: string;
+    onRefresh?: () => void;
+    failedTitle: string;
+    failedBody: string;
+    failedHref: string;
+    failedCta: string;
+}
+
+export default function ReturnStatusPage(props: ReturnStatusPageProps) {
+    return (
+        <div className="max-w-md mx-auto px-4 py-12 flex flex-col items-center gap-5 text-center pb-32">
+            {props.variant === 'success' && (
+                <>
+                    <CheckCircleIcon className="h-16 w-16 text-green-400" aria-hidden />
+                    <p className="text-xl font-display font-bold text-gray-100">{props.successTitle}</p>
+                    <p className="text-sm text-gray-500">{props.successBody}</p>
+                    {props.successExtra}
+                    <Link href={props.successHref} className="px-5 py-2.5 bg-sky-600 hover:bg-sky-500 text-white text-sm font-medium rounded-lg transition-colors">
+                        {props.successCta}
+                    </Link>
+                </>
+            )}
+            {props.variant === 'pending' && (
+                <>
+                    <ClockIcon className="h-16 w-16 text-amber-400" aria-hidden />
+                    <p className="text-xl font-display font-bold text-gray-100">{props.pendingTitle}</p>
+                    <p className="text-sm text-gray-500">{props.pendingBody}</p>
+                    {props.pendingEmailNote && (
+                        <p className="text-xs text-gray-600">{props.pendingEmailNote}</p>
+                    )}
+                    <div className="flex gap-2">
+                        {props.onRefresh && (
+                            <button
+                                onClick={props.onRefresh}
+                                aria-label="Check again"
+                                className="px-4 py-2.5 bg-sky-600/80 hover:bg-sky-500 text-white text-sm font-medium rounded-lg transition-colors flex items-center gap-2"
+                            >
+                                <ArrowPathIcon className="h-4 w-4" aria-hidden />
+                                Check again
+                            </button>
+                        )}
+                        <Link href={props.pendingHref} className="px-4 py-2.5 bg-gray-700/60 hover:bg-gray-700 text-gray-300 text-sm rounded-lg transition-colors">
+                            {props.pendingCta}
+                        </Link>
+                    </div>
+                </>
+            )}
+            {props.variant === 'failed' && (
+                <>
+                    <XCircleIcon className="h-16 w-16 text-red-400" aria-hidden />
+                    <p className="text-xl font-display font-bold text-gray-100">{props.failedTitle}</p>
+                    <p className="text-sm text-gray-500">{props.failedBody}</p>
+                    <Link href={props.failedHref} className="px-5 py-2.5 bg-gray-700/60 hover:bg-gray-700 text-gray-300 text-sm rounded-lg transition-colors">
+                        {props.failedCta}
+                    </Link>
+                </>
+            )}
+        </div>
+    );
+}

--- a/src/components/TestModeBanner.tsx
+++ b/src/components/TestModeBanner.tsx
@@ -1,0 +1,10 @@
+import { AppSettings } from '@/services/adminService';
+
+export default function TestModeBanner({ settings }: { settings: AppSettings | null }) {
+    if (!settings?.vippsTestMode) return null;
+    return (
+        <div className="bg-amber-500/10 border border-amber-500/30 rounded-xl px-4 py-3">
+            <p className="text-xs font-medium text-amber-400">Vipps test mode is active — no real payments will be processed</p>
+        </div>
+    );
+}

--- a/src/components/TestPill.tsx
+++ b/src/components/TestPill.tsx
@@ -1,0 +1,11 @@
+export default function TestPill({ visible }: { visible: boolean }) {
+    if (!visible) return null;
+    return (
+        <span
+            title="Test mode"
+            className="px-1.5 py-0.5 bg-amber-500/15 border border-amber-500/40 text-amber-400 text-[10px] font-bold uppercase tracking-wider rounded"
+        >
+            Test
+        </span>
+    );
+}

--- a/src/lib/company.ts
+++ b/src/lib/company.ts
@@ -1,0 +1,7 @@
+export const COMPANY = {
+    name: 'Garge',
+    legalName: 'Sjølyst Innovations',
+    orgNumber: '934 531 035',
+    address: 'Mårvegen 21a, 4347 Lye',
+    email: 'sondresjoelyst@gmail.com',
+} as const;

--- a/src/lib/errorMessages.ts
+++ b/src/lib/errorMessages.ts
@@ -1,0 +1,20 @@
+import { AxiosError } from 'axios';
+
+export function formatApiError(err: unknown, fallback: string): string {
+    if (err instanceof AxiosError) {
+        const status = err.response?.status;
+        const data = err.response?.data;
+        const serverMessage = typeof data === 'string'
+            ? data
+            : (typeof data === 'object' && data && 'message' in data ? String((data as { message: unknown }).message) : '');
+
+        if (status === 400 && serverMessage) return serverMessage;
+        if (status === 401 || status === 403) return 'Not authorized.';
+        if (status === 404) return serverMessage || 'Not found.';
+        if (status === 409) return serverMessage || 'Conflict — already exists.';
+        if (status === 502 || status === 503) return 'Vipps unreachable. Try again in a moment.';
+        if (status === 429) return 'Too many requests. Wait a moment.';
+        if (serverMessage) return serverMessage;
+    }
+    return fallback;
+}

--- a/src/lib/formatUtils.ts
+++ b/src/lib/formatUtils.ts
@@ -1,0 +1,3 @@
+export function formatNok(ore: number): string {
+    return `NOK ${(ore / 100).toFixed(2).replace('.', ',')}`;
+}

--- a/src/lib/phone.ts
+++ b/src/lib/phone.ts
@@ -1,0 +1,6 @@
+export function normalizeNoPhone(raw: string): string | null {
+    const digits = raw.replace(/\D/g, '');
+    if (digits.length === 8) return `47${digits}`;
+    if (digits.length === 10 && digits.startsWith('47')) return digits;
+    return null;
+}

--- a/src/lib/pricing.ts
+++ b/src/lib/pricing.ts
@@ -1,0 +1,11 @@
+export const VAT_PERCENT = 25;
+
+export function effectivePriceInOre(priceInOre: number, vatEnabled: boolean): number {
+    return vatEnabled
+        ? Math.round(priceInOre * (1 + VAT_PERCENT / 100))
+        : priceInOre;
+}
+
+export function vatLabel(vatEnabled: boolean): string {
+    return vatEnabled ? 'incl. VAT' : 'excl. VAT';
+}

--- a/src/lib/statusUtils.ts
+++ b/src/lib/statusUtils.ts
@@ -1,0 +1,15 @@
+export function statusColor(status: string): string {
+    switch (status) {
+        case 'Active':
+        case 'Paid':
+            return 'bg-green-500/20 border-green-500/30 text-green-400';
+        case 'Reserved':
+        case 'Pending':
+            return 'bg-amber-500/20 border-amber-500/30 text-amber-400';
+        case 'Cancelled':
+        case 'Failed':
+            return 'bg-red-500/20 border-red-500/30 text-red-400';
+        default:
+            return 'bg-gray-700/50 border-gray-600/40 text-gray-500';
+    }
+}

--- a/src/lib/useEscapeKey.ts
+++ b/src/lib/useEscapeKey.ts
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+
+export function useEscapeKey(enabled: boolean, onEscape: () => void) {
+    useEffect(() => {
+        if (!enabled) return;
+        const handler = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') onEscape();
+        };
+        window.addEventListener('keydown', handler);
+        return () => window.removeEventListener('keydown', handler);
+    }, [enabled, onEscape]);
+}

--- a/src/lib/usePollUntilFinal.ts
+++ b/src/lib/usePollUntilFinal.ts
@@ -1,0 +1,61 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface PollResult<T> {
+    data: T | null;
+    loading: boolean;
+    refresh: () => void;
+}
+
+export function usePollUntilFinal<T>(
+    fetcher: () => Promise<T | null>,
+    isFinal: (value: T | null) => boolean,
+    options: { retries?: number; delayMs?: number } = {},
+): PollResult<T> {
+    const { retries = 8, delayMs = 4000 } = options;
+    const [data, setData] = useState<T | null>(null);
+    const [loading, setLoading] = useState(true);
+    const cancelled = useRef(false);
+    const timer = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+    const tickRef = useRef<() => Promise<void>>(async () => {});
+
+    const start = useCallback(() => {
+        cancelled.current = false;
+        setLoading(true);
+        let attempt = 0;
+
+        const tick = async () => {
+            try {
+                const value = await fetcher();
+                if (cancelled.current) return;
+                setData(value);
+                if (isFinal(value) || attempt >= retries) {
+                    setLoading(false);
+                    return;
+                }
+                attempt += 1;
+                timer.current = setTimeout(tick, delayMs);
+            } catch {
+                if (!cancelled.current) setLoading(false);
+            }
+        };
+        tickRef.current = tick;
+        tick();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [retries, delayMs]);
+
+    useEffect(() => {
+        start();
+        return () => {
+            cancelled.current = true;
+            if (timer.current) clearTimeout(timer.current);
+        };
+    }, [start]);
+
+    const refresh = useCallback(() => {
+        cancelled.current = true;
+        if (timer.current) clearTimeout(timer.current);
+        start();
+    }, [start]);
+
+    return { data, loading, refresh };
+}

--- a/src/services/adminService.ts
+++ b/src/services/adminService.ts
@@ -45,6 +45,7 @@ export interface EmailStats {
 
 export interface AppSettings {
     cookieBannerEnabled: boolean;
+    vatEnabled: boolean;
 }
 
 const AdminService = {

--- a/src/services/adminService.ts
+++ b/src/services/adminService.ts
@@ -46,6 +46,7 @@ export interface EmailStats {
 export interface AppSettings {
     cookieBannerEnabled: boolean;
     vatEnabled: boolean;
+    vippsTestMode: boolean;
 }
 
 const AdminService = {

--- a/src/services/productService.ts
+++ b/src/services/productService.ts
@@ -1,6 +1,7 @@
 import axiosInstance from '@/services/axiosInstance';
 
 export type BillingInterval = 'Monthly' | 'Yearly';
+export type ProductType = 'Primary' | 'AddOn';
 
 export interface Product {
     id: number;
@@ -8,6 +9,7 @@ export interface Product {
     description: string | null;
     priceInOre: number;
     interval: BillingInterval;
+    type: ProductType;
     isActive: boolean;
     createdAt: string;
 }
@@ -17,6 +19,7 @@ export interface CreateProductPayload {
     description?: string;
     priceInOre: number;
     interval: 0 | 1;
+    type: 0 | 1;
 }
 
 export interface UpdateProductPayload extends CreateProductPayload {

--- a/src/services/productService.ts
+++ b/src/services/productService.ts
@@ -1,0 +1,51 @@
+import axiosInstance from '@/services/axiosInstance';
+
+export type BillingInterval = 'Monthly' | 'Yearly';
+
+export interface Product {
+    id: number;
+    name: string;
+    description: string | null;
+    priceInOre: number;
+    interval: BillingInterval;
+    isActive: boolean;
+    createdAt: string;
+}
+
+export interface CreateProductPayload {
+    name: string;
+    description?: string;
+    priceInOre: number;
+    interval: 0 | 1;
+}
+
+export interface UpdateProductPayload extends CreateProductPayload {
+    isActive: boolean;
+}
+
+const ProductService = {
+    async getProducts(): Promise<Product[]> {
+        const res = await axiosInstance.get<Product[]>('/products');
+        return res.data;
+    },
+
+    async getProduct(id: number): Promise<Product> {
+        const res = await axiosInstance.get<Product>(`/products/${id}`);
+        return res.data;
+    },
+
+    async createProduct(payload: CreateProductPayload): Promise<Product> {
+        const res = await axiosInstance.post<Product>('/products', payload);
+        return res.data;
+    },
+
+    async updateProduct(id: number, payload: UpdateProductPayload): Promise<void> {
+        await axiosInstance.put(`/products/${id}`, payload);
+    },
+
+    async deleteProduct(id: number): Promise<void> {
+        await axiosInstance.delete(`/products/${id}`);
+    },
+};
+
+export default ProductService;

--- a/src/services/shopService.ts
+++ b/src/services/shopService.ts
@@ -37,6 +37,7 @@ export interface Order {
     vippsOrderId: string | null;
     status: OrderStatus;
     totalInOre: number;
+    isTest: boolean;
     items: OrderItem[];
     createdAt: string;
     updatedAt: string;

--- a/src/services/shopService.ts
+++ b/src/services/shopService.ts
@@ -1,0 +1,109 @@
+import axiosInstance from '@/services/axiosInstance';
+
+export interface ShopItem {
+    id: number;
+    name: string;
+    description: string | null;
+    priceInOre: number;
+    stockCount: number;
+    isActive: boolean;
+    createdAt: string;
+}
+
+export interface CreateShopItemPayload {
+    name: string;
+    description?: string;
+    priceInOre: number;
+    stockCount: number;
+}
+
+export interface UpdateShopItemPayload extends CreateShopItemPayload {
+    isActive: boolean;
+}
+
+export interface OrderItem {
+    id: number;
+    shopItemId: number;
+    shopItemName: string;
+    quantity: number;
+    priceAtPurchaseInOre: number;
+}
+
+export type OrderStatus = 'Pending' | 'Paid' | 'Failed' | 'Refunded' | 'Reserved' | 'Cancelled';
+
+export interface Order {
+    id: number;
+    userId: string;
+    vippsOrderId: string | null;
+    status: OrderStatus;
+    totalInOre: number;
+    items: OrderItem[];
+    createdAt: string;
+    updatedAt: string;
+}
+
+export interface AdminOrder extends Order {
+    userEmail: string;
+    userName: string;
+}
+
+export interface CheckoutPayload {
+    items: { shopItemId: number; quantity: number }[];
+    phoneNumber: string;
+    redirectUrl: string;
+}
+
+export interface CheckoutResponse {
+    orderId: number;
+    redirectUrl: string;
+}
+
+const ShopService = {
+    async getShopItems(): Promise<ShopItem[]> {
+        const res = await axiosInstance.get<ShopItem[]>('/shop/items');
+        return res.data;
+    },
+
+    async getShopItem(id: number): Promise<ShopItem> {
+        const res = await axiosInstance.get<ShopItem>(`/shop/items/${id}`);
+        return res.data;
+    },
+
+    async createShopItem(payload: CreateShopItemPayload): Promise<ShopItem> {
+        const res = await axiosInstance.post<ShopItem>('/shop/items', payload);
+        return res.data;
+    },
+
+    async updateShopItem(id: number, payload: UpdateShopItemPayload): Promise<void> {
+        await axiosInstance.put(`/shop/items/${id}`, payload);
+    },
+
+    async deleteShopItem(id: number): Promise<void> {
+        await axiosInstance.delete(`/shop/items/${id}`);
+    },
+
+    async checkout(payload: CheckoutPayload): Promise<CheckoutResponse> {
+        const res = await axiosInstance.post<CheckoutResponse>('/shop/checkout', payload);
+        return res.data;
+    },
+
+    async getMyOrders(): Promise<Order[]> {
+        const res = await axiosInstance.get<Order[]>('/shop/orders/my');
+        return res.data;
+    },
+
+    async getAllOrders(): Promise<AdminOrder[]> {
+        const res = await axiosInstance.get<AdminOrder[]>('/shop/orders');
+        return res.data;
+    },
+
+    async captureOrder(id: number): Promise<void> {
+        await axiosInstance.post(`/shop/orders/${id}/capture`);
+    },
+
+    async cancelOrder(id: number): Promise<void> {
+        await axiosInstance.post(`/shop/orders/${id}/cancel`);
+    },
+};
+
+export default ShopService;

--- a/src/services/shopService.ts
+++ b/src/services/shopService.ts
@@ -37,6 +37,9 @@ export interface Order {
     vippsOrderId: string | null;
     status: OrderStatus;
     totalInOre: number;
+    shippingAddress: string | null;
+    shippedAt: string | null;
+    hasInvoice: boolean;
     isTest: boolean;
     items: OrderItem[];
     createdAt: string;
@@ -51,7 +54,7 @@ export interface AdminOrder extends Order {
 export interface CheckoutPayload {
     items: { shopItemId: number; quantity: number }[];
     phoneNumber: string;
-    redirectUrl: string;
+    shippingAddress: string;
 }
 
 export interface CheckoutResponse {
@@ -104,6 +107,18 @@ const ShopService = {
 
     async cancelOrder(id: number): Promise<void> {
         await axiosInstance.post(`/shop/orders/${id}/cancel`);
+    },
+
+    async downloadInvoice(orderId: number): Promise<void> {
+        const res = await axiosInstance.get(`/shop/orders/${orderId}/invoice`, { responseType: 'blob' });
+        const url = URL.createObjectURL(res.data as Blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `invoice-order-${orderId}.pdf`;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        URL.revokeObjectURL(url);
     },
 };
 

--- a/src/services/subscriptionService.ts
+++ b/src/services/subscriptionService.ts
@@ -11,6 +11,7 @@ export interface Subscription {
     interval: string;
     vippsAgreementId: string;
     status: SubscriptionStatus;
+    isTest: boolean;
     startDate: string | null;
     nextChargeDate: string | null;
     createdAt: string;

--- a/src/services/subscriptionService.ts
+++ b/src/services/subscriptionService.ts
@@ -1,0 +1,54 @@
+import axiosInstance from '@/services/axiosInstance';
+
+export type SubscriptionStatus = 'Pending' | 'Active' | 'Stopped' | 'Expired';
+
+export interface Subscription {
+    id: number;
+    userId: string;
+    productId: number;
+    productName: string;
+    priceInOre: number;
+    interval: string;
+    vippsAgreementId: string;
+    status: SubscriptionStatus;
+    startDate: string | null;
+    nextChargeDate: string | null;
+    createdAt: string;
+    updatedAt: string;
+}
+
+export interface InitiateSubscriptionPayload {
+    productId: number;
+    phoneNumber: string;
+    redirectUrl: string;
+}
+
+export interface InitiateSubscriptionResponse {
+    subscriptionId: number;
+    vippsConfirmationUrl: string;
+    vippsAgreementId: string;
+}
+
+const SubscriptionService = {
+    async getMySubscription(): Promise<Subscription | null> {
+        try {
+            const res = await axiosInstance.get<Subscription>('/subscriptions/my');
+            if (res.status === 204) return null;
+            return res.data;
+        } catch (e: unknown) {
+            if ((e as { response?: { status?: number } })?.response?.status === 204) return null;
+            throw e;
+        }
+    },
+
+    async initiateSubscription(payload: InitiateSubscriptionPayload): Promise<InitiateSubscriptionResponse> {
+        const res = await axiosInstance.post<InitiateSubscriptionResponse>('/subscriptions/initiate', payload);
+        return res.data;
+    },
+
+    async cancelSubscription(): Promise<void> {
+        await axiosInstance.post('/subscriptions/cancel');
+    },
+};
+
+export default SubscriptionService;

--- a/src/services/subscriptionService.ts
+++ b/src/services/subscriptionService.ts
@@ -1,12 +1,14 @@
 import axiosInstance from '@/services/axiosInstance';
 
 export type SubscriptionStatus = 'Pending' | 'Active' | 'Stopped' | 'Expired';
+export type SubscriptionProductType = 'Primary' | 'AddOn';
 
 export interface Subscription {
     id: number;
     userId: string;
     productId: number;
     productName: string;
+    productType: SubscriptionProductType;
     priceInOre: number;
     interval: string;
     vippsAgreementId: string;
@@ -21,7 +23,7 @@ export interface Subscription {
 export interface InitiateSubscriptionPayload {
     productId: number;
     phoneNumber: string;
-    redirectUrl: string;
+    consentToWaiveWithdrawal: boolean;
 }
 
 export interface InitiateSubscriptionResponse {
@@ -31,15 +33,9 @@ export interface InitiateSubscriptionResponse {
 }
 
 const SubscriptionService = {
-    async getMySubscription(): Promise<Subscription | null> {
-        try {
-            const res = await axiosInstance.get<Subscription>('/subscriptions/my');
-            if (res.status === 204) return null;
-            return res.data;
-        } catch (e: unknown) {
-            if ((e as { response?: { status?: number } })?.response?.status === 204) return null;
-            throw e;
-        }
+    async getMySubscriptions(): Promise<Subscription[]> {
+        const res = await axiosInstance.get<Subscription[]>('/subscriptions/my');
+        return res.data;
     },
 
     async initiateSubscription(payload: InitiateSubscriptionPayload): Promise<InitiateSubscriptionResponse> {
@@ -47,8 +43,13 @@ const SubscriptionService = {
         return res.data;
     },
 
-    async cancelSubscription(): Promise<void> {
-        await axiosInstance.post('/subscriptions/cancel');
+    async cancelSubscription(id: number): Promise<void> {
+        await axiosInstance.post(`/subscriptions/cancel/${id}`);
+    },
+
+    async getConfirmationUrl(id: number): Promise<string> {
+        const res = await axiosInstance.get<{ vippsConfirmationUrl: string }>(`/subscriptions/${id}/confirmation-url`);
+        return res.data.vippsConfirmationUrl;
     },
 };
 

--- a/tests/e2e/admin-orders.spec.ts
+++ b/tests/e2e/admin-orders.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect, Page } from '@playwright/test'
+import { mockSession, mockApi, adminUser } from './helpers/auth'
+
+function reservedOrder(opts: {
+    id: number; createdDaysAgo: number; isTest?: boolean;
+}): unknown {
+    const created = new Date(Date.now() - opts.createdDaysAgo * 24 * 60 * 60 * 1000)
+    return {
+        id: opts.id, userId: 'user-1', userEmail: 'buyer@example.com', userName: 'Buyer Bob',
+        vippsOrderId: String(opts.id), status: 'Reserved', totalInOre: 50000,
+        shippingAddress: 'Testgata 1', shippedAt: null,
+        hasInvoice: false, isTest: opts.isTest ?? false,
+        items: [{ id: 1, shopItemId: 1, shopItemName: 'Sensor', quantity: 1, priceAtPurchaseInOre: 50000 }],
+        createdAt: created.toISOString(),
+        updatedAt: created.toISOString(),
+    }
+}
+
+async function setup(page: Page, orders: unknown[]) {
+    await mockSession(page, adminUser)
+    await mockApi(page, '/shop/orders', orders)
+    await page.goto('/admin/orders')
+}
+
+test.describe('Admin orders page', () => {
+    test('shows empty state when no orders', async ({ page }) => {
+        await setup(page, [])
+        await expect(page.getByText(/no orders yet/i)).toBeVisible()
+    })
+
+    test('renders Reserved order with countdown', async ({ page }) => {
+        await setup(page, [reservedOrder({ id: 1, createdDaysAgo: 1 })])
+        await expect(page.getByText(/order #1/i)).toBeVisible()
+        await expect(page.getByText(/reservation expires in/i)).toBeVisible()
+    })
+
+    test('reservation 1 day from expiry shows red warning', async ({ page }) => {
+        await setup(page, [reservedOrder({ id: 1, createdDaysAgo: 6 })])
+        const text = page.getByText(/reservation expires in 1 day/i)
+        await expect(text).toBeVisible()
+    })
+
+    test('expired reservation shows red expiry message', async ({ page }) => {
+        await setup(page, [reservedOrder({ id: 1, createdDaysAgo: 8 })])
+        await expect(page.getByText(/reservation expired/i)).toBeVisible()
+    })
+
+    test('test-mode order shows TEST pill', async ({ page }) => {
+        await setup(page, [reservedOrder({ id: 1, createdDaysAgo: 1, isTest: true })])
+        await expect(page.getByTitle('Test mode')).toBeVisible()
+    })
+
+    test('Capture button opens confirm modal', async ({ page }) => {
+        await setup(page, [reservedOrder({ id: 1, createdDaysAgo: 1 })])
+        await page.getByRole('button', { name: /capture payment/i }).click()
+        await expect(page.getByRole('alertdialog')).toBeVisible()
+        await expect(page.getByRole('heading', { name: /capture payment/i })).toBeVisible()
+    })
+
+    test('Cancel order button opens confirm modal', async ({ page }) => {
+        await setup(page, [reservedOrder({ id: 1, createdDaysAgo: 1 })])
+        await page.getByRole('button', { name: /cancel order/i }).click()
+        await expect(page.getByRole('alertdialog')).toBeVisible()
+    })
+
+    test('Escape closes capture confirm modal', async ({ page }) => {
+        await setup(page, [reservedOrder({ id: 1, createdDaysAgo: 1 })])
+        await page.getByRole('button', { name: /capture payment/i }).click()
+        await page.keyboard.press('Escape')
+        await expect(page.getByRole('alertdialog')).not.toBeVisible()
+    })
+})

--- a/tests/e2e/admin-products.spec.ts
+++ b/tests/e2e/admin-products.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect } from '@playwright/test'
+import { mockSession, mockApi, adminUser, regularUser } from './helpers/auth'
+
+const monthlyPrimary = {
+    id: 1, name: 'Garge Basic', type: 'Primary',
+    priceInOre: 29900, interval: 'Monthly', isActive: true, description: '',
+}
+const yearlyPrimary = {
+    id: 2, name: 'Garge Pro Annual', type: 'Primary',
+    priceInOre: 299000, interval: 'Yearly', isActive: true, description: '',
+}
+const addonProduct = {
+    id: 3, name: 'Extra Sensor', type: 'AddOn',
+    priceInOre: 4900, interval: 'Monthly', isActive: true, description: '',
+}
+
+test.describe('Admin products page', () => {
+    test('non-admin is redirected away from /admin/products', async ({ page }) => {
+        await mockSession(page, regularUser)
+        await page.goto('/admin/products')
+        await expect(page).not.toHaveURL(/admin\/products/, { timeout: 5000 })
+    })
+
+    test('renders product list for admin', async ({ page }) => {
+        await mockSession(page, adminUser)
+        await mockApi(page, '/api/products', [monthlyPrimary])
+        await page.goto('/admin/products')
+        await expect(page.getByText('Garge Basic')).toBeVisible()
+    })
+
+    test('shows Primary type badge', async ({ page }) => {
+        await mockSession(page, adminUser)
+        await mockApi(page, '/api/products', [monthlyPrimary])
+        await page.goto('/admin/products')
+        await expect(page.getByText('Primary')).toBeVisible()
+    })
+
+    test('shows Add-on type badge', async ({ page }) => {
+        await mockSession(page, adminUser)
+        await mockApi(page, '/api/products', [addonProduct])
+        await page.goto('/admin/products')
+        await expect(page.getByText('Add-on')).toBeVisible()
+    })
+
+    test('shows "mo" for Monthly interval, not Norwegian "mnd"', async ({ page }) => {
+        await mockSession(page, adminUser)
+        await mockApi(page, '/api/products', [monthlyPrimary])
+        await page.goto('/admin/products')
+        await expect(page.getByText(/\/ mo/)).toBeVisible()
+        await expect(page.getByText(/mnd/i)).not.toBeVisible()
+    })
+
+    test('shows "yr" for Yearly interval, not Norwegian "år"', async ({ page }) => {
+        await mockSession(page, adminUser)
+        await mockApi(page, '/api/products', [yearlyPrimary])
+        await page.goto('/admin/products')
+        await expect(page.getByText(/\/ yr/)).toBeVisible()
+        await expect(page.getByText(/\bår\b/i)).not.toBeVisible()
+    })
+
+    test('form has Primary and Add-on type options', async ({ page }) => {
+        await mockSession(page, adminUser)
+        await mockApi(page, '/api/products', [])
+        await page.goto('/admin/products')
+        await page.getByRole('button', { name: /add plan/i }).click()
+        await expect(page.getByRole('option', { name: 'Primary' })).toBeAttached()
+        await expect(page.getByRole('option', { name: 'Add-on' })).toBeAttached()
+    })
+})

--- a/tests/e2e/billing.spec.ts
+++ b/tests/e2e/billing.spec.ts
@@ -1,0 +1,136 @@
+import { test, expect, Page } from '@playwright/test'
+import { mockSession, mockApi, regularUser } from './helpers/auth'
+
+const primarySub = {
+    id: 1, productName: 'Garge Basic', productType: 'Primary',
+    status: 'Active', priceInOre: 29900, interval: 'Monthly',
+    isTest: false,
+    startDate: '2026-01-01', nextChargeDate: '2026-06-01',
+}
+const addonSub = {
+    id: 2, productName: 'Extra Sensor', productType: 'AddOn',
+    status: 'Active', priceInOre: 4900, interval: 'Monthly',
+    isTest: false,
+    startDate: '2026-01-01', nextChargeDate: '2026-06-01',
+}
+const pendingSub = {
+    id: 3, productName: 'Garge Basic', productType: 'Primary',
+    status: 'Pending', priceInOre: 29900, interval: 'Monthly',
+    isTest: false,
+    startDate: null, nextChargeDate: null,
+}
+const stoppedGraceSub = {
+    id: 4, productName: 'Garge Basic', productType: 'Primary',
+    status: 'Stopped', priceInOre: 29900, interval: 'Monthly',
+    isTest: false,
+    startDate: '2026-01-01', nextChargeDate: '2099-12-31',
+}
+const testSub = {
+    id: 5, productName: 'Garge Test', productType: 'Primary',
+    status: 'Active', priceInOre: 29900, interval: 'Monthly',
+    isTest: true,
+    startDate: '2026-01-01', nextChargeDate: '2026-06-01',
+}
+
+const paidOrder = {
+    id: 101, userId: 'user-1', vippsOrderId: '101',
+    status: 'Paid', totalInOre: 50000,
+    shippingAddress: 'Testgata 1', shippedAt: '2026-04-01',
+    hasInvoice: true, isTest: false,
+    items: [{ id: 1, shopItemId: 1, shopItemName: 'Sensor', quantity: 1, priceAtPurchaseInOre: 50000 }],
+    createdAt: '2026-03-30', updatedAt: '2026-04-01',
+}
+
+async function setup(page: Page, subscriptions: unknown[] = [], orders: unknown[] = [], vatEnabled = false) {
+    await mockSession(page, regularUser)
+    await mockApi(page, '/admin/settings', { vatEnabled, vippsTestMode: false })
+    await mockApi(page, '/subscriptions/my', subscriptions)
+    await mockApi(page, '/shop/orders/my', orders)
+    await page.goto('/profile/billing')
+}
+
+test.describe('Billing page', () => {
+    test('shows empty state when no subscriptions', async ({ page }) => {
+        await setup(page, [])
+        await expect(page.getByText('No active subscription.')).toBeVisible()
+        await expect(page.getByRole('link', { name: /browse plans/i })).toBeVisible()
+    })
+
+    test('shows Primary subscription card', async ({ page }) => {
+        await setup(page, [primarySub])
+        await expect(page.getByText('Garge Basic')).toBeVisible()
+        await expect(page.getByText('Primary', { exact: true })).toBeVisible()
+    })
+
+    test('shows Add-on badge for AddOn subscription', async ({ page }) => {
+        await setup(page, [addonSub])
+        await expect(page.getByText('Extra Sensor')).toBeVisible()
+        await expect(page.getByText('Add-on', { exact: true })).toBeVisible()
+    })
+
+    test('shows English VAT label when vatEnabled', async ({ page }) => {
+        await setup(page, [primarySub], [], true)
+        await expect(page.getByText(/incl\. VAT/).first()).toBeVisible()
+    })
+
+    test('cancel button opens confirmation modal', async ({ page }) => {
+        await setup(page, [primarySub])
+        await page.getByRole('button', { name: /^Cancel$/ }).first().click()
+        await expect(page.getByRole('heading', { name: 'Cancel subscription' })).toBeVisible()
+    })
+
+    test('cancel modal shows keep-access message with date', async ({ page }) => {
+        await setup(page, [primarySub])
+        await page.getByRole('button', { name: /^Cancel$/ }).first().click()
+        await expect(page.getByText(/you keep access until/i)).toBeVisible()
+    })
+
+    test('cancel modal warns about cascade for Primary', async ({ page }) => {
+        await setup(page, [primarySub])
+        await page.getByRole('button', { name: /^Cancel$/ }).first().click()
+        await expect(page.getByText(/cancelling primary also cancels.*add-on/i)).toBeVisible()
+    })
+
+    test('Pending subscription shows Complete in Vipps button', async ({ page }) => {
+        await setup(page, [pendingSub])
+        await expect(page.getByRole('button', { name: /complete in vipps/i })).toBeVisible()
+    })
+
+    test('Stopped sub in grace shows Cancelled note', async ({ page }) => {
+        await setup(page, [stoppedGraceSub])
+        await expect(page.getByText(/cancelled\. you keep access until/i)).toBeVisible()
+    })
+
+    test('Test subscription shows TEST pill', async ({ page }) => {
+        await setup(page, [testSub])
+        await expect(page.getByTitle('Test mode')).toBeVisible()
+    })
+
+    test('Paid order shows download invoice button', async ({ page }) => {
+        await setup(page, [], [paidOrder])
+        await expect(page.getByRole('button', { name: /download invoice/i })).toBeVisible()
+    })
+
+    test('Order link navigates to detail page', async ({ page }) => {
+        await setup(page, [], [paidOrder])
+        await page.getByRole('link', { name: /order #101/i }).click()
+        await expect(page).toHaveURL(/\/profile\/orders\/101/)
+    })
+
+    test('Resume Pending sub fetches confirmation URL', async ({ page }) => {
+        await mockSession(page, regularUser)
+        await mockApi(page, '/admin/settings', { vatEnabled: false, vippsTestMode: false })
+        await mockApi(page, '/subscriptions/my', [pendingSub])
+        await mockApi(page, '/shop/orders/my', [])
+        await mockApi(page, '/subscriptions/3/confirmation-url', {
+            vippsConfirmationUrl: 'https://example.test/vipps-redirect',
+        })
+        await page.goto('/profile/billing')
+
+        await page.route('https://example.test/vipps-redirect', route =>
+            route.fulfill({ status: 200, contentType: 'text/html', body: '<p>Vipps stub</p>' })
+        )
+        await page.getByRole('button', { name: /complete in vipps/i }).click()
+        await expect(page).toHaveURL(/example\.test\/vipps-redirect/, { timeout: 5000 })
+    })
+})

--- a/tests/e2e/helpers/auth.ts
+++ b/tests/e2e/helpers/auth.ts
@@ -1,0 +1,61 @@
+import { Page } from '@playwright/test';
+import { encode } from 'next-auth/jwt';
+
+const NEXTAUTH_SECRET = 'foobarfoobarfoobarfoobarfoobarfoobarfoobarfoobar';
+
+export interface MockUser {
+    id: string;
+    email: string;
+    name: string;
+    roles: string[];
+}
+
+export const adminUser: MockUser = {
+    id: 'admin-1',
+    email: 'admin@example.com',
+    name: 'Admin User',
+    roles: ['Admin'],
+};
+
+export const regularUser: MockUser = {
+    id: 'user-1',
+    email: 'user@example.com',
+    name: 'Regular User',
+    roles: [],
+};
+
+export async function mockSession(page: Page, user: MockUser) {
+    const token = await encode({
+        secret: NEXTAUTH_SECRET,
+        token: {
+            user: { id: user.id, name: user.name, email: user.email, roles: user.roles },
+            accessToken: 'test-access-token',
+            accessTokenExpires: Date.now() + 3_600_000,
+            loginAt: Date.now(),
+        },
+        maxAge: 3600,
+    });
+    await page.context().addCookies([{
+        name: 'next-auth.session-token',
+        value: token,
+        domain: 'localhost',
+        path: '/',
+        httpOnly: true,
+        secure: false,
+        sameSite: 'Lax',
+    }]);
+}
+
+export async function mockApi(page: Page, path: string, body: unknown, status = 200) {
+    await page.route(`**${path}`, route =>
+        route.fulfill({
+            status,
+            contentType: 'application/json',
+            body: JSON.stringify(body),
+        })
+    );
+}
+
+export async function mockNoSession(page: Page) {
+    await page.context().clearCookies();
+}

--- a/tests/e2e/order-detail.spec.ts
+++ b/tests/e2e/order-detail.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect, Page } from '@playwright/test'
+import { mockSession, mockApi, regularUser } from './helpers/auth'
+
+const paidOrder = {
+    id: 101, userId: 'user-1', vippsOrderId: '101',
+    status: 'Paid', totalInOre: 50000,
+    shippingAddress: 'Testgata 1, 0001 Oslo', shippedAt: '2026-04-01T12:00:00Z',
+    hasInvoice: true, isTest: false,
+    items: [
+        { id: 1, shopItemId: 1, shopItemName: 'Garge Sensor', quantity: 1, priceAtPurchaseInOre: 50000 },
+    ],
+    createdAt: '2026-03-30T10:00:00Z',
+    updatedAt: '2026-03-31T08:00:00Z',
+}
+
+const failedOrder = {
+    ...paidOrder,
+    id: 102, status: 'Failed', shippedAt: null, hasInvoice: false,
+}
+
+const reservedOrder = {
+    ...paidOrder,
+    id: 103, status: 'Reserved', shippedAt: null, hasInvoice: false,
+}
+
+async function setup(page: Page, orders: unknown[], orderId: number) {
+    await mockSession(page, regularUser)
+    await mockApi(page, '/shop/orders/my', orders)
+    await page.goto(`/profile/orders/${orderId}`)
+}
+
+test.describe('Order detail page', () => {
+    test('renders order header with status', async ({ page }) => {
+        await setup(page, [paidOrder], 101)
+        await expect(page.getByRole('heading', { name: /order #101/i })).toBeVisible()
+        await expect(page.getByText('Paid', { exact: true })).toBeVisible()
+    })
+
+    test('renders item list and total', async ({ page }) => {
+        await setup(page, [paidOrder], 101)
+        await expect(page.getByText('Garge Sensor × 1')).toBeVisible()
+        await expect(page.getByText('NOK 500,00').first()).toBeVisible()
+    })
+
+    test('renders shipping address', async ({ page }) => {
+        await setup(page, [paidOrder], 101)
+        await expect(page.getByText('Testgata 1, 0001 Oslo')).toBeVisible()
+    })
+
+    test('renders Vipps payment reference section', async ({ page }) => {
+        await setup(page, [paidOrder], 101)
+        await expect(page.getByRole('heading', { name: /payment reference/i })).toBeVisible()
+    })
+
+    test('shows download invoice button for Paid order', async ({ page }) => {
+        await setup(page, [paidOrder], 101)
+        await expect(page.getByRole('button', { name: /download invoice/i })).toBeVisible()
+    })
+
+    test('hides invoice download for Reserved order', async ({ page }) => {
+        await setup(page, [reservedOrder], 103)
+        await expect(page.getByRole('button', { name: /download invoice/i })).toHaveCount(0)
+    })
+
+    test('shows failure step in timeline for Failed order', async ({ page }) => {
+        await setup(page, [failedOrder], 102)
+        await expect(page.getByText('Failed').first()).toBeVisible()
+    })
+
+    test('renders not-found state for unknown order ID', async ({ page }) => {
+        await setup(page, [paidOrder], 999)
+        await expect(page.getByText(/order not found/i)).toBeVisible()
+        await expect(page.getByRole('link', { name: /back to billing/i })).toBeVisible()
+    })
+
+    test('timeline shows reached steps as active', async ({ page }) => {
+        await setup(page, [paidOrder], 101)
+        await expect(page.getByText('Order placed')).toBeVisible()
+        await expect(page.getByText('Payment reserved')).toBeVisible()
+        await expect(page.getByText('Payment captured')).toBeVisible()
+        await expect(page.getByText('Shipped')).toBeVisible()
+    })
+})

--- a/tests/e2e/return-pages.spec.ts
+++ b/tests/e2e/return-pages.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect, Page } from '@playwright/test'
+import { mockSession, mockApi, regularUser } from './helpers/auth'
+
+test.describe.configure({ timeout: 60_000 })
+
+const pendingOrder = {
+    id: 201, userId: 'user-1', vippsOrderId: '201', status: 'Pending',
+    totalInOre: 50000, shippingAddress: null, shippedAt: null,
+    hasInvoice: false, isTest: false, items: [],
+    createdAt: '2026-05-01', updatedAt: '2026-05-01',
+}
+const paidOrder = { ...pendingOrder, id: 202, status: 'Paid' }
+const failedOrder = { ...pendingOrder, id: 203, status: 'Failed' }
+
+const pendingSub = {
+    id: 301, productName: 'Garge Basic', productType: 'Primary',
+    status: 'Pending', priceInOre: 29900, interval: 'Monthly',
+    isTest: false, startDate: null, nextChargeDate: null,
+}
+const activeSub = { ...pendingSub, id: 302, status: 'Active' }
+
+async function setupShopReturn(page: Page, orders: unknown[], orderId: number) {
+    await mockSession(page, regularUser)
+    await mockApi(page, '/shop/orders/my', orders)
+    await page.goto(`/shop/return?orderId=${orderId}`)
+}
+
+async function setupBillingReturn(page: Page, subs: unknown[]) {
+    await mockSession(page, regularUser)
+    await mockApi(page, '/subscriptions/my', subs)
+    await page.goto('/profile/billing/return')
+}
+
+test.describe('Shop return page', () => {
+    test('Paid status shows success', async ({ page }) => {
+        await setupShopReturn(page, [paidOrder], 202)
+        await expect(page.getByText(/payment received/i)).toBeVisible()
+        await expect(page.getByRole('link', { name: /back to shop/i })).toBeVisible()
+    })
+
+    test('Failed status shows error message', async ({ page }) => {
+        await setupShopReturn(page, [failedOrder], 203)
+        await expect(page.getByText(/payment failed/i)).toBeVisible()
+        await expect(page.getByText(/no charge was made/i)).toBeVisible()
+    })
+
+    test('Pending status shows refresh button and email note', async ({ page }) => {
+        await setupShopReturn(page, [pendingOrder], 201)
+        await expect(page.getByText(/payment pending/i)).toBeVisible({ timeout: 45_000 })
+        await expect(page.getByRole('button', { name: /check again/i })).toBeVisible()
+        await expect(page.getByText(/we'll email you a receipt/i)).toBeVisible()
+    })
+
+    test('Pending shows View billing link', async ({ page }) => {
+        await setupShopReturn(page, [pendingOrder], 201)
+        await expect(page.getByRole('link', { name: /view billing/i })).toBeVisible({ timeout: 45_000 })
+    })
+})
+
+test.describe('Billing return page', () => {
+    test('Active sub shows success', async ({ page }) => {
+        await setupBillingReturn(page, [activeSub])
+        await expect(page.getByText(/subscription active/i)).toBeVisible()
+        await expect(page.getByRole('link', { name: /go to dashboard/i })).toBeVisible()
+    })
+
+    test('Pending sub shows refresh and email note', async ({ page }) => {
+        await setupBillingReturn(page, [pendingSub])
+        await expect(page.getByText(/pending confirmation/i)).toBeVisible({ timeout: 45_000 })
+        await expect(page.getByRole('button', { name: /check again/i })).toBeVisible()
+        await expect(page.getByText(/we'll send a confirmation/i)).toBeVisible()
+    })
+
+    test('No sub returns failure state', async ({ page }) => {
+        await setupBillingReturn(page, [])
+        await expect(page.getByText(/subscription not found/i)).toBeVisible({ timeout: 45_000 })
+    })
+})

--- a/tests/e2e/shop.spec.ts
+++ b/tests/e2e/shop.spec.ts
@@ -1,0 +1,175 @@
+import { test, expect, Page } from '@playwright/test'
+import { mockSession, mockApi, regularUser } from './helpers/auth'
+
+const sensorItem = {
+    id: 1, name: 'Garge Sensor', description: 'Bike battery monitor',
+    priceInOre: 50000, stockCount: 10, isActive: true,
+    createdAt: '2026-01-01',
+}
+const lowStockItem = {
+    id: 2, name: 'Almost Gone', description: null,
+    priceInOre: 12000, stockCount: 2, isActive: true,
+    createdAt: '2026-01-01',
+}
+const outOfStockItem = {
+    id: 3, name: 'Sold Out', description: null,
+    priceInOre: 9900, stockCount: 0, isActive: true,
+    createdAt: '2026-01-01',
+}
+const primaryProduct = {
+    id: 1, name: 'Garge Basic', description: 'Monthly plan',
+    priceInOre: 29900, interval: 'Monthly', type: 'Primary',
+    isActive: true, createdAt: '2026-01-01',
+}
+
+async function setup(page: Page, opts: {
+    items?: unknown[]; products?: unknown[]; vatEnabled?: boolean; vippsTestMode?: boolean
+} = {}) {
+    await mockSession(page, regularUser)
+    await mockApi(page, '/admin/settings', {
+        vatEnabled: opts.vatEnabled ?? false,
+        vippsTestMode: opts.vippsTestMode ?? false,
+    })
+    await mockApi(page, '/shop/items', opts.items ?? [])
+    await mockApi(page, '/products', opts.products ?? [])
+    await page.goto('/shop')
+}
+
+test.describe('Shop page — items', () => {
+    test('renders product card with name and price', async ({ page }) => {
+        await setup(page, { items: [sensorItem] })
+        await expect(page.getByText('Garge Sensor')).toBeVisible()
+        await expect(page.getByText('Bike battery monitor')).toBeVisible()
+        await expect(page.getByText('NOK 500,00')).toBeVisible()
+    })
+
+    test('shows VAT-inclusive price when VatEnabled', async ({ page }) => {
+        await setup(page, { items: [sensorItem], vatEnabled: true })
+        await expect(page.getByText('NOK 625,00')).toBeVisible()
+        await expect(page.getByText(/incl\. VAT/i).first()).toBeVisible()
+    })
+
+    test('shows "Only N left" warning when stock low', async ({ page }) => {
+        await setup(page, { items: [lowStockItem] })
+        await expect(page.getByText(/only 2 left/i)).toBeVisible()
+    })
+
+    test('out-of-stock item shows ribbon and hides Buy button', async ({ page }) => {
+        await setup(page, { items: [outOfStockItem] })
+        await expect(page.getByText(/out of stock/i)).toBeVisible()
+        await expect(page.getByRole('button', { name: /^Buy$/ })).toHaveCount(0)
+    })
+
+    test('quantity stepper increments and updates total', async ({ page }) => {
+        await setup(page, { items: [sensorItem] })
+        await expect(page.getByText('NOK 500,00').first()).toBeVisible()
+
+        await page.getByRole('button', { name: /increase quantity/i }).click()
+        await expect(page.getByText('NOK 1000,00')).toBeVisible()
+
+        await page.getByRole('button', { name: /increase quantity/i }).click()
+        await expect(page.getByText('NOK 1500,00')).toBeVisible()
+
+        await page.getByRole('button', { name: /decrease quantity/i }).click()
+        await expect(page.getByText('NOK 1000,00')).toBeVisible()
+    })
+
+    test('decrease disabled at quantity 1', async ({ page }) => {
+        await setup(page, { items: [sensorItem] })
+        await expect(page.getByRole('button', { name: /decrease quantity/i })).toBeDisabled()
+    })
+
+    test('test mode banner appears when enabled', async ({ page }) => {
+        await setup(page, { items: [sensorItem], vippsTestMode: true })
+        await expect(page.getByText(/vipps test mode is active/i)).toBeVisible()
+    })
+
+    test('test mode banner hidden when disabled', async ({ page }) => {
+        await setup(page, { items: [sensorItem] })
+        await expect(page.getByText(/vipps test mode is active/i)).not.toBeVisible()
+    })
+})
+
+test.describe('Shop page — payment modal', () => {
+    test('Buy opens payment modal with item summary', async ({ page }) => {
+        await setup(page, { items: [sensorItem] })
+        await page.getByRole('button', { name: /^Buy$/ }).click()
+        await expect(page.getByRole('dialog')).toBeVisible()
+        await expect(page.getByText(/pay with vipps/i)).toBeVisible()
+    })
+
+    test('phone input auto-focuses when modal opens', async ({ page }) => {
+        await setup(page, { items: [sensorItem] })
+        await page.getByRole('button', { name: /^Buy$/ }).click()
+        const phone = page.locator('input[type="tel"]')
+        await expect(phone).toBeFocused()
+    })
+
+    test('phone validates as user types — invalid then valid', async ({ page }) => {
+        await setup(page, { items: [sensorItem] })
+        await page.getByRole('button', { name: /^Buy$/ }).click()
+        const phone = page.locator('input[type="tel"]')
+
+        await phone.fill('123')
+        await expect(page.getByText(/use a norwegian number/i)).toBeVisible()
+
+        await phone.fill('91234567')
+        await expect(page.getByText(/norwegian mobile or landline/i)).toBeVisible()
+    })
+
+    test('Continue button disabled when phone invalid', async ({ page }) => {
+        await setup(page, { items: [sensorItem] })
+        await page.getByRole('button', { name: /^Buy$/ }).click()
+        await page.locator('input[type="tel"]').fill('123')
+        await expect(page.getByRole('button', { name: /continue to vipps/i })).toBeDisabled()
+    })
+
+    test('Continue still disabled when valid phone but missing shipping', async ({ page }) => {
+        await setup(page, { items: [sensorItem] })
+        await page.getByRole('button', { name: /^Buy$/ }).click()
+        await page.locator('input[type="tel"]').fill('91234567')
+        await page.getByRole('button', { name: /continue to vipps/i }).click()
+        await expect(page.getByText(/shipping address required/i)).toBeVisible()
+    })
+
+    test('Escape closes modal', async ({ page }) => {
+        await setup(page, { items: [sensorItem] })
+        await page.getByRole('button', { name: /^Buy$/ }).click()
+        await expect(page.getByRole('dialog')).toBeVisible()
+        await page.keyboard.press('Escape')
+        await expect(page.getByRole('dialog')).not.toBeVisible()
+    })
+
+    test('Cancel button closes modal', async ({ page }) => {
+        await setup(page, { items: [sensorItem] })
+        await page.getByRole('button', { name: /^Buy$/ }).click()
+        await page.getByRole('button', { name: /cancel payment/i }).click()
+        await expect(page.getByRole('dialog')).not.toBeVisible()
+    })
+})
+
+test.describe('Shop page — subscription modal', () => {
+    test('Subscribe opens modal with consent checkbox', async ({ page }) => {
+        await setup(page, { products: [primaryProduct] })
+        await page.getByRole('button', { name: /subscribe/i }).click()
+        await expect(page.getByRole('dialog')).toBeVisible()
+        await expect(page.getByText(/14-day right of withdrawal/i)).toBeVisible()
+    })
+
+    test('Continue disabled until consent checked', async ({ page }) => {
+        await setup(page, { products: [primaryProduct] })
+        await page.getByRole('button', { name: /subscribe/i }).click()
+        await page.locator('input[type="tel"]').fill('91234567')
+        const continueBtn = page.getByRole('button', { name: /continue to vipps/i })
+        await expect(continueBtn).toBeDisabled()
+        await page.getByRole('checkbox').check()
+        await expect(continueBtn).toBeEnabled()
+    })
+
+    test('Terms link in modal opens in new tab', async ({ page }) => {
+        await setup(page, { products: [primaryProduct] })
+        await page.getByRole('button', { name: /subscribe/i }).click()
+        const terms = page.getByRole('dialog').getByRole('link', { name: /terms of service/i })
+        await expect(terms).toHaveAttribute('target', '_blank')
+    })
+})

--- a/tests/e2e/subscription-gate.spec.ts
+++ b/tests/e2e/subscription-gate.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test'
+import { mockSession, mockApi, mockNoSession, regularUser } from './helpers/auth'
+
+test.describe('Subscription gate', () => {
+    test('unauthenticated user is redirected to login', async ({ page }) => {
+        await mockNoSession(page)
+        await page.goto('/profile/billing')
+        await expect(page).toHaveURL(/\/login/, { timeout: 5000 })
+    })
+
+    test('unauthenticated user visiting shop is redirected to login', async ({ page }) => {
+        await mockNoSession(page)
+        await page.goto('/shop')
+        await expect(page).toHaveURL(/\/login/, { timeout: 5000 })
+    })
+
+    test('billing page shows empty state for user with no subscriptions', async ({ page }) => {
+        await mockSession(page, regularUser)
+        await mockApi(page, '/admin/settings', { vatEnabled: false, vippsTestMode: false })
+        await mockApi(page, '/subscriptions/my', [])
+        await mockApi(page, '/shop/orders/my', [])
+        await page.goto('/profile/billing')
+        await expect(page.getByText('No active subscription.')).toBeVisible()
+    })
+
+    test('billing page shows "Browse plans" link when no subscriptions', async ({ page }) => {
+        await mockSession(page, regularUser)
+        await mockApi(page, '/admin/settings', { vatEnabled: false, vippsTestMode: false })
+        await mockApi(page, '/subscriptions/my', [])
+        await mockApi(page, '/shop/orders/my', [])
+        await page.goto('/profile/billing')
+        await expect(page.getByRole('link', { name: /browse plans/i })).toBeVisible()
+    })
+
+    test('shop page renders subscription plans section', async ({ page }) => {
+        await mockSession(page, regularUser)
+        await mockApi(page, '/admin/settings', { vatEnabled: false, vippsTestMode: false })
+        await mockApi(page, '/shop/items', [])
+        await mockApi(page, '/products', [])
+        await page.goto('/shop')
+        await expect(page.getByText(/subscription plans/i)).toBeVisible()
+    })
+
+    test('billing page shows active subscription for subscribed user', async ({ page }) => {
+        await mockSession(page, regularUser)
+        await mockApi(page, '/admin/settings', { vatEnabled: false, vippsTestMode: false })
+        await mockApi(page, '/subscriptions/my', [{
+            id: 1, productName: 'Garge Basic', productType: 'Primary',
+            status: 'Active', priceInOre: 29900, interval: 'Monthly',
+            startDate: '2026-01-01', nextChargeDate: '2026-06-01',
+        }])
+        await mockApi(page, '/shop/orders/my', [])
+        await page.goto('/profile/billing')
+        await expect(page.getByText('Garge Basic')).toBeVisible()
+        await expect(page.getByText('Active')).toBeVisible()
+    })
+})


### PR DESCRIPTION
## Summary

- `/shop` page: hardware products + subscription plans, both with Vipps phone modal
- `/profile/billing` page: active subscription status + cancel, order history
- Subscription return page with auto-retry on Pending status
- Shop return page with order status feedback
- Admin pages: products (subscription plans), shop items, orders
- Services: `productService`, `shopService`, `subscriptionService`
- Helpers: `formatUtils`, `statusUtils`, `company`

## Test plan

- [ ] `/shop` loads hardware items and subscription plans
- [ ] Subscription modal shows withdrawal consent checkbox; Subscribe disabled without it
- [ ] Hardware buy modal shows phone input, no withdrawal checkbox
- [ ] `/profile/billing` shows active subscription with cancel button
- [ ] `/profile/billing` with no sub shows "Browse plans" link to `/shop`
- [ ] Return pages show correct state (Active/Pending/Failed)