### PR TITLE
feat: drop checkout shipping form, show address in admin orders

### DIFF
--- a/src/app/(protected)/admin/orders/page.tsx
+++ b/src/app/(protected)/admin/orders/page.tsx
@@ -126,6 +126,13 @@ export default function AdminOrdersPage() {
                                             ))}
                                         </ul>
 
+                                        {order.shippingAddress && (
+                                            <div className="pt-2 border-t border-gray-700/30">
+                                                <p className="text-[10px] uppercase tracking-wider text-gray-500">Ship to</p>
+                                                <p className="text-xs text-gray-300 whitespace-pre-wrap">{order.shippingAddress}</p>
+                                            </div>
+                                        )}
+
                                         {reserved && (
                                             <div className="flex gap-2 pt-1">
                                                 <button

--- a/src/app/(protected)/shop/page.tsx
+++ b/src/app/(protected)/shop/page.tsx
@@ -26,8 +26,6 @@ export default function ShopPage() {
     const [phoneItemModal, setPhoneItemModal] = useState<{ item: ShopItem; quantity: number } | null>(null);
     const [phoneSubModal, setPhoneSubModal] = useState<Product | null>(null);
     const [savedPhone, setSavedPhone] = useLocalStorage('garge-phone', '');
-    const [savedAddress, setSavedAddress] = useLocalStorage('garge-shipping-address', '');
-    const [pendingAddress, setPendingAddress] = useState('');
     const [purchasing, setPurchasing] = useState(false);
     const [redirecting, setRedirecting] = useState(false);
     const [quantities, setQuantities] = useState<Record<number, number>>({});
@@ -60,7 +58,6 @@ export default function ShopPage() {
 
     function openItemModal(item: ShopItem) {
         setPhoneItemModal({ item, quantity: getQty(item.id) });
-        setPendingAddress(savedAddress);
     }
 
     function openSubModal(product: Product) {
@@ -72,20 +69,13 @@ export default function ShopPage() {
     }
 
     async function handleCheckout(item: ShopItem, quantity: number, msisdn: string) {
-        const address = pendingAddress.trim();
-        if (!address) {
-            toast.error('Shipping address required');
-            return;
-        }
         setPurchasing(true);
         try {
             const res = await ShopService.checkout({
                 items: [{ shopItemId: item.id, quantity }],
                 phoneNumber: msisdn,
-                shippingAddress: address,
             });
             setSavedPhone(msisdn);
-            setSavedAddress(address);
             setRedirecting(true);
             window.location.href = res.redirectUrl;
         } catch (err) {
@@ -227,17 +217,6 @@ export default function ShopPage() {
                             {' — '}
                             {formatNok(effectivePriceInOre(phoneItemModal.item.priceInOre, vatEnabled) * phoneItemModal.quantity)} {vatLabel(vatEnabled)}
                         </>
-                    }
-                    extraField={
-                        <input
-                            type="text"
-                            value={pendingAddress}
-                            onChange={e => setPendingAddress(e.target.value)}
-                            placeholder="Shipping address"
-                            aria-label="Shipping address"
-                            autoComplete="street-address"
-                            className="w-full bg-gray-800/60 border border-gray-700/60 rounded-lg px-3 py-2 text-sm text-gray-100 placeholder-gray-600 focus:outline-none focus:border-sky-500/60"
-                        />
                     }
                     initialPhone={savedPhone}
                     submitting={purchasing}

--- a/src/services/shopService.ts
+++ b/src/services/shopService.ts
@@ -54,7 +54,7 @@ export interface AdminOrder extends Order {
 export interface CheckoutPayload {
     items: { shopItemId: number; quantity: number }[];
     phoneNumber: string;
-    shippingAddress: string;
+    shippingAddress?: string;
 }
 
 export interface CheckoutResponse {

--- a/tests/e2e/admin-orders.spec.ts
+++ b/tests/e2e/admin-orders.spec.ts
@@ -50,6 +50,12 @@ test.describe('Admin orders page', () => {
         await expect(page.getByTitle('Test mode')).toBeVisible()
     })
 
+    test('shows shipping address', async ({ page }) => {
+        await setup(page, [reservedOrder({ id: 1, createdDaysAgo: 1 })])
+        await expect(page.getByText(/ship to/i)).toBeVisible()
+        await expect(page.getByText('Testgata 1')).toBeVisible()
+    })
+
     test('Capture button opens confirm modal', async ({ page }) => {
         await setup(page, [reservedOrder({ id: 1, createdDaysAgo: 1 })])
         await page.getByRole('button', { name: /capture payment/i }).click()

--- a/tests/e2e/shop.spec.ts
+++ b/tests/e2e/shop.spec.ts
@@ -124,14 +124,6 @@ test.describe('Shop page — payment modal', () => {
         await expect(page.getByRole('button', { name: /continue to vipps/i })).toBeDisabled()
     })
 
-    test('Continue still disabled when valid phone but missing shipping', async ({ page }) => {
-        await setup(page, { items: [sensorItem] })
-        await page.getByRole('button', { name: /^Buy$/ }).click()
-        await page.locator('input[type="tel"]').fill('91234567')
-        await page.getByRole('button', { name: /continue to vipps/i }).click()
-        await expect(page.getByText(/shipping address required/i)).toBeVisible()
-    })
-
     test('Escape closes modal', async ({ page }) => {
         await setup(page, { items: [sensorItem] })
         await page.getByRole('button', { name: /^Buy$/ }).click()


### PR DESCRIPTION
## Summary
- Drop the shipping-address input from the shop checkout modal — `garge-api` now pulls the address from the Vipps profile on `AUTHORIZED`, so retyping it in our own UI was just a worse copy. The local-storage cache (`garge-shipping-address`) is no longer written.
- `CheckoutPayload.shippingAddress` becomes optional in `shopService.ts` to match the new API contract.
- Render `shippingAddress` on the admin orders list so operators no longer need a DB query to see where to ship a Reserved order.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `vitest run` — 41/41 pass
- [ ] `playwright test` — local (added `shows shipping address` assertion in `admin-orders.spec`, removed obsolete missing-shipping toast assertion in `shop.spec`)
- [ ] After deploy: place a sensor order, complete in Vipps test app, confirm the order appears in `/admin/orders` with a `Ship to` block populated from the Vipps profile
- [ ] After deploy: confirm the checkout modal no longer renders a shipping-address input

## Notes
- Depends on garge-api PR #174 (`fix/vipps-checkout-address-and-invoice`) for the optional-address contract and the Vipps userinfo lookup. Merge order: api → app.
