### PR TITLE
fix: drop phone hint, show error only on invalid input

### DIFF
--- a/src/components/PaymentPhoneModal.tsx
+++ b/src/components/PaymentPhoneModal.tsx
@@ -86,11 +86,11 @@ export default function PaymentPhoneModal({
                             <CheckIcon className="absolute right-2.5 top-2.5 h-4 w-4 text-green-400" aria-hidden />
                         )}
                     </div>
-                    <p id="phone-hint" className="text-[11px] text-gray-600">
-                        {phoneTouched && !phoneValid
-                            ? 'Use a Norwegian number (8 digits, optionally prefixed with +47).'
-                            : 'Norwegian mobile or landline. Spaces and +47 OK.'}
-                    </p>
+                    {phoneTouched && !phoneValid && (
+                        <p id="phone-hint" role="alert" className="text-[11px] text-red-400">
+                            Enter a valid phone number.
+                        </p>
+                    )}
                 </div>
 
                 {extraField}

--- a/tests/e2e/shop.spec.ts
+++ b/tests/e2e/shop.spec.ts
@@ -111,10 +111,10 @@ test.describe('Shop page — payment modal', () => {
         const phone = page.locator('input[type="tel"]')
 
         await phone.fill('123')
-        await expect(page.getByText(/use a norwegian number/i)).toBeVisible()
+        await expect(page.getByText(/enter a valid phone number/i)).toBeVisible()
 
         await phone.fill('91234567')
-        await expect(page.getByText(/norwegian mobile or landline/i)).toBeVisible()
+        await expect(page.getByText(/enter a valid phone number/i)).not.toBeVisible()
     })
 
     test('Continue button disabled when phone invalid', async ({ page }) => {


### PR DESCRIPTION
## Summary
- The payment phone field had a permanent helper line saying `Norwegian mobile or landline. Spaces and +47 OK.` (resting) / `Use a Norwegian number (8 digits, optionally prefixed with +47).` (invalid). Reads as visual noise — the placeholder `91 23 45 67` already communicates format.
- Render the hint only when the input is touched and invalid, with a short generic `Enter a valid phone number.` plus `role="alert"` for assistive tech.
- Backend validation stays Norway-only (`src/lib/phone.ts` accepts 8 digits or 47-prefixed 10). This change is pure copy + visibility.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 41/41
- [ ] `npx playwright test tests/e2e/shop.spec.ts` — updated `phone validates as user types` assertion targets the new error string and confirms it disappears on a valid number.
- [ ] Manual: open shop, click Buy, confirm:
  - empty input: no helper line under field
  - `12`: red border + `Enter a valid phone number.` shown
  - `91234567`: green border, check icon, no error line
