### PR TITLE
feat: admin can download invoices from /admin/orders

### DIFF
--- a/src/app/(protected)/admin/orders/page.tsx
+++ b/src/app/(protected)/admin/orders/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { ArrowLeftIcon } from '@heroicons/react/24/outline';
+import { ArrowLeftIcon, ArrowDownTrayIcon } from '@heroicons/react/24/outline';
 import Section from '@/components/Section';
 import LoadingDots from '@/components/LoadingDots';
 import ConfirmModal from '@/components/ConfirmModal';
@@ -65,6 +65,14 @@ export default function AdminOrdersPage() {
             setCancelTarget(null);
         } catch (err) {
             toast.error(formatApiError(err, 'Failed to cancel order'));
+        }
+    }
+
+    async function handleDownloadInvoice(orderId: number) {
+        try {
+            await ShopService.downloadInvoice(orderId);
+        } catch (err) {
+            toast.error(formatApiError(err, 'Failed to download invoice'));
         }
     }
 
@@ -146,6 +154,18 @@ export default function AdminOrdersPage() {
                                                     className="px-3 py-1.5 bg-gray-700/60 hover:bg-red-900/40 border border-gray-600/40 hover:border-red-700/50 text-gray-400 hover:text-red-400 text-xs rounded-lg transition-all"
                                                 >
                                                     Cancel order
+                                                </button>
+                                            </div>
+                                        )}
+
+                                        {order.hasInvoice && (
+                                            <div className="flex pt-1">
+                                                <button
+                                                    onClick={() => handleDownloadInvoice(order.id)}
+                                                    className="inline-flex items-center gap-1.5 px-3 py-1.5 bg-gray-800/60 hover:bg-gray-700/80 border border-gray-700/50 text-gray-300 text-xs rounded-lg transition-colors"
+                                                >
+                                                    <ArrowDownTrayIcon className="h-3.5 w-3.5" aria-hidden />
+                                                    Download invoice
                                                 </button>
                                             </div>
                                         )}

--- a/tests/e2e/admin-orders.spec.ts
+++ b/tests/e2e/admin-orders.spec.ts
@@ -16,6 +16,19 @@ function reservedOrder(opts: {
     }
 }
 
+function paidOrder(opts: { id: number; hasInvoice: boolean }): unknown {
+    const created = new Date()
+    return {
+        id: opts.id, userId: 'user-1', userEmail: 'buyer@example.com', userName: 'Buyer Bob',
+        vippsOrderId: String(opts.id), status: 'Paid', totalInOre: 50000,
+        shippingAddress: 'Testgata 1', shippedAt: created.toISOString(),
+        hasInvoice: opts.hasInvoice, isTest: false,
+        items: [{ id: 1, shopItemId: 1, shopItemName: 'Sensor', quantity: 1, priceAtPurchaseInOre: 50000 }],
+        createdAt: created.toISOString(),
+        updatedAt: created.toISOString(),
+    }
+}
+
 async function setup(page: Page, orders: unknown[]) {
     await mockSession(page, adminUser)
     await mockApi(page, '/shop/orders', orders)
@@ -74,5 +87,15 @@ test.describe('Admin orders page', () => {
         await page.getByRole('button', { name: /capture payment/i }).click()
         await page.keyboard.press('Escape')
         await expect(page.getByRole('alertdialog')).not.toBeVisible()
+    })
+
+    test('Paid order with invoice shows Download invoice button', async ({ page }) => {
+        await setup(page, [paidOrder({ id: 7, hasInvoice: true })])
+        await expect(page.getByRole('button', { name: /download invoice/i })).toBeVisible()
+    })
+
+    test('Paid order without invoice hides Download invoice button', async ({ page }) => {
+        await setup(page, [paidOrder({ id: 8, hasInvoice: false })])
+        await expect(page.getByRole('button', { name: /download invoice/i })).toHaveCount(0)
     })
 })


### PR DESCRIPTION
## Summary
The admin orders page (`/admin/orders`) already receives `hasInvoice` on every `AdminOrder`, and `garge-api`'s `GetInvoicePdf` endpoint permits admins to fetch any order's invoice — but there was no UI button. Admins had to either know the URL or open the buyer's order-detail page. Add a small `Download invoice` button on each paid order whose `hasInvoice` is true; click calls the existing `ShopService.downloadInvoice(orderId)` helper, which streams the bytes and triggers a browser download via the same flow already used by buyers.

## Test plan
- [x] `npx tsc --noEmit` clean.
- [x] `npx vitest run` — 41/41.
- [x] Playwright spec: assert button visible on a paid+invoice order, absent on paid+no-invoice.
- [ ] Manual: log in as admin on `dev.garge.no`, open `/admin/orders`, click `Download invoice` on a paid order — PDF downloads as `invoice-order-{id}.pdf`.
