### PR TITLE
feat: render order + subscription stats on /admin landing

### DIFF
--- a/src/app/(protected)/admin/page.tsx
+++ b/src/app/(protected)/admin/page.tsx
@@ -242,7 +242,7 @@ export default function AdminPage() {
                                 { label: 'Active', value: stats?.subscriptions.active },
                                 { label: 'Pending confirm', value: stats?.subscriptions.pendingConfirm },
                                 { label: 'Stopped this month', value: stats?.subscriptions.stoppedThisMonth },
-                                { label: 'MRR', value: stats ? formatNok(stats.subscriptions.monthlyRecurringInOre) : undefined },
+                                { label: 'Monthly recurring revenue', value: stats ? formatNok(stats.subscriptions.monthlyRecurringInOre) : undefined },
                             ]).map(({ label, value }) => (
                                 <div key={label} className="bg-gray-900/50 border border-gray-700/40 rounded-xl p-4">
                                     <p className="text-2xl font-bold text-gray-100 tabular-nums">{value ?? '—'}</p>

--- a/src/app/(protected)/admin/page.tsx
+++ b/src/app/(protected)/admin/page.tsx
@@ -13,6 +13,7 @@ import { toast } from 'sonner';
 
 const TimeSeriesChart = dynamic(() => import('@/components/TimeSeriesChart'), { ssr: false });
 import AdminService, { AdminStats, AdminUser, StatSnapshot, EmailStats, AppSettings } from '@/services/adminService';
+import { formatNok } from '@/lib/formatUtils';
 
 type StatKey = 'totalUsers' | 'totalSensors' | 'totalSwitches' | 'totalAutomations';
 
@@ -212,6 +213,43 @@ export default function AdminPage() {
                                 />
                             </div>
                         )}
+                    </Section>
+
+                    {/* Orders */}
+                    <Section title="Orders">
+                        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                            {([
+                                { label: 'Today', value: stats?.orders.today },
+                                { label: 'This week', value: stats?.orders.thisWeek },
+                                { label: 'This month', value: stats?.orders.thisMonth },
+                                { label: 'Pending capture', value: stats?.orders.pendingCapture },
+                                { label: 'Failed / cancelled', value: stats?.orders.failedOrCancelled },
+                                { label: 'Month revenue', value: stats ? formatNok(stats.orders.monthRevenueInOre) : undefined },
+                                { label: 'Total revenue', value: stats ? formatNok(stats.orders.totalRevenueInOre) : undefined },
+                            ]).map(({ label, value }) => (
+                                <div key={label} className="bg-gray-900/50 border border-gray-700/40 rounded-xl p-4">
+                                    <p className="text-2xl font-bold text-gray-100 tabular-nums">{value ?? '—'}</p>
+                                    <p className="text-xs text-gray-500 mt-1">{label}</p>
+                                </div>
+                            ))}
+                        </div>
+                    </Section>
+
+                    {/* Subscriptions */}
+                    <Section title="Subscriptions">
+                        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                            {([
+                                { label: 'Active', value: stats?.subscriptions.active },
+                                { label: 'Pending confirm', value: stats?.subscriptions.pendingConfirm },
+                                { label: 'Stopped this month', value: stats?.subscriptions.stoppedThisMonth },
+                                { label: 'MRR', value: stats ? formatNok(stats.subscriptions.monthlyRecurringInOre) : undefined },
+                            ]).map(({ label, value }) => (
+                                <div key={label} className="bg-gray-900/50 border border-gray-700/40 rounded-xl p-4">
+                                    <p className="text-2xl font-bold text-gray-100 tabular-nums">{value ?? '—'}</p>
+                                    <p className="text-xs text-gray-500 mt-1">{label}</p>
+                                </div>
+                            ))}
+                        </div>
                     </Section>
 
                     {/* System Health */}

--- a/src/services/adminService.ts
+++ b/src/services/adminService.ts
@@ -1,10 +1,29 @@
 import axiosInstance from './axiosInstance';
 
+export interface AdminOrderStats {
+    today: number;
+    thisWeek: number;
+    thisMonth: number;
+    pendingCapture: number;
+    failedOrCancelled: number;
+    totalRevenueInOre: number;
+    monthRevenueInOre: number;
+}
+
+export interface AdminSubscriptionStats {
+    active: number;
+    pendingConfirm: number;
+    stoppedThisMonth: number;
+    monthlyRecurringInOre: number;
+}
+
 export interface AdminStats {
     totalUsers: number;
     totalSensors: number;
     totalSwitches: number;
     activeAutomations: number;
+    orders: AdminOrderStats;
+    subscriptions: AdminSubscriptionStats;
 }
 
 export interface AdminUser {


### PR DESCRIPTION
## Summary
Surface the new commerce metrics on the `/admin` landing page. Pulls from the matching backend PR (`feat/admin-order-sub-stats` on `garge-api`, PR #185), which extends `GET /api/admin/stats` with `orders` and `subscriptions` blocks.

Two new sections added below the existing Overview, before System Health:

- **Orders**: Today, This week, This month, Pending capture, Failed/cancelled, Month revenue, Total revenue. Currency cards rendered via `formatNok`.
- **Subscriptions**: Active, Pending confirm, Stopped this month, MRR.

Cards reuse the existing `bg-gray-900/50 border border-gray-700/40 rounded-xl` styling so the page rhythm matches.

## Test plan
- [x] `npx tsc --noEmit` clean.
- [x] `npx vitest run` — 41/41.
- [ ] Playwright spec for `/admin` landing doesn't exist today; manual verification only.
- [ ] Manual: log in as admin on `dev.garge.no`, open `/admin`, confirm two new card rows show numbers (or `—` while loading), revenue figures formatted as `NOK …`.

## Notes
- Depends on backend PR #185 (`feat: add order + subscription stats to /api/admin/stats`). Merge backend first, otherwise the frontend will render `—` for the new cards because the response shape lacks `orders` / `subscriptions`.
- No new charts. Existing `/admin/stats/history` chart on the Overview cards is unchanged.
