### PR TITLE
fix: defensive optional chaining on admin stats

### DIFF
--- a/src/app/(protected)/admin/page.tsx
+++ b/src/app/(protected)/admin/page.tsx
@@ -219,13 +219,13 @@ export default function AdminPage() {
                     <Section title="Orders">
                         <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
                             {([
-                                { label: 'Today', value: stats?.orders.today },
-                                { label: 'This week', value: stats?.orders.thisWeek },
-                                { label: 'This month', value: stats?.orders.thisMonth },
-                                { label: 'Pending capture', value: stats?.orders.pendingCapture },
-                                { label: 'Failed / cancelled', value: stats?.orders.failedOrCancelled },
-                                { label: 'Month revenue', value: stats ? formatNok(stats.orders.monthRevenueInOre) : undefined },
-                                { label: 'Total revenue', value: stats ? formatNok(stats.orders.totalRevenueInOre) : undefined },
+                                { label: 'Today', value: stats?.orders?.today },
+                                { label: 'This week', value: stats?.orders?.thisWeek },
+                                { label: 'This month', value: stats?.orders?.thisMonth },
+                                { label: 'Pending capture', value: stats?.orders?.pendingCapture },
+                                { label: 'Failed / cancelled', value: stats?.orders?.failedOrCancelled },
+                                { label: 'Month revenue', value: stats?.orders ? formatNok(stats.orders.monthRevenueInOre) : undefined },
+                                { label: 'Total revenue', value: stats?.orders ? formatNok(stats.orders.totalRevenueInOre) : undefined },
                             ]).map(({ label, value }) => (
                                 <div key={label} className="bg-gray-900/50 border border-gray-700/40 rounded-xl p-4">
                                     <p className="text-2xl font-bold text-gray-100 tabular-nums">{value ?? '—'}</p>
@@ -239,10 +239,10 @@ export default function AdminPage() {
                     <Section title="Subscriptions">
                         <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
                             {([
-                                { label: 'Active', value: stats?.subscriptions.active },
-                                { label: 'Pending confirm', value: stats?.subscriptions.pendingConfirm },
-                                { label: 'Stopped this month', value: stats?.subscriptions.stoppedThisMonth },
-                                { label: 'Monthly recurring revenue', value: stats ? formatNok(stats.subscriptions.monthlyRecurringInOre) : undefined },
+                                { label: 'Active', value: stats?.subscriptions?.active },
+                                { label: 'Pending confirm', value: stats?.subscriptions?.pendingConfirm },
+                                { label: 'Stopped this month', value: stats?.subscriptions?.stoppedThisMonth },
+                                { label: 'Monthly recurring revenue', value: stats?.subscriptions ? formatNok(stats.subscriptions.monthlyRecurringInOre) : undefined },
                             ]).map(({ label, value }) => (
                                 <div key={label} className="bg-gray-900/50 border border-gray-700/40 rounded-xl p-4">
                                     <p className="text-2xl font-bold text-gray-100 tabular-nums">{value ?? '—'}</p>

--- a/src/services/adminService.ts
+++ b/src/services/adminService.ts
@@ -22,8 +22,10 @@ export interface AdminStats {
     totalSensors: number;
     totalSwitches: number;
     activeAutomations: number;
-    orders: AdminOrderStats;
-    subscriptions: AdminSubscriptionStats;
+    // Optional so the UI keeps loading even if it talks to an older API build
+    // that hasn't shipped the new commerce stats yet.
+    orders?: AdminOrderStats;
+    subscriptions?: AdminSubscriptionStats;
 }
 
 export interface AdminUser {


### PR DESCRIPTION
Admin page crashed with `TypeError: can't access property "today", S.orders is undefined` when `/api/admin/stats` returned a payload without the new `orders` / `subscriptions` blocks (older API pod, transient deploy state, or any future response gap). The optional chain stopped at `stats?` and then hit hard-property access on a missing `orders` field.

- Mark `orders` and `subscriptions` as optional in the `AdminStats` interface.
- Chain through them with `?.` so each card falls back to the `—` placeholder instead of throwing.

41/41 vitest, type-check clean.
