### PR TITLE
feat: live / test toggle for admin commerce stats

### DIFF
--- a/src/app/(protected)/admin/page.tsx
+++ b/src/app/(protected)/admin/page.tsx
@@ -32,6 +32,8 @@ export default function AdminPage() {
     }, [status, isAdmin, router]);
 
     const [stats, setStats] = useState<AdminStats | null>(null);
+    const [statsTest, setStatsTest] = useState(false);
+    const [statsLoading, setStatsLoading] = useState(false);
     const [history, setHistory] = useState<StatSnapshot[]>([]);
     const [selectedStat, setSelectedStat] = useState<StatKey | null>('totalUsers');
     const [users, setUsers] = useState<AdminUser[]>([]);
@@ -61,7 +63,7 @@ export default function AdminPage() {
         setError(null);
         try {
             const [s, u, h] = await Promise.all([
-                AdminService.getStats(),
+                AdminService.getStats({ test: statsTest }),
                 AdminService.getUsers(),
                 AdminService.getStatsHistory(),
             ]);
@@ -73,6 +75,20 @@ export default function AdminPage() {
             setError('Failed to load admin data');
         } finally {
             setLoading(false);
+        }
+    }, [statsTest]);
+
+    const reloadStatsForTestToggle = useCallback(async (test: boolean) => {
+        setStatsTest(test);
+        setStatsLoading(true);
+        try {
+            const s = await AdminService.getStats({ test });
+            setStats(s);
+            setLoadedAt(new Date());
+        } catch {
+            toast.error('Failed to reload stats');
+        } finally {
+            setStatsLoading(false);
         }
     }, []);
 
@@ -214,6 +230,36 @@ export default function AdminPage() {
                             </div>
                         )}
                     </Section>
+
+                    {/* Live / Test toggle for the commerce stats */}
+                    <div className="flex items-center justify-between bg-gray-900/40 border border-gray-700/30 rounded-xl px-4 py-3">
+                        <div>
+                            <p className="text-xs text-gray-500 uppercase tracking-widest font-semibold">Commerce data</p>
+                            <p className="text-sm text-gray-300 mt-0.5">{statsTest ? 'Showing Vipps test orders + subscriptions' : 'Showing live orders + subscriptions'}</p>
+                        </div>
+                        <div className="flex bg-gray-800/60 border border-gray-700/40 rounded-lg p-0.5">
+                            {([
+                                { label: 'Live', value: false },
+                                { label: 'Test', value: true },
+                            ]).map(({ label, value }) => {
+                                const active = statsTest === value;
+                                return (
+                                    <button
+                                        key={label}
+                                        onClick={() => active || statsLoading ? null : reloadStatsForTestToggle(value)}
+                                        disabled={statsLoading}
+                                        className={`px-3 py-1 text-xs rounded-md transition-colors ${
+                                            active
+                                                ? 'bg-sky-600 text-white'
+                                                : 'text-gray-400 hover:text-gray-200'
+                                        }`}
+                                    >
+                                        {label}
+                                    </button>
+                                );
+                            })}
+                        </div>
+                    </div>
 
                     {/* Orders */}
                     <Section title="Orders">

--- a/src/services/adminService.ts
+++ b/src/services/adminService.ts
@@ -69,8 +69,10 @@ export interface AppSettings {
 }
 
 const AdminService = {
-    async getStats(): Promise<AdminStats> {
-        const res = await axiosInstance.get<AdminStats>('/admin/stats');
+    async getStats(opts?: { test?: boolean }): Promise<AdminStats> {
+        const res = await axiosInstance.get<AdminStats>('/admin/stats', {
+            params: opts?.test ? { test: true } : undefined,
+        });
         return res.data;
     },
 


### PR DESCRIPTION
## Summary
Pair with the new `?test=` query param on `garge-api`'s `/api/admin/stats` (PR #186). Add a small Live / Test segmented control above the Orders + Subscriptions cards on `/admin`. Flipping it refetches stats with the matching `IsTest` filter, so admins can sanity-check the test-mode set without bringing it into the live numbers.

- Defaults to **Live**.
- `AdminService.getStats()` now takes an optional `{ test }` flag that becomes the query param.
- New `reloadStatsForTestToggle` handler keeps the toggle interaction snappy (only refetches stats, not the full admin page).

## Test plan
- [x] `npx tsc --noEmit` clean.
- [x] `npx vitest run` — 41/41.
- [ ] Manual: log in as admin on `dev.garge.no/admin`, click `Test` — Orders + Subscriptions cards repopulate with the test-mode totals; click `Live` — back to the real numbers.

## Notes
- Depends on backend PR #186. Without it, the `test` query param is ignored and both views show the same numbers.
- Friendly with PR #236 (defensive optional chaining) — they touch the same file but don't conflict.
