### PR TITLE
feat: grey out AddOn plans when user has no active core subscription

### DIFF
--- a/src/app/(protected)/shop/page.tsx
+++ b/src/app/(protected)/shop/page.tsx
@@ -21,6 +21,7 @@ export default function ShopPage() {
     const [items, setItems] = useState<ShopItem[]>([]);
     const [products, setProducts] = useState<Product[]>([]);
     const [appSettings, setAppSettings] = useState<AppSettings | null>(null);
+    const [hasActivePrimary, setHasActivePrimary] = useState(false);
     const [loading, setLoading] = useState(true);
 
     const [phoneItemModal, setPhoneItemModal] = useState<{ item: ShopItem; quantity: number } | null>(null);
@@ -35,11 +36,14 @@ export default function ShopPage() {
             ShopService.getShopItems(),
             ProductService.getProducts(),
             AdminService.getAppSettings(),
+            // A 401/empty mySubs shouldn't break the shop, so swallow + treat as no primary.
+            SubscriptionService.getMySubscriptions().catch(() => []),
         ])
-            .then(([shopItems, prods, settings]) => {
+            .then(([shopItems, prods, settings, mySubs]) => {
                 setItems(shopItems);
                 setProducts(prods);
                 setAppSettings(settings);
+                setHasActivePrimary(mySubs.some(s => s.status === 'Active' && s.productType === 'Primary'));
             })
             .catch(err => toast.error(formatApiError(err, 'Failed to load shop')))
             .finally(() => setLoading(false));
@@ -61,9 +65,9 @@ export default function ShopPage() {
     }
 
     function openSubModal(product: Product) {
-        const hasPrimary = false;
-        if (product.type === 'AddOn' && !hasPrimary) {
-            // Server enforces this; UI nudge here too.
+        if (product.type === 'AddOn' && !hasActivePrimary) {
+            toast.error('Subscribe to the core plan first.');
+            return;
         }
         setPhoneSubModal(product);
     }
@@ -183,26 +187,42 @@ export default function ShopPage() {
                     <p className="text-sm text-gray-500">No plans available.</p>
                 ) : (
                     <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                        {products.map(p => (
-                            <div key={p.id} className="bg-gray-900/40 border border-gray-700/30 rounded-xl p-4 flex flex-col gap-3">
-                                <div className="flex-1">
-                                    <p className="text-sm font-semibold text-gray-100">{p.name}</p>
-                                    <p className="text-lg font-bold text-sky-400 mt-1">
-                                        {formatNok(effectivePriceInOre(p.priceInOre, vatEnabled))}
-                                        <span className="text-xs font-normal text-gray-500 ml-1">
-                                            / {p.interval === 'Monthly' ? 'month' : 'year'} · {vatLabel(vatEnabled)}
-                                        </span>
-                                    </p>
-                                    {p.description && <p className="text-xs text-gray-500 mt-1">{p.description}</p>}
-                                </div>
-                                <button
-                                    onClick={() => openSubModal(p)}
-                                    className="w-full px-4 py-2 bg-sky-600 hover:bg-sky-500 text-white text-sm font-medium rounded-lg transition-colors"
+                        {products.map(p => {
+                            const addOnLocked = p.type === 'AddOn' && !hasActivePrimary;
+                            return (
+                                <div
+                                    key={p.id}
+                                    className={`bg-gray-900/40 border border-gray-700/30 rounded-xl p-4 flex flex-col gap-3 ${
+                                        addOnLocked ? 'opacity-60 grayscale' : ''
+                                    }`}
                                 >
-                                    Subscribe
-                                </button>
-                            </div>
-                        ))}
+                                    <div className="flex-1">
+                                        <p className="text-sm font-semibold text-gray-100">{p.name}</p>
+                                        <p className="text-lg font-bold text-sky-400 mt-1">
+                                            {formatNok(effectivePriceInOre(p.priceInOre, vatEnabled))}
+                                            <span className="text-xs font-normal text-gray-500 ml-1">
+                                                / {p.interval === 'Monthly' ? 'month' : 'year'} · {vatLabel(vatEnabled)}
+                                            </span>
+                                        </p>
+                                        {p.description && <p className="text-xs text-gray-500 mt-1">{p.description}</p>}
+                                        {addOnLocked && (
+                                            <p className="text-xs text-amber-400 mt-2">Requires an active core subscription</p>
+                                        )}
+                                    </div>
+                                    <button
+                                        onClick={() => openSubModal(p)}
+                                        disabled={addOnLocked}
+                                        className={`w-full px-4 py-2 text-white text-sm font-medium rounded-lg transition-colors ${
+                                            addOnLocked
+                                                ? 'bg-gray-700 cursor-not-allowed'
+                                                : 'bg-sky-600 hover:bg-sky-500'
+                                        }`}
+                                    >
+                                        Subscribe
+                                    </button>
+                                </div>
+                            );
+                        })}
                     </div>
                 )}
             </Section>

--- a/src/app/(protected)/shop/page.tsx
+++ b/src/app/(protected)/shop/page.tsx
@@ -66,7 +66,7 @@ export default function ShopPage() {
 
     function openSubModal(product: Product) {
         if (product.type === 'AddOn' && !hasActivePrimary) {
-            toast.error('Subscribe to the core plan first.');
+            toast.error('Subscribe to the primary plan first.');
             return;
         }
         setPhoneSubModal(product);
@@ -206,7 +206,7 @@ export default function ShopPage() {
                                         </p>
                                         {p.description && <p className="text-xs text-gray-500 mt-1">{p.description}</p>}
                                         {addOnLocked && (
-                                            <p className="text-xs text-amber-400 mt-2">Requires an active core subscription</p>
+                                            <p className="text-xs text-amber-400 mt-2">Requires an active primary subscription</p>
                                         )}
                                     </div>
                                     <button

--- a/tests/e2e/shop.spec.ts
+++ b/tests/e2e/shop.spec.ts
@@ -23,7 +23,8 @@ const primaryProduct = {
 }
 
 async function setup(page: Page, opts: {
-    items?: unknown[]; products?: unknown[]; vatEnabled?: boolean; vippsTestMode?: boolean
+    items?: unknown[]; products?: unknown[]; vatEnabled?: boolean; vippsTestMode?: boolean;
+    mySubscriptions?: unknown[];
 } = {}) {
     await mockSession(page, regularUser)
     await mockApi(page, '/admin/settings', {
@@ -32,7 +33,22 @@ async function setup(page: Page, opts: {
     })
     await mockApi(page, '/shop/items', opts.items ?? [])
     await mockApi(page, '/products', opts.products ?? [])
+    await mockApi(page, '/subscriptions/my', opts.mySubscriptions ?? [])
     await page.goto('/shop')
+}
+
+const addOnProduct = {
+    id: 2, name: 'Garge Extra Sensor', description: 'Add another vehicle',
+    priceInOre: 4900, interval: 'Monthly', type: 'AddOn',
+    isActive: true, createdAt: '2026-01-01',
+}
+
+const activePrimarySubscription = {
+    id: 1, userId: 'user-1', productId: 1, productName: 'Garge Basic',
+    productType: 'Primary', priceInOre: 29900, interval: 'Monthly',
+    vippsAgreementId: 'agr-1', status: 'Active', isTest: false,
+    startDate: '2026-01-01', nextChargeDate: '2026-02-01',
+    createdAt: '2026-01-01', updatedAt: '2026-01-01',
 }
 
 test.describe('Shop page — items', () => {
@@ -163,5 +179,26 @@ test.describe('Shop page — subscription modal', () => {
         await page.getByRole('button', { name: /subscribe/i }).click()
         const terms = page.getByRole('dialog').getByRole('link', { name: /terms of service/i })
         await expect(terms).toHaveAttribute('target', '_blank')
+    })
+
+    test('AddOn locked when user has no active core subscription', async ({ page }) => {
+        await setup(page, { products: [primaryProduct, addOnProduct], mySubscriptions: [] })
+        await expect(page.getByText(/requires an active core subscription/i)).toBeVisible()
+
+        const subscribeButtons = page.getByRole('button', { name: /^Subscribe$/ })
+        await expect(subscribeButtons.nth(0)).toBeEnabled()   // Primary
+        await expect(subscribeButtons.nth(1)).toBeDisabled()  // AddOn
+    })
+
+    test('AddOn unlocked when user has active core subscription', async ({ page }) => {
+        await setup(page, {
+            products: [primaryProduct, addOnProduct],
+            mySubscriptions: [activePrimarySubscription],
+        })
+        await expect(page.getByText(/requires an active core subscription/i)).not.toBeVisible()
+
+        const subscribeButtons = page.getByRole('button', { name: /^Subscribe$/ })
+        await expect(subscribeButtons.nth(0)).toBeEnabled()
+        await expect(subscribeButtons.nth(1)).toBeEnabled()
     })
 })

--- a/tests/e2e/shop.spec.ts
+++ b/tests/e2e/shop.spec.ts
@@ -183,7 +183,7 @@ test.describe('Shop page — subscription modal', () => {
 
     test('AddOn locked when user has no active core subscription', async ({ page }) => {
         await setup(page, { products: [primaryProduct, addOnProduct], mySubscriptions: [] })
-        await expect(page.getByText(/requires an active core subscription/i)).toBeVisible()
+        await expect(page.getByText(/requires an active primary subscription/i)).toBeVisible()
 
         const subscribeButtons = page.getByRole('button', { name: /^Subscribe$/ })
         await expect(subscribeButtons.nth(0)).toBeEnabled()   // Primary
@@ -195,7 +195,7 @@ test.describe('Shop page — subscription modal', () => {
             products: [primaryProduct, addOnProduct],
             mySubscriptions: [activePrimarySubscription],
         })
-        await expect(page.getByText(/requires an active core subscription/i)).not.toBeVisible()
+        await expect(page.getByText(/requires an active primary subscription/i)).not.toBeVisible()
 
         const subscribeButtons = page.getByRole('button', { name: /^Subscribe$/ })
         await expect(subscribeButtons.nth(0)).toBeEnabled()


### PR DESCRIPTION
## Summary
`openSubModal` had `const hasPrimary = false` hardcoded, so AddOn plans rendered identical to the core plan and the only signal a user couldn't actually subscribe was a 4xx returned by the API after clicking. Confusing on `/shop` where the cards sit side by side.

- Fetch the user's subscriptions on shop load via `SubscriptionService.getMySubscriptions()` (failing soft to `[]`).
- Compute `hasActivePrimary = subs.some(s => s.status === 'Active' && s.productType === 'Primary')`.
- AddOn cards while `!hasActivePrimary`: `opacity-60 grayscale`, disabled Subscribe button, plus a small amber `Requires an active core subscription` note. Mirrors the out-of-stock treatment already used on shop items.
- `openSubModal` also bails with a toast if someone manages to click an AddOn while still locked.

## Test plan
- [x] `npx tsc --noEmit` clean.
- [x] `npx vitest run` — 41/41.
- [x] New playwright assertions: locked state shows the explainer + disabled button; unlocked state when an Active Primary sub is mocked.
- [ ] Manual: log in without a subscription → AddOn looks dimmed + disabled. Subscribe to the core plan → AddOn becomes clickable.

## Notes
- Backend already enforces this (subscription create rejects an AddOn without a Primary); this PR is just the UX/UI hint.
- Friendly with PR #237 (Live/Test stats toggle) and #236 (defensive admin chaining) — different files.
