### PR TITLE
style: widen commerce pages to max-w-7xl to match the rest of the app

### DIFF
--- a/src/app/(protected)/admin/orders/page.tsx
+++ b/src/app/(protected)/admin/orders/page.tsx
@@ -77,7 +77,7 @@ export default function AdminOrdersPage() {
     }
 
     return (
-        <div className="max-w-3xl mx-auto px-4 py-6 space-y-5 pb-32">
+        <div className="max-w-7xl mx-auto px-4 py-6 space-y-5 pb-32">
             <div className="flex items-center gap-3">
                 <Link href="/admin" className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-gray-700/60 transition-all" aria-label="Back to admin">
                     <ArrowLeftIcon className="h-4 w-4" aria-hidden />

--- a/src/app/(protected)/admin/products/page.tsx
+++ b/src/app/(protected)/admin/products/page.tsx
@@ -124,7 +124,7 @@ export default function AdminProductsPage() {
     }
 
     return (
-        <div className="max-w-3xl mx-auto px-4 py-6 space-y-5 pb-32">
+        <div className="max-w-7xl mx-auto px-4 py-6 space-y-5 pb-32">
             <div className="flex items-center gap-3">
                 <Link href="/admin" className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-gray-700/60 transition-all">
                     <ArrowLeftIcon className="h-4 w-4" />

--- a/src/app/(protected)/admin/shop/page.tsx
+++ b/src/app/(protected)/admin/shop/page.tsx
@@ -123,7 +123,7 @@ export default function AdminShopPage() {
     }
 
     return (
-        <div className="max-w-3xl mx-auto px-4 py-6 space-y-5 pb-32">
+        <div className="max-w-7xl mx-auto px-4 py-6 space-y-5 pb-32">
             <div className="flex items-center gap-3">
                 <Link href="/admin" className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-gray-700/60 transition-all">
                     <ArrowLeftIcon className="h-4 w-4" />

--- a/src/app/(protected)/profile/billing/page.tsx
+++ b/src/app/(protected)/profile/billing/page.tsx
@@ -100,7 +100,7 @@ export default function BillingPage() {
     if (loading) return <LoadingDots height="h-64" />;
 
     return (
-        <div className="max-w-2xl mx-auto px-4 py-6 space-y-5 pb-32">
+        <div className="max-w-7xl mx-auto px-4 py-6 space-y-5 pb-32">
             <div className="flex items-center gap-3">
                 <Link href="/profile" className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-gray-700/60 transition-all">
                     <ArrowLeftIcon className="h-4 w-4" aria-hidden />

--- a/src/app/(protected)/profile/orders/[id]/page.tsx
+++ b/src/app/(protected)/profile/orders/[id]/page.tsx
@@ -76,7 +76,7 @@ export default function OrderDetailPage({ params }: { params: Promise<{ id: stri
     const timeline = buildTimeline(order);
 
     return (
-        <div className="max-w-2xl mx-auto px-4 py-6 space-y-5 pb-32">
+        <div className="max-w-7xl mx-auto px-4 py-6 space-y-5 pb-32">
             <div className="flex items-center gap-3">
                 <Link href="/profile/billing" className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-gray-700/60 transition-all" aria-label="Back to billing">
                     <ArrowLeftIcon className="h-4 w-4" aria-hidden />

--- a/src/app/(protected)/shop/page.tsx
+++ b/src/app/(protected)/shop/page.tsx
@@ -108,7 +108,7 @@ export default function ShopPage() {
     if (loading) return <LoadingDots height="h-64" />;
 
     return (
-        <div className="max-w-2xl mx-auto px-4 py-6 space-y-5 pb-32">
+        <div className="max-w-7xl mx-auto px-4 py-6 space-y-5 pb-32">
             <h1 className="text-xl font-display font-bold text-gray-100">Shop</h1>
 
             <TestModeBanner settings={appSettings} />


### PR DESCRIPTION
Six pages were stuck at `max-w-2xl` / `max-w-3xl` while everything else (profile, electricity, automations, admin landing) uses `max-w-7xl`. On wide screens the commerce pages felt cramped against the same chrome.

Touched:
- `shop/page.tsx`
- `profile/billing/page.tsx`
- `profile/orders/[id]/page.tsx`
- `admin/orders/page.tsx`
- `admin/products/page.tsx`
- `admin/shop/page.tsx`

Single Tailwind class swap on the outermost wrapper of each, no markup or logic change.

Type-check clean, 41/41 vitest.