### PR TITLE
ci: declare secrets in workflow_call

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,6 +16,11 @@ on:
         description: "Tag for the Docker image"
         type: string
         required: true
+    secrets:
+      DOCKER_PASSWORD:
+        required: true
+      GARGE_PAT:
+        required: false
 
 permissions:
   contents: read


### PR DESCRIPTION
Fixes startup_failure by declaring DOCKER_PASSWORD and GARGE_PAT in docker.yml workflow_call secrets.