### PR TITLE
feat(signalr): live dashboard updates via DeviceHub

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.12.1",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
+        "@microsoft/signalr": "^9.0.6",
         "apexcharts": "^5.10.6",
         "axios": "^1.15.0",
         "date-fns": "^4.1.0",
@@ -1341,6 +1342,19 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@microsoft/signalr": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@microsoft/signalr/-/signalr-9.0.6.tgz",
+      "integrity": "sha512-DrhgzFWI9JE4RPTsHYRxh4yr+OhnwKz8bnJe7eIi7mLLjqhJpEb62CiUy/YbFvLqLzcGzlzz1QWgVAW0zyipMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "eventsource": "^2.0.2",
+        "fetch-cookie": "^2.0.3",
+        "node-fetch": "^2.6.7",
+        "ws": "^7.5.10"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -3190,6 +3204,18 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -4719,6 +4745,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -4788,6 +4832,31 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fetch-cookie": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-2.2.0.tgz",
+      "integrity": "sha512-h9AgfjURuCgA2+2ISl8GbavpUdR+WGAM2McW/ovn4tVccegp8ZqCKWSBR8uRdM8dDNlx5WdKRWxBYUwteLDCNQ==",
+      "license": "Unlicense",
+      "dependencies": {
+        "set-cookie-parser": "^2.4.8",
+        "tough-cookie": "^4.0.0"
+      }
+    },
+    "node_modules/fetch-cookie/node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/file-entry-cache": {
@@ -6650,6 +6719,48 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.38",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
@@ -7030,6 +7141,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7137,15 +7249,32 @@
         "node": ">=10"
       }
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -7311,6 +7440,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.6",
@@ -7535,6 +7670,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -8379,6 +8520,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -8453,6 +8603,16 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/uuid": {
@@ -8837,6 +8997,27 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
+    "@microsoft/signalr": "^9.0.6",
     "apexcharts": "^5.10.6",
     "axios": "^1.15.0",
     "date-fns": "^4.1.0",

--- a/src/app/DeviceDashboard.tsx
+++ b/src/app/DeviceDashboard.tsx
@@ -303,6 +303,12 @@ const DeviceDashboard: React.FC = () => {
 
     useEffect(() => { loadData(); }, [loadData]);
 
+    const refetchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const debouncedReload = useCallback(() => {
+        if (refetchTimer.current) clearTimeout(refetchTimer.current);
+        refetchTimer.current = setTimeout(() => { loadData(); }, 500);
+    }, [loadData]);
+
     useDeviceStream({
         onSwitch: (e) => {
             const newState = (e.value || '').trim().toUpperCase() || 'UNKNOWN';
@@ -324,6 +330,12 @@ const DeviceDashboard: React.FC = () => {
                     }
                     : d
             ));
+        },
+        onDeviceCreated: () => {
+            // New device appeared in the user's accessible set — re-fetch the
+            // full list. Debounced so a burst (e.g., onboarding several
+            // devices) collapses to a single network round-trip.
+            debouncedReload();
         },
     });
 

--- a/src/app/DeviceDashboard.tsx
+++ b/src/app/DeviceDashboard.tsx
@@ -14,6 +14,7 @@ import ConfirmModal from '@/components/ConfirmModal';
 import { groupEmoji } from '@/lib/groupIcons';
 import { useLocalStorage } from '@/lib/useLocalStorage';
 import CollapsibleSection from '@/components/CollapsibleSection';
+import { useDeviceStream } from '@/hooks/useDeviceStream';
 
 // ── Type sort order for group cards ───────────────────────────────────────────
 const TYPE_ORDER: Record<string, number> = { voltage: 0, temperature: 1, humidity: 2, socket: 3 };
@@ -301,6 +302,30 @@ const DeviceDashboard: React.FC = () => {
     }, []);
 
     useEffect(() => { loadData(); }, [loadData]);
+
+    useDeviceStream({
+        onSwitch: (e) => {
+            const newState = (e.value || '').trim().toUpperCase() || 'UNKNOWN';
+            setDevices(prev => prev.map(d =>
+                d.kind === 'socket' && d.id === e.switchId
+                    ? { ...d, latestState: newState, isActive: newState !== 'UNKNOWN' }
+                    : d
+            ));
+        },
+        onSensor: (e) => {
+            const numericValue = Number(e.value);
+            setDevices(prev => prev.map(d =>
+                d.kind === 'sensor' && d.id === e.sensorId
+                    ? {
+                        ...d,
+                        latestValue: Number.isFinite(numericValue) ? numericValue : d.latestValue,
+                        latestTimestamp: e.timestamp,
+                        isActive: true,
+                    }
+                    : d
+            ));
+        },
+    });
 
     const filterPills = useMemo(() => {
         const types = [...new Set(devices.map(d => d.type))].sort();

--- a/src/hooks/useDeviceStream.ts
+++ b/src/hooks/useDeviceStream.ts
@@ -18,16 +18,35 @@ export interface SensorEvent {
     timestamp: string;
 }
 
+export interface DeviceCreatedEvent {
+    kind: 'switch' | 'sensor';
+    id: number;
+}
+
 interface Handlers {
     onSwitch?: (e: SwitchEvent) => void;
     onSensor?: (e: SensorEvent) => void;
+    onDeviceCreated?: (e: DeviceCreatedEvent) => void;
+    onForceLogout?: () => void;
 }
 
-export function useDeviceStream({ onSwitch, onSensor }: Handlers): void {
-    const handlersRef = useRef<Handlers>({ onSwitch, onSensor });
-    handlersRef.current = { onSwitch, onSensor };
+/**
+ * Opens a SignalR connection to garge-api's DeviceHub for the current
+ * authenticated user and forwards events to the supplied handlers.
+ *
+ * Dependency array is intentionally `[]`: the connection lifecycle is tied
+ * to the component lifetime, not to handler identity. The latest handlers
+ * are captured into a ref on every render so consumers don't need to
+ * memoize callbacks; the ref is read inside the connection-event closures.
+ */
+export function useDeviceStream(handlers: Handlers): void {
+    const handlersRef = useRef<Handlers>(handlers);
 
     useEffect(() => {
+        // Refresh the ref each effect run so closures see latest handlers
+        // without re-creating the SignalR connection.
+        handlersRef.current = handlers;
+
         const apiBase = process.env.NEXT_PUBLIC_API_URL;
         if (!apiBase) return;
 
@@ -54,6 +73,12 @@ export function useDeviceStream({ onSwitch, onSensor }: Handlers): void {
             connection.on('sensor', (payload: SensorEvent) => {
                 handlersRef.current.onSensor?.(payload);
             });
+            connection.on('device-created', (payload: DeviceCreatedEvent) => {
+                handlersRef.current.onDeviceCreated?.(payload);
+            });
+            connection.on('forceLogout', () => {
+                handlersRef.current.onForceLogout?.();
+            });
 
             try {
                 await connection.start();
@@ -71,5 +96,6 @@ export function useDeviceStream({ onSwitch, onSensor }: Handlers): void {
             cancelled = true;
             connection?.stop().catch(() => { });
         };
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 }

--- a/src/hooks/useDeviceStream.ts
+++ b/src/hooks/useDeviceStream.ts
@@ -1,0 +1,75 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { HubConnection, HubConnectionBuilder, LogLevel } from '@microsoft/signalr';
+import { getSession } from 'next-auth/react';
+
+export interface SwitchEvent {
+    id: number;
+    switchId: number;
+    value: string;
+    timestamp: string;
+}
+
+export interface SensorEvent {
+    id: number;
+    sensorId: number;
+    value: string;
+    timestamp: string;
+}
+
+interface Handlers {
+    onSwitch?: (e: SwitchEvent) => void;
+    onSensor?: (e: SensorEvent) => void;
+}
+
+export function useDeviceStream({ onSwitch, onSensor }: Handlers): void {
+    const handlersRef = useRef<Handlers>({ onSwitch, onSensor });
+    handlersRef.current = { onSwitch, onSensor };
+
+    useEffect(() => {
+        const apiBase = process.env.NEXT_PUBLIC_API_URL;
+        if (!apiBase) return;
+
+        let cancelled = false;
+        let connection: HubConnection | null = null;
+
+        (async () => {
+            const hubUrl = `${apiBase.replace(/\/$/, '')}/hubs/devices`;
+
+            connection = new HubConnectionBuilder()
+                .withUrl(hubUrl, {
+                    accessTokenFactory: async () => {
+                        const session = await getSession();
+                        return session?.accessToken ?? '';
+                    },
+                })
+                .withAutomaticReconnect()
+                .configureLogging(LogLevel.Warning)
+                .build();
+
+            connection.on('switch', (payload: SwitchEvent) => {
+                handlersRef.current.onSwitch?.(payload);
+            });
+            connection.on('sensor', (payload: SensorEvent) => {
+                handlersRef.current.onSensor?.(payload);
+            });
+
+            try {
+                await connection.start();
+                if (cancelled) {
+                    await connection.stop();
+                }
+            } catch (err) {
+                if (process.env.NODE_ENV === 'development') {
+                    console.error('useDeviceStream connect failed:', err);
+                }
+            }
+        })();
+
+        return () => {
+            cancelled = true;
+            connection?.stop().catch(() => { });
+        };
+    }, []);
+}

--- a/src/tests/hooks/useDeviceStream.test.tsx
+++ b/src/tests/hooks/useDeviceStream.test.tsx
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import React from 'react';
+import { useDeviceStream } from '@/hooks/useDeviceStream';
+
+const handlers = new Map<string, (payload: unknown) => void>();
+
+const mockConnection = {
+    on: vi.fn((event: string, fn: (payload: unknown) => void) => {
+        handlers.set(event, fn);
+    }),
+    start: vi.fn(() => Promise.resolve()),
+    stop: vi.fn(() => Promise.resolve()),
+};
+
+const builderInstance = {
+    withUrl: vi.fn().mockReturnThis(),
+    withAutomaticReconnect: vi.fn().mockReturnThis(),
+    configureLogging: vi.fn().mockReturnThis(),
+    build: vi.fn(() => mockConnection),
+};
+
+vi.mock('@microsoft/signalr', () => ({
+    HubConnectionBuilder: function () {
+        return builderInstance;
+    },
+    LogLevel: { Warning: 3 },
+}));
+
+vi.mock('next-auth/react', () => ({
+    getSession: vi.fn(() => Promise.resolve({ accessToken: 'test-token' })),
+}));
+
+interface ProbeProps {
+    onSwitch?: (e: unknown) => void;
+    onSensor?: (e: unknown) => void;
+}
+const Probe: React.FC<ProbeProps> = ({ onSwitch, onSensor }) => {
+    useDeviceStream({ onSwitch, onSensor });
+    return null;
+};
+
+describe('useDeviceStream', () => {
+    beforeEach(() => {
+        handlers.clear();
+        mockConnection.on.mockClear();
+        mockConnection.start.mockClear();
+        mockConnection.stop.mockClear();
+        builderInstance.withUrl.mockClear();
+        process.env.NEXT_PUBLIC_API_URL = 'https://api.test';
+    });
+
+    afterEach(() => {
+        delete process.env.NEXT_PUBLIC_API_URL;
+    });
+
+    it('subscribes to switch and sensor events', async () => {
+        render(<Probe onSwitch={() => { }} onSensor={() => { }} />);
+        await waitFor(() => expect(mockConnection.start).toHaveBeenCalled());
+        expect(mockConnection.on).toHaveBeenCalledWith('switch', expect.any(Function));
+        expect(mockConnection.on).toHaveBeenCalledWith('sensor', expect.any(Function));
+    });
+
+    it('forwards switch payloads to onSwitch', async () => {
+        const onSwitch = vi.fn();
+        render(<Probe onSwitch={onSwitch} />);
+        await waitFor(() => expect(handlers.has('switch')).toBe(true));
+
+        const payload = { id: 1, switchId: 42, value: 'ON', timestamp: 'now' };
+        handlers.get('switch')!(payload);
+
+        expect(onSwitch).toHaveBeenCalledWith(payload);
+    });
+
+    it('forwards sensor payloads to onSensor', async () => {
+        const onSensor = vi.fn();
+        render(<Probe onSensor={onSensor} />);
+        await waitFor(() => expect(handlers.has('sensor')).toBe(true));
+
+        const payload = { id: 7, sensorId: 12, value: '23.4', timestamp: 'now' };
+        handlers.get('sensor')!(payload);
+
+        expect(onSensor).toHaveBeenCalledWith(payload);
+    });
+
+    it('builds the hub url from NEXT_PUBLIC_API_URL', async () => {
+        render(<Probe onSwitch={() => { }} />);
+        await waitFor(() => expect(builderInstance.withUrl).toHaveBeenCalled());
+        expect(builderInstance.withUrl).toHaveBeenCalledWith(
+            'https://api.test/hubs/devices',
+            expect.objectContaining({ accessTokenFactory: expect.any(Function) }),
+        );
+    });
+
+    it('stops the connection on unmount', async () => {
+        const { unmount } = render(<Probe onSwitch={() => { }} />);
+        await waitFor(() => expect(mockConnection.start).toHaveBeenCalled());
+        unmount();
+        expect(mockConnection.stop).toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary

- Dashboard now updates live for switch toggles and sensor readings — no more manual refresh needed.
- Subscribes to garge-api's `/hubs/devices` SignalR hub via a small `useDeviceStream` hook.
- Token refresh is handled by `accessTokenFactory` calling `getSession()` on every (re)connect, so JWT expiry just works through `withAutomaticReconnect()`.

## `useDeviceStream` hook

- Builds a `HubConnection` against `NEXT_PUBLIC_API_URL/hubs/devices`.
- Subscribes to two server events: `switch` and `sensor`.
- Forwards payloads to caller-supplied callbacks via a ref so consumers don't have to memoize handlers.
- Cleans up the connection on unmount.

## `DeviceDashboard` wiring

After the existing initial fetch, the hook merges events into `setDevices` keyed by id:

- Switch: normalize value to upper-case, set `latestState`, recompute `isActive`.
- Sensor: parse value as Number with NaN-safe fallback to the previous value; set `latestTimestamp`.

Initial-fetch path is unchanged; events only update existing devices in state. New devices that appear after mount still require a refresh (out of scope for this PR — a separate "device discovered" event would handle that).

## Data usage

Single TCP/WebSocket connection. Idle ≈ 0 bytes after handshake. Per-event ~150–250 bytes including SignalR framing. Realistic 24-hour usage with the dashboard open and a typical sensor + switch mix lands around 1–2 MB/day; idle ≈ 60 KB/day for keepalive.

## Test plan

- [x] `npm test` — 46 pass (41 existing + 5 new).
- [x] `npm run build` — clean.
- [ ] Open dashboard, toggle Wiz socket physically — card flips state without refresh within ~1 s.
- [ ] Open dashboard, trigger a sensor reading — card value updates live.
- [ ] Two browser tabs same user — both update simultaneously.
- [ ] Token-expiry: with a short JWT TTL, leave dashboard for >TTL and trigger an event — `accessTokenFactory` provides a fresh token on the next reconnect, event lands.

## Related

- garge-api: feat/signalr-device-events (Hub + dispatcher + sensor trigger + webhook removal)
- garge-operator: feat/signalr-device-events (operator becomes hub client; `/webhook` removed)

## Note on PR base

This branch sits on top of `fix/security-audit-and-gdpr-compliance`. Targeting that branch keeps the diff focused on SignalR work only. Retarget to `development` once the GDPR PR merges.
