### PR TITLE
fix(admin): fetch role list from api instead of hardcoding

### DIFF
--- a/src/app/(protected)/admin/page.tsx
+++ b/src/app/(protected)/admin/page.tsx
@@ -17,8 +17,6 @@ import { formatNok } from '@/lib/formatUtils';
 
 type StatKey = 'totalUsers' | 'totalSensors' | 'totalSwitches' | 'totalAutomations';
 
-const ALL_ROLES = ['Admin', 'Default', 'Electricity', 'SensorAdmin', 'MqttAdmin', 'AutomationAdmin', 'SwitchAdmin', 'ComplimentaryUser'];
-
 
 export default function AdminPage() {
     const { data: session, status } = useSession();
@@ -43,6 +41,7 @@ export default function AdminPage() {
     const [addRoleFor, setAddRoleFor] = useState<string | null>(null);
     const [selectedRole, setSelectedRole] = useState('');
     const [roleLoading, setRoleLoading] = useState(false);
+    const [allRoles, setAllRoles] = useState<string[]>([]);
 
     const [emailStats, setEmailStats] = useState<EmailStats | null>(null);
     const [emailStatsDays, setEmailStatsDays] = useState(30);
@@ -111,6 +110,13 @@ export default function AdminPage() {
     useEffect(() => {
         if (isAdmin) load();
     }, [isAdmin, load]);
+
+    useEffect(() => {
+        if (!isAdmin) return;
+        AdminService.getAllRoles()
+            .then(setAllRoles)
+            .catch(() => toast.error('Failed to load roles'));
+    }, [isAdmin]);
 
     useEffect(() => {
         if (!isAdmin) return;
@@ -476,7 +482,7 @@ export default function AdminPage() {
                                     <ul className="space-y-3">
                                         {paged.map((u) => {
                                             const isAddingRole = addRoleFor === u.id;
-                                            const available = ALL_ROLES.filter(r => !u.roles.includes(r));
+                                            const available = allRoles.filter(r => !u.roles.includes(r));
                                             return (
                                                 <li key={u.id} className="bg-gray-900/40 border border-gray-700/30 rounded-xl p-3 space-y-2">
                                                     <div className="flex items-start justify-between gap-2">

--- a/src/services/adminService.ts
+++ b/src/services/adminService.ts
@@ -90,6 +90,13 @@ const AdminService = {
         return '$values' in data ? data.$values : data;
     },
 
+    async getAllRoles(): Promise<string[]> {
+        const res = await axiosInstance.get<{ name: string }[] | { $values: { name: string }[] }>('/roles');
+        const data = res.data;
+        const list = '$values' in data ? data.$values : data;
+        return list.map(r => r.name);
+    },
+
     async assignRole(userEmail: string, roleName: string): Promise<void> {
         await axiosInstance.post(`/roles/${encodeURIComponent(roleName)}/users`, null, {
             params: { userEmail },


### PR DESCRIPTION
## Summary

`/admin` role-assignment dropdown was hardcoded with `ALL_ROLES = [...]` next to the canonical list in `garge-api/Constants/RoleNames.cs`. Adding `DeviceBridge` to the api didn't surface in the dropdown until the frontend was patched — a duplication that's silently drifted before.

Fix: use the existing `GET /api/roles` endpoint as the single source of truth.

## Changes

- `src/services/adminService.ts` — new `getAllRoles()` calling `GET /api/roles` and mapping `r => r.name`.
- `src/app/(protected)/admin/page.tsx` — remove hardcoded `ALL_ROLES`; add `allRoles` state populated by an effect; replace the single `ALL_ROLES.filter(...)` usage.

No api change. The endpoint already exists.

## Test plan

- [x] `npm test` — 46 pass.
- [x] `npm run build` — clean.
- [ ] Open `/admin` on dev → role dropdown shows the current role list including `DeviceBridge`. Add a future role to `RoleNames.AllRoles` on api, redeploy api only — frontend picks it up without rebuild.
