### PR TITLE
ci: run npm test + build on PRs and pushes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,12 +13,36 @@ on:
     branches:
       - development
       - main
+  pull_request:
 
 permissions:
   contents: read
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '23'
+          cache: 'npm'
+
+      - name: Install
+        run: npm ci
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+        env:
+          NEXT_PUBLIC_API_URL: https://garge-api-dev.prod.tumogroup.com/api
+
   dev:
+    needs: test
     if: github.ref == 'refs/heads/development'
     uses: equinor/ops-actions/.github/workflows/docker.yml@e925ef9959a37d43073b77efa2f73c64253fbd55 # v9.37.2
     secrets:
@@ -33,6 +57,7 @@ jobs:
       tag_latest: false
 
   prod:
+    needs: test
     if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
     uses: equinor/ops-actions/.github/workflows/docker.yml@e925ef9959a37d43073b77efa2f73c64253fbd55 # v9.37.2
     secrets:


### PR DESCRIPTION
## Summary

Bring `garge-app` CI in line with `garge-api` / `garge-operator`: run tests on every PR and on push, gate docker publish behind tests.

## Changes

- `.github/workflows/docker.yml`:
  - Added `pull_request:` trigger so PR diffs are tested before merge (was missing).
  - New `test` job: `actions/checkout` + `actions/setup-node@v4.4.0` (node 23 to match Dockerfile) + `npm ci` + `npm test` + `npm run build`.
  - `dev` and `prod` jobs gain `needs: test` — failing tests block docker publish.

The `npm run build` step uses the dev API URL since CI is environment-agnostic; the actual prod URL is still injected by the `prod` job's `build_args`.

## Test plan

- [x] Workflow YAML lints (no schema issues).
- [ ] On PR open: `test` job runs, all 46 Vitest specs pass, build completes.
- [ ] On merge to `development`: `test` runs, then `dev` publishes the image.
