### PR TITLE
fix(csp): allow wss:// to api host for SignalR

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -18,7 +18,13 @@ const nextConfig: NextConfig = {
     },
     async headers() {
         const apiOrigin = getApiOrigin();
-        const connectSrc = ['self', apiOrigin].filter(Boolean).map(s => s === 'self' ? "'self'" : s).join(' ');
+        // SignalR WebSocket transport uses ws/wss on the same host as the
+        // REST origin. CSP connect-src needs both schemes.
+        const apiWsOrigin = apiOrigin.replace(/^https:/, 'wss:').replace(/^http:/, 'ws:');
+        const connectSrc = ['self', apiOrigin, apiWsOrigin]
+            .filter(Boolean)
+            .map(s => s === 'self' ? "'self'" : s)
+            .join(' ');
 
         const isDev = process.env.NODE_ENV !== 'production';
         const scriptSrc = isDev


### PR DESCRIPTION
## Summary

Prod console:

```
Content-Security-Policy: blocked the loading of a resource (connect-src)
at wss://garge-api.prod.tumogroup.com/hubs/devices?id=...&access_token=...
because it violates the following directive:
"connect-src 'self' https://garge-api.prod.tumogroup.com"
```

`next.config.ts` derives `connect-src` from `NEXT_PUBLIC_API_URL`'s origin, but only emits the `https://` form. SignalR's WebSocket transport upgrades to `wss://` and gets blocked.

## Fix

Append the `ws/wss` equivalent of the api origin to `connect-src` so both schemes are allowed.

```
connect-src 'self' https://garge-api.prod.tumogroup.com wss://garge-api.prod.tumogroup.com
```

## Test plan

- [x] `npm run build` clean.
- [ ] Deploy → open dashboard → `wss://` SignalR connection establishes (network tab WS column shows the hub frame), no CSP violation in console.
