### PR TITLE
fix(csp): allow wss:// to api host for SignalR (#251)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -18,7 +18,13 @@ const nextConfig: NextConfig = {
     },
     async headers() {
         const apiOrigin = getApiOrigin();
-        const connectSrc = ['self', apiOrigin].filter(Boolean).map(s => s === 'self' ? "'self'" : s).join(' ');
+        // SignalR WebSocket transport uses ws/wss on the same host as the
+        // REST origin. CSP connect-src needs both schemes.
+        const apiWsOrigin = apiOrigin.replace(/^https:/, 'wss:').replace(/^http:/, 'ws:');
+        const connectSrc = ['self', apiOrigin, apiWsOrigin]
+            .filter(Boolean)
+            .map(s => s === 'self' ? "'self'" : s)
+            .join(' ');
 
         const isDev = process.env.NODE_ENV !== 'production';
         const scriptSrc = isDev


### PR DESCRIPTION
The connect-src directive only listed the https origin from NEXT_PUBLIC_API_URL, so the browser blocked the SignalR WebSocket upgrade in prod with:

  Content-Security-Policy: blocked the loading of a resource
  (connect-src) at wss://garge-api.prod.tumogroup.com/hubs/devices...
  because it violates the following directive:
  connect-src 'self' https://garge-api.prod.tumogroup.com

Add the ws/wss equivalent of the api origin to connect-src so the hub's WebSocket transport works.