### PR TITLE
refactor(profile): inline edit name/phone in Account block, wire phone into shop

### DIFF
--- a/src/app/(protected)/profile/page.tsx
+++ b/src/app/(protected)/profile/page.tsx
@@ -7,7 +7,8 @@ import UserService from '@/services/userService';
 import { UserDTO } from '@/dto/UserDTO';
 import SensorService from '@/services/sensorService';
 import SwitchService from '@/services/switchService';
-import { ChevronRightIcon } from '@heroicons/react/24/outline';
+import { ChevronRightIcon, PencilIcon, CheckIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import { normalizeNoPhone } from '@/lib/phone';
 import { isPushSupported, isPushSubscribed, subscribeToPush, unsubscribeFromPush, sendTestNotification } from '@/services/pushNotificationService';
 import ConfirmModal from '@/components/ConfirmModal';
 import LoadingDots from '@/components/LoadingDots';
@@ -51,6 +52,7 @@ const Profile: React.FC = () => {
     const [editLastName, setEditLastName] = useState('');
     const [editPhone, setEditPhone] = useState('');
     const [profileSaving, setProfileSaving] = useState(false);
+    const [editingField, setEditingField] = useState<'name' | 'phone' | null>(null);
 
     useEffect(() => {
         if (!isAuthenticated) { router.push('/login'); return; }
@@ -59,9 +61,6 @@ const Profile: React.FC = () => {
             setPriceZone(u.priceZone ?? 'NO2');
             setPushEnabled(u.pushNotificationsEnabled ?? false);
             setOfflineThreshold(u.offlineAlertThresholdHours > 0 ? u.offlineAlertThresholdHours : 4);
-            setEditFirstName(u.firstName ?? '');
-            setEditLastName(u.lastName ?? '');
-            setEditPhone(u.phoneNumber ?? '');
         }).catch(console.error).finally(() => setProfileLoading(false));
         if (isPushSupported()) {
             setPushPermission(Notification.permission);
@@ -78,23 +77,66 @@ const Profile: React.FC = () => {
         return () => clearTimeout(timer);
     }, [countdown]);
 
-    const handleProfileSave = async () => {
+    const startEditName = () => {
+        if (!user) return;
+        setEditFirstName(user.firstName ?? '');
+        setEditLastName(user.lastName ?? '');
+        setEditingField('name');
+    };
+
+    const startEditPhone = () => {
+        if (!user) return;
+        setEditPhone(user.phoneNumber ?? '');
+        setEditingField('phone');
+    };
+
+    const cancelEdit = () => setEditingField(null);
+
+    const handleSaveName = async () => {
         if (!user?.id) return;
-        if (!editFirstName.trim() || !editLastName.trim()) {
+        const first = editFirstName.trim();
+        const last = editLastName.trim();
+        if (!first || !last) {
             toast.error('First name and last name are required.');
             return;
         }
         setProfileSaving(true);
         try {
             await UserService.updateProfile(user.id, {
-                firstName: editFirstName.trim(),
-                lastName: editLastName.trim(),
-                phoneNumber: editPhone.trim() || undefined,
+                firstName: first,
+                lastName: last,
+                phoneNumber: user.phoneNumber || undefined,
             });
-            setUser(prev => prev ? { ...prev, firstName: editFirstName.trim(), lastName: editLastName.trim(), phoneNumber: editPhone.trim() } : prev);
-            toast.success('Profile updated.');
+            setUser(prev => prev ? { ...prev, firstName: first, lastName: last } : prev);
+            setEditingField(null);
+            toast.success('Name updated.');
         } catch (err) {
-            toast.error(err instanceof Error ? err.message : 'Failed to update profile.');
+            toast.error(err instanceof Error ? err.message : 'Failed to update name.');
+        } finally {
+            setProfileSaving(false);
+        }
+    };
+
+    const handleSavePhone = async () => {
+        if (!user?.id) return;
+        const raw = editPhone.trim();
+        const normalized = raw ? normalizeNoPhone(raw) : '';
+        if (raw && normalized === null) {
+            toast.error('Enter a valid phone number.');
+            return;
+        }
+        setProfileSaving(true);
+        try {
+            await UserService.updateProfile(user.id, {
+                firstName: user.firstName,
+                lastName: user.lastName,
+                phoneNumber: normalized || undefined,
+            });
+            setUser(prev => prev ? { ...prev, phoneNumber: normalized || '' } : prev);
+            setEditingField(null);
+            toast.success('Phone number updated.');
+        } catch (err) {
+            toast.error(err instanceof Error ? err.message : 'Failed to update phone number.');
         } finally {
             setProfileSaving(false);
         }
@@ -269,13 +311,96 @@ const Profile: React.FC = () => {
                 <Section title="Account">
                     {isUserLoading ? <LoadingDots /> : (
                         <div className="space-y-3">
-                            <div className="flex items-center justify-between py-2 border-b border-gray-700/40">
-                                <span className="text-sm text-gray-400">Name</span>
-                                <span className="text-sm text-gray-100">{user.firstName} {user.lastName}</span>
+                            <div className="py-2 border-b border-gray-700/40">
+                                {editingField === 'name' ? (
+                                    <div className="space-y-2">
+                                        <span className="text-sm text-gray-400">Name</span>
+                                        <div className="grid grid-cols-2 gap-2">
+                                            <input
+                                                type="text"
+                                                value={editFirstName}
+                                                onChange={e => setEditFirstName(e.target.value)}
+                                                placeholder="First name"
+                                                className={inputClass}
+                                                autoFocus
+                                                disabled={profileSaving}
+                                            />
+                                            <input
+                                                type="text"
+                                                value={editLastName}
+                                                onChange={e => setEditLastName(e.target.value)}
+                                                placeholder="Last name"
+                                                className={inputClass}
+                                                disabled={profileSaving}
+                                            />
+                                        </div>
+                                        <div className="flex gap-2">
+                                            <button onClick={handleSaveName} disabled={profileSaving} className="flex items-center gap-1.5 px-3 py-1.5 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 text-white text-xs font-medium rounded-lg transition-all">
+                                                <CheckIcon className="h-3.5 w-3.5" />
+                                                {profileSaving ? 'Saving…' : 'Save'}
+                                            </button>
+                                            <button onClick={cancelEdit} disabled={profileSaving} className="flex items-center gap-1.5 px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-300 text-xs font-medium rounded-lg transition-all">
+                                                <XMarkIcon className="h-3.5 w-3.5" />
+                                                Cancel
+                                            </button>
+                                        </div>
+                                    </div>
+                                ) : (
+                                    <div className="flex items-center justify-between">
+                                        <span className="text-sm text-gray-400">Name</span>
+                                        <div className="flex items-center gap-2">
+                                            <span className="text-sm text-gray-100">{user.firstName} {user.lastName}</span>
+                                            <button onClick={startEditName} aria-label="Edit name" className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-gray-700/60 transition-all">
+                                                <PencilIcon className="h-3.5 w-3.5" />
+                                            </button>
+                                        </div>
+                                    </div>
+                                )}
                             </div>
                             <div className="flex items-center justify-between py-2 border-b border-gray-700/40">
                                 <span className="text-sm text-gray-400">Email</span>
                                 <span className="text-sm text-gray-100">{user.email}</span>
+                            </div>
+                            <div className="py-2 border-b border-gray-700/40">
+                                {editingField === 'phone' ? (
+                                    <div className="space-y-2">
+                                        <span className="text-sm text-gray-400">Phone</span>
+                                        <input
+                                            type="tel"
+                                            inputMode="tel"
+                                            autoComplete="tel"
+                                            value={editPhone}
+                                            onChange={e => setEditPhone(e.target.value)}
+                                            placeholder="91 23 45 67"
+                                            className={inputClass}
+                                            autoFocus
+                                            disabled={profileSaving}
+                                        />
+                                        {editPhone.trim() && normalizeNoPhone(editPhone) === null && (
+                                            <p className="text-[11px] text-red-400">Enter a valid phone number.</p>
+                                        )}
+                                        <div className="flex gap-2">
+                                            <button onClick={handleSavePhone} disabled={profileSaving} className="flex items-center gap-1.5 px-3 py-1.5 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 text-white text-xs font-medium rounded-lg transition-all">
+                                                <CheckIcon className="h-3.5 w-3.5" />
+                                                {profileSaving ? 'Saving…' : 'Save'}
+                                            </button>
+                                            <button onClick={cancelEdit} disabled={profileSaving} className="flex items-center gap-1.5 px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-300 text-xs font-medium rounded-lg transition-all">
+                                                <XMarkIcon className="h-3.5 w-3.5" />
+                                                Cancel
+                                            </button>
+                                        </div>
+                                    </div>
+                                ) : (
+                                    <div className="flex items-center justify-between">
+                                        <span className="text-sm text-gray-400">Phone</span>
+                                        <div className="flex items-center gap-2">
+                                            <span className="text-sm text-gray-100">{user.phoneNumber || '—'}</span>
+                                            <button onClick={startEditPhone} aria-label="Edit phone" className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-gray-700/60 transition-all">
+                                                <PencilIcon className="h-3.5 w-3.5" />
+                                            </button>
+                                        </div>
+                                    </div>
+                                )}
                             </div>
                             <div className="flex items-center justify-between py-2">
                                 <span className="text-sm text-gray-400">Email confirmed</span>
@@ -316,32 +441,6 @@ const Profile: React.FC = () => {
                             )}
                         </div>
                     )}
-                </Section>
-
-                <Section title="Edit profile">
-                    <div className="space-y-3">
-                        <div className="grid grid-cols-2 gap-3">
-                            <div>
-                                <label className="block text-xs font-medium text-gray-400 mb-1.5">First name</label>
-                                <input className={inputClass} type="text" value={editFirstName} onChange={e => setEditFirstName(e.target.value)} />
-                            </div>
-                            <div>
-                                <label className="block text-xs font-medium text-gray-400 mb-1.5">Last name</label>
-                                <input className={inputClass} type="text" value={editLastName} onChange={e => setEditLastName(e.target.value)} />
-                            </div>
-                        </div>
-                        <div>
-                            <label className="block text-xs font-medium text-gray-400 mb-1.5">Phone number</label>
-                            <input className={inputClass} type="tel" placeholder="optional" value={editPhone} onChange={e => setEditPhone(e.target.value)} />
-                        </div>
-                        <button
-                            onClick={handleProfileSave}
-                            disabled={profileSaving}
-                            className="px-4 py-2 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 text-white text-sm font-medium rounded-xl transition-all"
-                        >
-                            {profileSaving ? 'Saving…' : 'Save'}
-                        </button>
-                    </div>
                 </Section>
 
                 <Section title="Billing">

--- a/src/app/(protected)/shop/page.tsx
+++ b/src/app/(protected)/shop/page.tsx
@@ -12,6 +12,7 @@ import AdminService, { AppSettings } from '@/services/adminService';
 import ProductService, { Product } from '@/services/productService';
 import ShopService, { ShopItem } from '@/services/shopService';
 import SubscriptionService from '@/services/subscriptionService';
+import UserService from '@/services/userService';
 import { formatNok } from '@/lib/formatUtils';
 import { effectivePriceInOre, vatLabel } from '@/lib/pricing';
 import { useLocalStorage } from '@/lib/useLocalStorage';
@@ -27,6 +28,7 @@ export default function ShopPage() {
     const [phoneItemModal, setPhoneItemModal] = useState<{ item: ShopItem; quantity: number } | null>(null);
     const [phoneSubModal, setPhoneSubModal] = useState<Product | null>(null);
     const [savedPhone, setSavedPhone] = useLocalStorage('garge-phone', '');
+    const [profilePhone, setProfilePhone] = useState('');
     const [purchasing, setPurchasing] = useState(false);
     const [redirecting, setRedirecting] = useState(false);
     const [quantities, setQuantities] = useState<Record<number, number>>({});
@@ -47,6 +49,9 @@ export default function ShopPage() {
             })
             .catch(err => toast.error(formatApiError(err, 'Failed to load shop')))
             .finally(() => setLoading(false));
+        UserService.getUserProfile()
+            .then(u => setProfilePhone(u.phoneNumber ?? ''))
+            .catch(() => {});
     }, []);
 
     const vatEnabled = appSettings?.vatEnabled ?? false;
@@ -238,7 +243,7 @@ export default function ShopPage() {
                             {formatNok(effectivePriceInOre(phoneItemModal.item.priceInOre, vatEnabled) * phoneItemModal.quantity)} {vatLabel(vatEnabled)}
                         </>
                     }
-                    initialPhone={savedPhone}
+                    initialPhone={profilePhone || savedPhone}
                     submitting={purchasing}
                     onSubmit={(msisdn) => handleCheckout(phoneItemModal.item, phoneItemModal.quantity, msisdn)}
                     onCancel={() => setPhoneItemModal(null)}
@@ -256,7 +261,7 @@ export default function ShopPage() {
                         </>
                     }
                     requireConsent
-                    initialPhone={savedPhone}
+                    initialPhone={profilePhone || savedPhone}
                     submitting={purchasing}
                     onSubmit={(msisdn) => handleInitiate(phoneSubModal, msisdn)}
                     onCancel={() => setPhoneSubModal(null)}

--- a/src/tests/lib/phone.test.ts
+++ b/src/tests/lib/phone.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { normalizeNoPhone } from '@/lib/phone'
+
+describe('normalizeNoPhone', () => {
+    it('prefixes 47 to 8-digit Norwegian numbers', () => {
+        expect(normalizeNoPhone('91234567')).toBe('4791234567')
+    })
+
+    it('strips spaces and formatting characters', () => {
+        expect(normalizeNoPhone('91 23 45 67')).toBe('4791234567')
+        expect(normalizeNoPhone('+47 912-34-567')).toBe('4791234567')
+    })
+
+    it('accepts 10-digit numbers already prefixed with 47', () => {
+        expect(normalizeNoPhone('4791234567')).toBe('4791234567')
+        expect(normalizeNoPhone('+47 91234567')).toBe('4791234567')
+    })
+
+    it('returns null for too-short input', () => {
+        expect(normalizeNoPhone('1234567')).toBeNull()
+    })
+
+    it('returns null for too-long input', () => {
+        expect(normalizeNoPhone('12345678901')).toBeNull()
+    })
+
+    it('returns null for 10-digit number not starting with 47', () => {
+        expect(normalizeNoPhone('1234567890')).toBeNull()
+    })
+
+    it('returns null for empty string', () => {
+        expect(normalizeNoPhone('')).toBeNull()
+    })
+})


### PR DESCRIPTION
## Summary
- Account block on profile page now has pencil-icon inline edit for Name and Phone (matches DeviceManagePage pattern); removes separate Edit profile section.
- Phone validated via normalizeNoPhone -- invalid input shows inline hint, empty clears.
- Shop checkout (PaymentPhoneModal) now prefills phone from user profile, falls back to garge-phone localStorage.
- Adds unit tests for normalizeNoPhone.