### PR TITLE
feat(shop): multi-item cart with single Vipps checkout

### DIFF
--- a/src/app/(protected)/shop/page.tsx
+++ b/src/app/(protected)/shop/page.tsx
@@ -2,12 +2,14 @@
 
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import { BuildingStorefrontIcon, CheckBadgeIcon, MinusIcon, PlusIcon } from '@heroicons/react/24/outline';
+import { BuildingStorefrontIcon, CheckBadgeIcon, MinusIcon, PlusIcon, ShoppingCartIcon } from '@heroicons/react/24/outline';
 import Section from '@/components/Section';
 import LoadingDots from '@/components/LoadingDots';
 import TestModeBanner from '@/components/TestModeBanner';
 import PaymentPhoneModal from '@/components/PaymentPhoneModal';
 import RedirectingOverlay from '@/components/RedirectingOverlay';
+import CartFab from '@/components/CartFab';
+import CartDrawer from '@/components/CartDrawer';
 import { toast } from 'sonner';
 import AdminService, { AppSettings } from '@/services/adminService';
 import ProductService, { Product } from '@/services/productService';
@@ -18,6 +20,7 @@ import { formatNok } from '@/lib/formatUtils';
 import { effectivePriceInOre, vatLabel } from '@/lib/pricing';
 import { useLocalStorage } from '@/lib/useLocalStorage';
 import { formatApiError } from '@/lib/errorMessages';
+import { CartLine, addToCart, cartItemCount } from '@/lib/cart';
 
 export default function ShopPage() {
     const [items, setItems] = useState<ShopItem[]>([]);
@@ -26,7 +29,6 @@ export default function ShopPage() {
     const [hasActivePrimary, setHasActivePrimary] = useState(false);
     const [loading, setLoading] = useState(true);
 
-    const [phoneItemModal, setPhoneItemModal] = useState<{ item: ShopItem; quantity: number } | null>(null);
     const [phoneSubModal, setPhoneSubModal] = useState<{ product: Product; quantity: number } | null>(null);
     const [subQuantities, setSubQuantities] = useState<Record<number, number>>({});
     const [savedPhone, setSavedPhone] = useLocalStorage('garge-phone', '');
@@ -34,6 +36,9 @@ export default function ShopPage() {
     const [purchasing, setPurchasing] = useState(false);
     const [redirecting, setRedirecting] = useState(false);
     const [quantities, setQuantities] = useState<Record<number, number>>({});
+
+    const [cart, setCart] = useLocalStorage<CartLine[]>('garge-cart-items', []);
+    const [cartOpen, setCartOpen] = useState(false);
 
     useEffect(() => {
         Promise.all([
@@ -67,8 +72,16 @@ export default function ShopPage() {
         setQuantities(prev => ({ ...prev, [itemId]: clamped }));
     }
 
-    function openItemModal(item: ShopItem) {
-        setPhoneItemModal({ item, quantity: getQty(item.id) });
+    function handleAddToCart(item: ShopItem) {
+        const qty = getQty(item.id);
+        const next = addToCart(cart, item.id, item.stockCount, qty);
+        if (next === cart) {
+            toast.error('Cannot add more — stock limit reached.');
+            return;
+        }
+        setCart(next);
+        setQuantities(prev => ({ ...prev, [item.id]: 1 }));
+        toast.success(`Added ${item.name} to cart`);
     }
 
     function getSubQty(productId: number): number {
@@ -88,14 +101,16 @@ export default function ShopPage() {
         setPhoneSubModal({ product, quantity });
     }
 
-    async function handleCheckout(item: ShopItem, quantity: number, msisdn: string) {
+    async function handleCartCheckout(msisdn: string) {
+        if (cart.length === 0) return;
         setPurchasing(true);
         try {
             const res = await ShopService.checkout({
-                items: [{ shopItemId: item.id, quantity }],
+                items: cart.map(l => ({ shopItemId: l.shopItemId, quantity: l.quantity })),
                 phoneNumber: msisdn,
             });
             setSavedPhone(msisdn);
+            setCart([]);
             setRedirecting(true);
             window.location.href = res.redirectUrl;
         } catch (err) {
@@ -185,10 +200,11 @@ export default function ShopPage() {
                                                 </button>
                                             </div>
                                             <button
-                                                onClick={() => openItemModal(item)}
-                                                className="flex-1 px-4 py-2 bg-sky-600 hover:bg-sky-500 text-white text-sm font-medium rounded-lg transition-colors"
+                                                onClick={() => handleAddToCart(item)}
+                                                className="flex-1 inline-flex items-center justify-center gap-1.5 px-4 py-2 bg-sky-600 hover:bg-sky-500 text-white text-sm font-medium rounded-lg transition-colors"
                                             >
-                                                Buy
+                                                <ShoppingCartIcon className="h-4 w-4" />
+                                                Add to cart
                                             </button>
                                         </div>
                                     )}
@@ -299,23 +315,19 @@ export default function ShopPage() {
                 </div>
             )}
 
-            {phoneItemModal && (
-                <PaymentPhoneModal
-                    title="Pay with Vipps"
-                    summary={
-                        <>
-                            <span className="text-gray-300">{phoneItemModal.item.name}</span>
-                            {' × '}{phoneItemModal.quantity}
-                            {' — '}
-                            {formatNok(effectivePriceInOre(phoneItemModal.item.priceInOre, vatEnabled) * phoneItemModal.quantity)} {vatLabel(vatEnabled)}
-                        </>
-                    }
-                    initialPhone={profilePhone || savedPhone}
-                    submitting={purchasing}
-                    onSubmit={(msisdn) => handleCheckout(phoneItemModal.item, phoneItemModal.quantity, msisdn)}
-                    onCancel={() => setPhoneItemModal(null)}
-                />
-            )}
+            <CartFab count={cartItemCount(cart)} onClick={() => setCartOpen(true)} />
+
+            <CartDrawer
+                open={cartOpen}
+                cart={cart}
+                items={items}
+                vatEnabled={vatEnabled}
+                initialPhone={profilePhone || savedPhone}
+                submitting={purchasing}
+                onChange={setCart}
+                onClose={() => setCartOpen(false)}
+                onCheckout={handleCartCheckout}
+            />
 
             {phoneSubModal && (
                 <PaymentPhoneModal

--- a/src/components/CartDrawer.tsx
+++ b/src/components/CartDrawer.tsx
@@ -60,7 +60,9 @@ export default function CartDrawer({
 
     const total = cartTotalInOre(priceableLines, vatEnabled);
 
-    const hasUnavailable = resolved.some(r => !r.item || !r.item.isActive || r.line.quantity > r.item.stockCount);
+    const hasUnavailable = resolved.some(r =>
+        !r.item || !r.item.isActive || (r.item.stockCount >= 0 && r.line.quantity > r.item.stockCount)
+    );
     const normalized = normalizeNoPhone(phone);
     const phoneValid = normalized !== null;
     const phoneTouched = phone.length > 0;
@@ -118,8 +120,10 @@ export default function CartDrawer({
                                     </div>
                                 );
                             }
-                            const overStock = line.quantity > item.stockCount;
+                            const unlimited = item.stockCount < 0;
+                            const overStock = !unlimited && line.quantity > item.stockCount;
                             const max = item.stockCount;
+                            const atMax = !unlimited && line.quantity >= max;
                             return (
                                 <div key={line.shopItemId} className="flex flex-col gap-2 p-3 bg-gray-800/40 border border-gray-700/40 rounded-xl">
                                     <div className="flex items-start justify-between gap-3">
@@ -149,7 +153,7 @@ export default function CartDrawer({
                                             <span className="text-sm font-medium text-gray-100 w-6 text-center tabular-nums">{line.quantity}</span>
                                             <button
                                                 onClick={() => onChange(setLineQty(cart, line.shopItemId, line.quantity + 1, max))}
-                                                disabled={line.quantity >= max}
+                                                disabled={atMax}
                                                 aria-label="Increase quantity"
                                                 className="p-1.5 rounded text-gray-400 hover:text-gray-200 hover:bg-gray-700 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
                                             >
@@ -180,7 +184,7 @@ export default function CartDrawer({
                         </div>
 
                         <div className="space-y-1">
-                            <label className="block text-[11px] font-medium text-gray-500 uppercase tracking-wider">Phone for Vipps</label>
+                            <label className="block text-[11px] font-medium text-gray-500 uppercase tracking-wider">Phone number</label>
                             <div className="relative">
                                 <input
                                     ref={phoneRef}

--- a/src/components/CartDrawer.tsx
+++ b/src/components/CartDrawer.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useRef, useState } from 'react';
+import { MinusIcon, PlusIcon, TrashIcon, XMarkIcon, CheckIcon } from '@heroicons/react/24/outline';
+import { CartLine, cartTotalInOre, removeLine, setLineQty } from '@/lib/cart';
+import { ShopItem } from '@/services/shopService';
+import { effectivePriceInOre, vatLabel } from '@/lib/pricing';
+import { formatNok } from '@/lib/formatUtils';
+import { normalizeNoPhone } from '@/lib/phone';
+import { useEscapeKey } from '@/lib/useEscapeKey';
+
+export interface CartDrawerProps {
+    open: boolean;
+    cart: CartLine[];
+    items: ShopItem[];
+    vatEnabled: boolean;
+    initialPhone: string;
+    submitting: boolean;
+    onChange: (cart: CartLine[]) => void;
+    onClose: () => void;
+    onCheckout: (phoneMsisdn: string) => void;
+}
+
+interface ResolvedLine {
+    line: CartLine;
+    item: ShopItem | null;
+}
+
+export default function CartDrawer({
+    open,
+    cart,
+    items,
+    vatEnabled,
+    initialPhone,
+    submitting,
+    onChange,
+    onClose,
+    onCheckout,
+}: CartDrawerProps) {
+    const [phone, setPhone] = useState(initialPhone);
+    const phoneRef = useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+        if (open) setPhone(initialPhone);
+    }, [open, initialPhone]);
+
+    useEscapeKey(open && !submitting, onClose);
+
+    if (!open) return null;
+
+    const resolved: ResolvedLine[] = cart.map(line => ({
+        line,
+        item: items.find(i => i.id === line.shopItemId) ?? null,
+    }));
+
+    const priceableLines = resolved
+        .filter(r => r.item && r.item.isActive)
+        .map(r => ({ priceInOre: r.item!.priceInOre, quantity: r.line.quantity }));
+
+    const total = cartTotalInOre(priceableLines, vatEnabled);
+
+    const hasUnavailable = resolved.some(r => !r.item || !r.item.isActive || r.line.quantity > r.item.stockCount);
+    const normalized = normalizeNoPhone(phone);
+    const phoneValid = normalized !== null;
+    const phoneTouched = phone.length > 0;
+    const canSubmit = cart.length > 0 && !hasUnavailable && phoneValid && !submitting;
+
+    function handleSubmit() {
+        if (!canSubmit || !normalized) return;
+        onCheckout(normalized);
+    }
+
+    return (
+        <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="cart-drawer-title"
+            className="fixed inset-0 z-50"
+        >
+            <div
+                className="absolute inset-0 bg-black/60 backdrop-blur-sm"
+                aria-hidden
+                onClick={() => { if (!submitting) onClose(); }}
+            />
+            <div className="absolute inset-y-0 right-0 w-full max-w-md bg-gray-900 border-l border-gray-700/60 shadow-2xl flex flex-col">
+                <div className="flex items-center justify-between p-4 border-b border-gray-700/60">
+                    <h2 id="cart-drawer-title" className="text-base font-semibold text-gray-100">Cart</h2>
+                    <button
+                        onClick={onClose}
+                        disabled={submitting}
+                        aria-label="Close cart"
+                        className="p-1.5 rounded-lg text-gray-400 hover:text-gray-200 hover:bg-gray-800 transition-colors disabled:opacity-50"
+                    >
+                        <XMarkIcon className="h-5 w-5" />
+                    </button>
+                </div>
+
+                <div className="flex-1 overflow-y-auto p-4 space-y-3">
+                    {cart.length === 0 ? (
+                        <p className="text-sm text-gray-500 text-center py-8">Your cart is empty.</p>
+                    ) : (
+                        resolved.map(({ line, item }) => {
+                            if (!item || !item.isActive) {
+                                return (
+                                    <div key={line.shopItemId} className="flex items-center justify-between gap-3 p-3 bg-gray-800/40 border border-gray-700/40 rounded-xl opacity-60">
+                                        <div className="min-w-0">
+                                            <p className="text-sm text-gray-300 truncate">Item no longer available</p>
+                                            <p className="text-xs text-gray-500">Was id {line.shopItemId}</p>
+                                        </div>
+                                        <button
+                                            onClick={() => onChange(removeLine(cart, line.shopItemId))}
+                                            aria-label="Remove unavailable item"
+                                            className="p-1.5 rounded-lg text-gray-400 hover:text-red-400 hover:bg-gray-800 transition-colors"
+                                        >
+                                            <TrashIcon className="h-4 w-4" />
+                                        </button>
+                                    </div>
+                                );
+                            }
+                            const overStock = line.quantity > item.stockCount;
+                            const max = item.stockCount;
+                            return (
+                                <div key={line.shopItemId} className="flex flex-col gap-2 p-3 bg-gray-800/40 border border-gray-700/40 rounded-xl">
+                                    <div className="flex items-start justify-between gap-3">
+                                        <div className="min-w-0">
+                                            <p className="text-sm font-medium text-gray-100 truncate">{item.name}</p>
+                                            <p className="text-xs text-gray-500">
+                                                {formatNok(effectivePriceInOre(item.priceInOre, vatEnabled))} {vatLabel(vatEnabled)} each
+                                            </p>
+                                        </div>
+                                        <button
+                                            onClick={() => onChange(removeLine(cart, line.shopItemId))}
+                                            aria-label={`Remove ${item.name}`}
+                                            className="p-1.5 rounded-lg text-gray-400 hover:text-red-400 hover:bg-gray-800 transition-colors flex-shrink-0"
+                                        >
+                                            <TrashIcon className="h-4 w-4" />
+                                        </button>
+                                    </div>
+                                    <div className="flex items-center justify-between">
+                                        <div className="flex items-center gap-1 bg-gray-800/60 border border-gray-700/40 rounded-lg p-0.5">
+                                            <button
+                                                onClick={() => onChange(setLineQty(cart, line.shopItemId, line.quantity - 1, max))}
+                                                aria-label="Decrease quantity"
+                                                className="p-1.5 rounded text-gray-400 hover:text-gray-200 hover:bg-gray-700 transition-colors"
+                                            >
+                                                <MinusIcon className="h-3.5 w-3.5" />
+                                            </button>
+                                            <span className="text-sm font-medium text-gray-100 w-6 text-center tabular-nums">{line.quantity}</span>
+                                            <button
+                                                onClick={() => onChange(setLineQty(cart, line.shopItemId, line.quantity + 1, max))}
+                                                disabled={line.quantity >= max}
+                                                aria-label="Increase quantity"
+                                                className="p-1.5 rounded text-gray-400 hover:text-gray-200 hover:bg-gray-700 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                                            >
+                                                <PlusIcon className="h-3.5 w-3.5" />
+                                            </button>
+                                        </div>
+                                        <p className="text-sm font-semibold text-sky-400 tabular-nums">
+                                            {formatNok(effectivePriceInOre(item.priceInOre, vatEnabled) * line.quantity)}
+                                        </p>
+                                    </div>
+                                    {overStock && (
+                                        <p className="text-[11px] text-red-400">Only {item.stockCount} in stock — reduce quantity.</p>
+                                    )}
+                                </div>
+                            );
+                        })
+                    )}
+                </div>
+
+                {cart.length > 0 && (
+                    <div className="border-t border-gray-700/60 p-4 space-y-3">
+                        <div className="flex items-center justify-between">
+                            <span className="text-sm text-gray-400">Total</span>
+                            <span className="text-lg font-bold text-sky-400 tabular-nums">
+                                {formatNok(total)}
+                                <span className="text-xs font-normal text-gray-500 ml-1">{vatLabel(vatEnabled)}</span>
+                            </span>
+                        </div>
+
+                        <div className="space-y-1">
+                            <label className="block text-[11px] font-medium text-gray-500 uppercase tracking-wider">Phone for Vipps</label>
+                            <div className="relative">
+                                <input
+                                    ref={phoneRef}
+                                    type="tel"
+                                    inputMode="tel"
+                                    autoComplete="tel"
+                                    value={phone}
+                                    onChange={e => setPhone(e.target.value)}
+                                    onKeyDown={e => { if (e.key === 'Enter') handleSubmit(); }}
+                                    placeholder="91 23 45 67"
+                                    disabled={submitting}
+                                    aria-invalid={phoneTouched && !phoneValid}
+                                    className={`w-full bg-gray-800/60 border rounded-lg pl-3 pr-9 py-2 text-sm text-gray-100 placeholder-gray-600 focus:outline-none transition-colors ${
+                                        phoneTouched && !phoneValid
+                                            ? 'border-red-600/60 focus:border-red-500'
+                                            : phoneValid
+                                                ? 'border-green-600/40 focus:border-green-500'
+                                                : 'border-gray-700/60 focus:border-sky-500/60'
+                                    }`}
+                                />
+                                {phoneValid && (
+                                    <CheckIcon className="absolute right-2.5 top-2.5 h-4 w-4 text-green-400" aria-hidden />
+                                )}
+                            </div>
+                            {phoneTouched && !phoneValid && (
+                                <p className="text-[11px] text-red-400">Enter a valid phone number.</p>
+                            )}
+                        </div>
+
+                        {hasUnavailable && (
+                            <p className="text-[11px] text-red-400">Fix unavailable lines before continuing.</p>
+                        )}
+
+                        <button
+                            onClick={handleSubmit}
+                            disabled={!canSubmit}
+                            className="w-full px-4 py-2.5 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded-lg transition-colors"
+                        >
+                            {submitting ? 'Redirecting…' : 'Continue to Vipps'}
+                        </button>
+                        <p className="text-[11px] text-gray-600 text-center">
+                            By continuing you accept our{' '}
+                            <Link href="/terms" target="_blank" rel="noopener noreferrer" className="text-sky-500 hover:text-sky-400 transition-colors">Terms of Service</Link>.
+                        </p>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/src/components/CartFab.tsx
+++ b/src/components/CartFab.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { ShoppingCartIcon } from '@heroicons/react/24/outline';
+
+export interface CartFabProps {
+    count: number;
+    onClick: () => void;
+}
+
+export default function CartFab({ count, onClick }: CartFabProps) {
+    if (count <= 0) return null;
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            aria-label={`Open cart (${count} item${count === 1 ? '' : 's'})`}
+            className="fixed bottom-6 right-6 z-40 flex h-14 w-14 items-center justify-center rounded-full bg-sky-600 hover:bg-sky-500 text-white shadow-lg shadow-sky-900/40 transition-colors"
+        >
+            <ShoppingCartIcon className="h-6 w-6" />
+            <span
+                aria-hidden
+                className="absolute -top-1 -right-1 min-w-[20px] h-5 px-1 rounded-full bg-red-500 text-white text-[11px] font-bold flex items-center justify-center tabular-nums"
+            >
+                {count > 99 ? '99+' : count}
+            </span>
+        </button>
+    );
+}

--- a/src/lib/cart.ts
+++ b/src/lib/cart.ts
@@ -6,16 +6,18 @@ export interface CartLine {
 }
 
 export function clampToStock(qty: number, stockCount: number): number {
-    if (stockCount <= 0) return 0;
+    if (stockCount === 0) return 0;
     if (qty < 1) return 0;
+    if (stockCount < 0) return qty;
     return Math.min(qty, stockCount);
 }
 
 export function addToCart(cart: CartLine[], itemId: number, stockCount: number, delta = 1): CartLine[] {
-    if (stockCount <= 0 || delta <= 0) return cart;
+    if (stockCount === 0 || delta <= 0) return cart;
     const existing = cart.find(l => l.shopItemId === itemId);
     if (existing) {
         const nextQty = clampToStock(existing.quantity + delta, stockCount);
+        if (nextQty === existing.quantity) return cart;
         if (nextQty === 0) return cart.filter(l => l.shopItemId !== itemId);
         return cart.map(l => l.shopItemId === itemId ? { ...l, quantity: nextQty } : l);
     }

--- a/src/lib/cart.ts
+++ b/src/lib/cart.ts
@@ -1,0 +1,50 @@
+import { effectivePriceInOre } from '@/lib/pricing';
+
+export interface CartLine {
+    shopItemId: number;
+    quantity: number;
+}
+
+export function clampToStock(qty: number, stockCount: number): number {
+    if (stockCount <= 0) return 0;
+    if (qty < 1) return 0;
+    return Math.min(qty, stockCount);
+}
+
+export function addToCart(cart: CartLine[], itemId: number, stockCount: number, delta = 1): CartLine[] {
+    if (stockCount <= 0 || delta <= 0) return cart;
+    const existing = cart.find(l => l.shopItemId === itemId);
+    if (existing) {
+        const nextQty = clampToStock(existing.quantity + delta, stockCount);
+        if (nextQty === 0) return cart.filter(l => l.shopItemId !== itemId);
+        return cart.map(l => l.shopItemId === itemId ? { ...l, quantity: nextQty } : l);
+    }
+    const startQty = clampToStock(delta, stockCount);
+    if (startQty === 0) return cart;
+    return [...cart, { shopItemId: itemId, quantity: startQty }];
+}
+
+export function setLineQty(cart: CartLine[], itemId: number, qty: number, stockCount: number): CartLine[] {
+    const clamped = clampToStock(qty, stockCount);
+    if (clamped === 0) return cart.filter(l => l.shopItemId !== itemId);
+    if (!cart.some(l => l.shopItemId === itemId)) {
+        return [...cart, { shopItemId: itemId, quantity: clamped }];
+    }
+    return cart.map(l => l.shopItemId === itemId ? { ...l, quantity: clamped } : l);
+}
+
+export function removeLine(cart: CartLine[], itemId: number): CartLine[] {
+    return cart.filter(l => l.shopItemId !== itemId);
+}
+
+export function cartTotalInOre(
+    lines: { priceInOre: number; quantity: number }[],
+    vatEnabled: boolean,
+): number {
+    const subtotal = lines.reduce((sum, l) => sum + l.priceInOre * l.quantity, 0);
+    return effectivePriceInOre(subtotal, vatEnabled);
+}
+
+export function cartItemCount(cart: CartLine[]): number {
+    return cart.reduce((sum, l) => sum + l.quantity, 0);
+}

--- a/src/tests/lib/cart.test.ts
+++ b/src/tests/lib/cart.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'vitest';
+import {
+    addToCart,
+    setLineQty,
+    removeLine,
+    clampToStock,
+    cartTotalInOre,
+    cartItemCount,
+    CartLine,
+} from '@/lib/cart';
+
+describe('clampToStock', () => {
+    it('returns 0 for stock <= 0', () => {
+        expect(clampToStock(5, 0)).toBe(0);
+        expect(clampToStock(5, -1)).toBe(0);
+    });
+
+    it('returns 0 for qty < 1', () => {
+        expect(clampToStock(0, 10)).toBe(0);
+        expect(clampToStock(-3, 10)).toBe(0);
+    });
+
+    it('caps qty to stock', () => {
+        expect(clampToStock(15, 10)).toBe(10);
+    });
+
+    it('returns qty when within bounds', () => {
+        expect(clampToStock(3, 10)).toBe(3);
+    });
+});
+
+describe('addToCart', () => {
+    it('adds new line when item not in cart', () => {
+        const cart: CartLine[] = [];
+        const next = addToCart(cart, 1, 10);
+        expect(next).toEqual([{ shopItemId: 1, quantity: 1 }]);
+    });
+
+    it('increments existing line', () => {
+        const cart: CartLine[] = [{ shopItemId: 1, quantity: 2 }];
+        const next = addToCart(cart, 1, 10);
+        expect(next).toEqual([{ shopItemId: 1, quantity: 3 }]);
+    });
+
+    it('clamps existing line increment to stock', () => {
+        const cart: CartLine[] = [{ shopItemId: 1, quantity: 4 }];
+        const next = addToCart(cart, 1, 5, 10);
+        expect(next).toEqual([{ shopItemId: 1, quantity: 5 }]);
+    });
+
+    it('ignores add when stock is 0', () => {
+        const cart: CartLine[] = [];
+        expect(addToCart(cart, 1, 0)).toBe(cart);
+    });
+
+    it('respects delta param', () => {
+        expect(addToCart([], 1, 10, 3)).toEqual([{ shopItemId: 1, quantity: 3 }]);
+    });
+
+    it('does not mutate the cart', () => {
+        const cart: CartLine[] = [{ shopItemId: 1, quantity: 1 }];
+        addToCart(cart, 1, 10);
+        expect(cart).toEqual([{ shopItemId: 1, quantity: 1 }]);
+    });
+});
+
+describe('setLineQty', () => {
+    it('removes line when qty <= 0', () => {
+        const cart: CartLine[] = [{ shopItemId: 1, quantity: 2 }, { shopItemId: 2, quantity: 1 }];
+        expect(setLineQty(cart, 1, 0, 10)).toEqual([{ shopItemId: 2, quantity: 1 }]);
+    });
+
+    it('clamps to stock', () => {
+        const cart: CartLine[] = [{ shopItemId: 1, quantity: 2 }];
+        expect(setLineQty(cart, 1, 99, 5)).toEqual([{ shopItemId: 1, quantity: 5 }]);
+    });
+
+    it('updates qty for existing line', () => {
+        const cart: CartLine[] = [{ shopItemId: 1, quantity: 2 }];
+        expect(setLineQty(cart, 1, 7, 10)).toEqual([{ shopItemId: 1, quantity: 7 }]);
+    });
+});
+
+describe('removeLine', () => {
+    it('removes matching line', () => {
+        const cart: CartLine[] = [{ shopItemId: 1, quantity: 2 }, { shopItemId: 2, quantity: 1 }];
+        expect(removeLine(cart, 1)).toEqual([{ shopItemId: 2, quantity: 1 }]);
+    });
+
+    it('is a no-op when id not present', () => {
+        const cart: CartLine[] = [{ shopItemId: 2, quantity: 1 }];
+        expect(removeLine(cart, 99)).toEqual([{ shopItemId: 2, quantity: 1 }]);
+    });
+});
+
+describe('cartTotalInOre', () => {
+    it('sums lines without VAT', () => {
+        const total = cartTotalInOre([
+            { priceInOre: 1000, quantity: 2 },
+            { priceInOre: 500, quantity: 3 },
+        ], false);
+        expect(total).toBe(3500);
+    });
+
+    it('applies VAT once on the subtotal', () => {
+        const total = cartTotalInOre([
+            { priceInOre: 1000, quantity: 2 },
+        ], true);
+        expect(total).toBe(2500);
+    });
+
+    it('returns 0 for empty cart', () => {
+        expect(cartTotalInOre([], false)).toBe(0);
+        expect(cartTotalInOre([], true)).toBe(0);
+    });
+});
+
+describe('cartItemCount', () => {
+    it('returns 0 for empty cart', () => {
+        expect(cartItemCount([])).toBe(0);
+    });
+
+    it('sums quantities across lines', () => {
+        expect(cartItemCount([{ shopItemId: 1, quantity: 2 }, { shopItemId: 2, quantity: 3 }])).toBe(5);
+    });
+});

--- a/src/tests/lib/cart.test.ts
+++ b/src/tests/lib/cart.test.ts
@@ -10,14 +10,19 @@ import {
 } from '@/lib/cart';
 
 describe('clampToStock', () => {
-    it('returns 0 for stock <= 0', () => {
+    it('returns 0 for stock = 0 (out of stock)', () => {
         expect(clampToStock(5, 0)).toBe(0);
-        expect(clampToStock(5, -1)).toBe(0);
+    });
+
+    it('treats negative stock as unlimited', () => {
+        expect(clampToStock(5, -1)).toBe(5);
+        expect(clampToStock(999, -1)).toBe(999);
     });
 
     it('returns 0 for qty < 1', () => {
         expect(clampToStock(0, 10)).toBe(0);
         expect(clampToStock(-3, 10)).toBe(0);
+        expect(clampToStock(0, -1)).toBe(0);
     });
 
     it('caps qty to stock', () => {
@@ -51,6 +56,20 @@ describe('addToCart', () => {
     it('ignores add when stock is 0', () => {
         const cart: CartLine[] = [];
         expect(addToCart(cart, 1, 0)).toBe(cart);
+    });
+
+    it('adds when stock is -1 (unlimited)', () => {
+        expect(addToCart([], 1, -1)).toEqual([{ shopItemId: 1, quantity: 1 }]);
+    });
+
+    it('increments existing line under unlimited stock', () => {
+        const cart: CartLine[] = [{ shopItemId: 1, quantity: 5 }];
+        expect(addToCart(cart, 1, -1, 100)).toEqual([{ shopItemId: 1, quantity: 105 }]);
+    });
+
+    it('returns same cart ref when increment would not change qty (already at stock cap)', () => {
+        const cart: CartLine[] = [{ shopItemId: 1, quantity: 5 }];
+        expect(addToCart(cart, 1, 5)).toBe(cart);
     });
 
     it('respects delta param', () => {


### PR DESCRIPTION
## Summary
- Adds CartFab (floating bottom-right button with count badge) and CartDrawer (slide-in right panel) to /shop.
- Replaces per-item Buy with Add-to-cart; lines persist in localStorage (garge-cart-items).
- Single Vipps redirect for whole cart via existing multi-item ShopService.checkout endpoint.
- Drawer prefills phone from profile, falls back to localStorage; revalidates stock and availability per line.
- Subscriptions remain direct (Vipps recurring API takes single productId).
- New pure helpers in src/lib/cart.ts with unit tests (clampToStock, addToCart, setLineQty, removeLine, cartTotalInOre, cartItemCount).