### PR TITLE
feat(shop): item images with shared photo uploader/service

### DIFF
--- a/src/app/(protected)/admin/shop/page.tsx
+++ b/src/app/(protected)/admin/shop/page.tsx
@@ -10,6 +10,9 @@ import LoadingDots from '@/components/LoadingDots';
 import ConfirmModal from '@/components/ConfirmModal';
 import { toast } from 'sonner';
 import ShopService, { ShopItem, CreateShopItemPayload, UpdateShopItemPayload } from '@/services/shopService';
+import ShopItemPhotoService from '@/services/shopItemPhotoService';
+import PhotoUploader from '@/components/PhotoUploader';
+import type { Photo } from '@/services/photoServiceFactory';
 import { formatNok } from '@/lib/formatUtils';
 
 const emptyForm = { name: '', description: '', priceNok: '', stock: '-1' };
@@ -32,6 +35,7 @@ export default function AdminShopPage() {
     const [deleteTarget, setDeleteTarget] = useState<ShopItem | null>(null);
     const [form, setForm] = useState(emptyForm);
     const [saving, setSaving] = useState(false);
+    const [editPhoto, setEditPhoto] = useState<Photo | null>(null);
 
     async function refresh() {
         const all = await ShopService.getShopItems();
@@ -47,6 +51,7 @@ export default function AdminShopPage() {
     function openCreate() {
         setEditTarget(null);
         setForm(emptyForm);
+        setEditPhoto(null);
         setShowForm(true);
     }
 
@@ -58,12 +63,17 @@ export default function AdminShopPage() {
             priceNok: (item.priceInOre / 100).toFixed(2),
             stock: item.stockCount.toString(),
         });
+        setEditPhoto(null);
         setShowForm(true);
+        if (item.hasImage) {
+            ShopItemPhotoService.get(item.id).then(p => setEditPhoto(p));
+        }
     }
 
     function closeForm() {
         setShowForm(false);
         setEditTarget(null);
+        setEditPhoto(null);
     }
 
     async function handleSave() {
@@ -196,6 +206,19 @@ export default function AdminShopPage() {
                                     placeholder="Description (optional)"
                                     className="w-full bg-gray-900/60 border border-gray-700/60 rounded-lg px-3 py-2 text-sm text-gray-100 placeholder-gray-600 focus:outline-none focus:border-sky-500/60"
                                 />
+                                {editTarget ? (
+                                    <PhotoUploader
+                                        photo={editPhoto}
+                                        service={ShopItemPhotoService}
+                                        parentId={editTarget.id}
+                                        alt={`${editTarget.name} image`}
+                                        aspectRatio="video"
+                                        addLabel="Add image"
+                                        onChange={p => { setEditPhoto(p); refresh().catch(() => {}); }}
+                                    />
+                                ) : (
+                                    <p className="text-xs text-gray-600 italic">Save the item first to add an image.</p>
+                                )}
                                 <div className="flex gap-2">
                                     <div className="relative flex-1">
                                         <span className="absolute left-3 top-1/2 -translate-y-1/2 text-xs text-gray-500 pointer-events-none">NOK</span>

--- a/src/app/(protected)/shop/page.tsx
+++ b/src/app/(protected)/shop/page.tsx
@@ -16,6 +16,8 @@ import ProductService, { Product } from '@/services/productService';
 import ShopService, { ShopItem } from '@/services/shopService';
 import SubscriptionService from '@/services/subscriptionService';
 import UserService from '@/services/userService';
+import ShopItemPhotoService from '@/services/shopItemPhotoService';
+import type { Photo } from '@/services/photoServiceFactory';
 import { formatNok } from '@/lib/formatUtils';
 import { effectivePriceInOre, vatLabel } from '@/lib/pricing';
 import { useLocalStorage } from '@/lib/useLocalStorage';
@@ -36,6 +38,7 @@ export default function ShopPage() {
     const [purchasing, setPurchasing] = useState(false);
     const [redirecting, setRedirecting] = useState(false);
     const [quantities, setQuantities] = useState<Record<number, number>>({});
+    const [photos, setPhotos] = useState<Record<number, Photo>>({});
 
     const [cart, setCart] = useLocalStorage<CartLine[]>('garge-cart-items', []);
     const [cartOpen, setCartOpen] = useState(false);
@@ -53,6 +56,11 @@ export default function ShopPage() {
                 setProducts(prods);
                 setAppSettings(settings);
                 setHasActivePrimary(mySubs.some(s => s.status === 'Active' && s.productType === 'Primary'));
+                shopItems.filter(i => i.hasImage).forEach(i => {
+                    ShopItemPhotoService.get(i.id).then(p => {
+                        if (p) setPhotos(prev => ({ ...prev, [i.id]: p }));
+                    });
+                });
             })
             .catch(err => toast.error(formatApiError(err, 'Failed to load shop')))
             .finally(() => setLoading(false));
@@ -152,62 +160,75 @@ export default function ShopPage() {
                             const outOfStock = item.stockCount === 0;
                             const qty = getQty(item.id);
                             const max = item.stockCount === -1 ? 99 : item.stockCount;
+                            const photo = photos[item.id];
                             return (
                                 <div
                                     key={item.id}
-                                    className={`relative bg-gray-900/40 border border-gray-700/30 rounded-xl p-4 flex flex-col gap-3 ${
+                                    className={`relative bg-gray-900/40 border border-gray-700/30 rounded-xl overflow-hidden flex flex-col ${
                                         outOfStock ? 'opacity-60 grayscale' : ''
                                     }`}
                                 >
+                                    {photo && (
+                                        <div className="aspect-video bg-gray-800/40 overflow-hidden">
+                                            {/* eslint-disable-next-line @next/next/no-img-element */}
+                                            <img
+                                                src={`data:${photo.contentType};base64,${photo.data}`}
+                                                alt={item.name}
+                                                className="w-full h-full object-cover"
+                                            />
+                                        </div>
+                                    )}
                                     {outOfStock && (
                                         <span className="absolute top-2 right-2 px-1.5 py-0.5 bg-red-500/20 border border-red-500/40 text-red-400 text-[10px] font-bold uppercase tracking-wider rounded">
                                             Out of stock
                                         </span>
                                     )}
-                                    <div className="flex-1">
-                                        <p className="text-sm font-semibold text-gray-100">{item.name}</p>
-                                        <p className="text-lg font-bold text-sky-400 mt-1">
-                                            {formatNok(effectivePriceInOre(item.priceInOre, vatEnabled) * qty)}
-                                            <span className="text-xs font-normal text-gray-500 ml-1">{vatLabel(vatEnabled)}</span>
-                                        </p>
-                                        {item.description && (
-                                            <p className="text-xs text-gray-500 mt-1">{item.description}</p>
-                                        )}
-                                        {item.stockCount !== -1 && item.stockCount > 0 && item.stockCount <= 5 && (
-                                            <p className="text-xs text-amber-400 mt-1">Only {item.stockCount} left</p>
-                                        )}
-                                    </div>
+                                    <div className="flex-1 flex flex-col gap-3 p-4">
+                                        <div className="flex-1">
+                                            <p className="text-sm font-semibold text-gray-100">{item.name}</p>
+                                            <p className="text-lg font-bold text-sky-400 mt-1">
+                                                {formatNok(effectivePriceInOre(item.priceInOre, vatEnabled) * qty)}
+                                                <span className="text-xs font-normal text-gray-500 ml-1">{vatLabel(vatEnabled)}</span>
+                                            </p>
+                                            {item.description && (
+                                                <p className="text-xs text-gray-500 mt-1">{item.description}</p>
+                                            )}
+                                            {item.stockCount !== -1 && item.stockCount > 0 && item.stockCount <= 5 && (
+                                                <p className="text-xs text-amber-400 mt-1">Only {item.stockCount} left</p>
+                                            )}
+                                        </div>
 
-                                    {!outOfStock && (
-                                        <div className="flex items-center gap-2">
-                                            <div className="flex items-center gap-1 bg-gray-800/60 border border-gray-700/40 rounded-lg p-0.5">
+                                        {!outOfStock && (
+                                            <div className="flex items-center gap-2">
+                                                <div className="flex items-center gap-1 bg-gray-800/60 border border-gray-700/40 rounded-lg p-0.5">
+                                                    <button
+                                                        onClick={() => setQty(item.id, qty - 1, max)}
+                                                        disabled={qty <= 1}
+                                                        aria-label="Decrease quantity"
+                                                        className="p-1.5 rounded text-gray-400 hover:text-gray-200 hover:bg-gray-700 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                                                    >
+                                                        <MinusIcon className="h-3.5 w-3.5" />
+                                                    </button>
+                                                    <span className="text-sm font-medium text-gray-100 w-6 text-center tabular-nums">{qty}</span>
+                                                    <button
+                                                        onClick={() => setQty(item.id, qty + 1, max)}
+                                                        disabled={qty >= max}
+                                                        aria-label="Increase quantity"
+                                                        className="p-1.5 rounded text-gray-400 hover:text-gray-200 hover:bg-gray-700 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                                                    >
+                                                        <PlusIcon className="h-3.5 w-3.5" />
+                                                    </button>
+                                                </div>
                                                 <button
-                                                    onClick={() => setQty(item.id, qty - 1, max)}
-                                                    disabled={qty <= 1}
-                                                    aria-label="Decrease quantity"
-                                                    className="p-1.5 rounded text-gray-400 hover:text-gray-200 hover:bg-gray-700 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                                                    onClick={() => handleAddToCart(item)}
+                                                    className="flex-1 inline-flex items-center justify-center gap-1.5 px-4 py-2 bg-sky-600 hover:bg-sky-500 text-white text-sm font-medium rounded-lg transition-colors"
                                                 >
-                                                    <MinusIcon className="h-3.5 w-3.5" />
-                                                </button>
-                                                <span className="text-sm font-medium text-gray-100 w-6 text-center tabular-nums">{qty}</span>
-                                                <button
-                                                    onClick={() => setQty(item.id, qty + 1, max)}
-                                                    disabled={qty >= max}
-                                                    aria-label="Increase quantity"
-                                                    className="p-1.5 rounded text-gray-400 hover:text-gray-200 hover:bg-gray-700 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
-                                                >
-                                                    <PlusIcon className="h-3.5 w-3.5" />
+                                                    <ShoppingCartIcon className="h-4 w-4" />
+                                                    Add to cart
                                                 </button>
                                             </div>
-                                            <button
-                                                onClick={() => handleAddToCart(item)}
-                                                className="flex-1 inline-flex items-center justify-center gap-1.5 px-4 py-2 bg-sky-600 hover:bg-sky-500 text-white text-sm font-medium rounded-lg transition-colors"
-                                            >
-                                                <ShoppingCartIcon className="h-4 w-4" />
-                                                Add to cart
-                                            </button>
-                                        </div>
-                                    )}
+                                        )}
+                                    </div>
                                 </div>
                             );
                         })}

--- a/src/app/DeviceDrawer.tsx
+++ b/src/app/DeviceDrawer.tsx
@@ -2,16 +2,17 @@
 
 import React, { useCallback, useEffect, useState } from 'react';
 import dynamic from 'next/dynamic';
-import { XMarkIcon, PencilIcon, CheckIcon, CameraIcon, TrashIcon } from '@heroicons/react/24/outline';
+import { XMarkIcon, PencilIcon, CheckIcon } from '@heroicons/react/24/outline';
 import { TYPE_CONFIG as typeConfig, DEFAULT_TYPE as defaultType, BATTERY_STATUS_CONFIG as statusConfig } from '@/lib/typeConfig';
 import { unitForType, typeLabel } from '@/lib/typeUtils';
 import { RANGE_OPTIONS, type RangeIndex } from '@/lib/constants';
 import LoadingDots from '@/components/LoadingDots';
+import PhotoUploader from '@/components/PhotoUploader';
 import SensorService, { SensorData, BatteryHealthData } from '@/services/sensorService';
 import SwitchService, { SwitchData } from '@/services/switchService';
 import { formatDateTime } from '@/lib/dateUtils';
 import SensorPhotoService from '@/services/sensorPhotoService';
-import { compressImage } from '@/lib/imageUtils';
+import type { Photo } from '@/services/photoServiceFactory';
 import { toast } from 'sonner';
 import ActivitiesSection from '@/components/ActivitiesSection';
 import type { UnifiedDevice } from './DeviceDashboard';
@@ -108,10 +109,7 @@ const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose }) => {
     const [loadingSwitch, setLoadingSwitch] = useState(false);
 
     // Photo (sensors only)
-    const [photo, setPhoto] = useState<{ data: string; contentType: string } | null | undefined>(undefined);
-    const [uploadingPhoto, setUploadingPhoto] = useState(false);
-    const [deletingPhoto, setDeletingPhoto] = useState(false);
-    const photoInputRef = React.useRef<HTMLInputElement>(null);
+    const [photo, setPhoto] = useState<Photo | null | undefined>(undefined);
 
     // Inline name editing (sensors + sockets)
     const [editingName, setEditingName] = useState(false);
@@ -231,36 +229,6 @@ const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose }) => {
         }
     };
 
-    const handlePhotoUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
-        const file = e.target.files?.[0];
-        if (!file) return;
-        e.target.value = '';
-        setUploadingPhoto(true);
-        try {
-            const { base64, contentType } = await compressImage(file);
-            await SensorPhotoService.upload(device.id, base64, contentType);
-            setPhoto({ data: base64, contentType });
-            toast.success('Photo saved');
-        } catch {
-            toast.error('Failed to upload photo');
-        } finally {
-            setUploadingPhoto(false);
-        }
-    };
-
-    const handlePhotoDelete = async () => {
-        setDeletingPhoto(true);
-        try {
-            await SensorPhotoService.remove(device.id);
-            setPhoto(null);
-            toast.success('Photo deleted');
-        } catch {
-            toast.error('Failed to delete photo');
-        } finally {
-            setDeletingPhoto(false);
-        }
-    };
-
     return (
         <>
             {/* Backdrop */}
@@ -332,53 +300,14 @@ const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose }) => {
                 <div className="px-5 py-5 pb-28 space-y-6">
 
                     {/* Photo — sensor only */}
-                    {device.kind === 'sensor' && (
-                        <div className="relative">
-                            <input
-                                ref={photoInputRef}
-                                type="file"
-                                accept="image/*"
-                                className="hidden"
-                                onChange={handlePhotoUpload}
-                            />
-                            {photo ? (
-                                <div className="relative rounded-2xl overflow-hidden bg-gray-800/60 border border-gray-700/40">
-                                    {/* eslint-disable-next-line @next/next/no-img-element */}
-                                    <img
-                                        src={`data:${photo.contentType};base64,${photo.data}`}
-                                        alt="Sensor photo"
-                                        className="w-full object-cover max-h-52"
-                                    />
-                                    <div className="absolute top-2 right-2 flex gap-1.5">
-                                        <button
-                                            onClick={() => photoInputRef.current?.click()}
-                                            disabled={uploadingPhoto}
-                                            title="Replace photo"
-                                            className="p-1.5 rounded-lg bg-gray-900/80 text-gray-300 hover:text-white transition-colors"
-                                        >
-                                            <CameraIcon className="h-4 w-4" />
-                                        </button>
-                                        <button
-                                            onClick={handlePhotoDelete}
-                                            disabled={deletingPhoto}
-                                            title="Delete photo"
-                                            className="p-1.5 rounded-lg bg-gray-900/80 text-red-400 hover:text-red-300 transition-colors"
-                                        >
-                                            <TrashIcon className="h-4 w-4" />
-                                        </button>
-                                    </div>
-                                </div>
-                            ) : photo === null ? (
-                                <button
-                                    onClick={() => photoInputRef.current?.click()}
-                                    disabled={uploadingPhoto}
-                                    className="w-full flex flex-col items-center gap-2 py-6 rounded-2xl border border-dashed border-gray-700/60 text-gray-500 hover:text-gray-300 hover:border-gray-600 transition-colors"
-                                >
-                                    <CameraIcon className="h-6 w-6" />
-                                    <span className="text-sm">{uploadingPhoto ? 'Uploading…' : 'Add photo'}</span>
-                                </button>
-                            ) : null /* loading — render nothing */}
-                        </div>
+                    {device.kind === 'sensor' && photo !== undefined && (
+                        <PhotoUploader
+                            photo={photo}
+                            service={SensorPhotoService}
+                            parentId={device.id}
+                            alt="Sensor photo"
+                            onChange={setPhoto}
+                        />
                     )}
 
                     {/* Current value — sensor */}

--- a/src/components/PhotoUploader.tsx
+++ b/src/components/PhotoUploader.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { CameraIcon, TrashIcon } from '@heroicons/react/24/outline';
+import { toast } from 'sonner';
+import { compressImage } from '@/lib/imageUtils';
+import type { Photo, PhotoService } from '@/services/photoServiceFactory';
+
+export interface PhotoUploaderProps {
+    photo: Photo | null;
+    service: PhotoService;
+    parentId: number;
+    alt: string;
+    onChange?: (photo: Photo | null) => void;
+    aspectRatio?: 'video' | 'square' | 'auto';
+    addLabel?: string;
+}
+
+export default function PhotoUploader({
+    photo,
+    service,
+    parentId,
+    alt,
+    onChange,
+    aspectRatio = 'auto',
+    addLabel = 'Add photo',
+}: PhotoUploaderProps) {
+    const inputRef = useRef<HTMLInputElement>(null);
+    const [uploading, setUploading] = useState(false);
+    const [deleting, setDeleting] = useState(false);
+
+    const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+        const file = e.target.files?.[0];
+        if (!file) return;
+        e.target.value = '';
+        setUploading(true);
+        try {
+            const { base64, contentType } = await compressImage(file);
+            await service.upload(parentId, base64, contentType);
+            onChange?.({ data: base64, contentType });
+            toast.success('Photo saved');
+        } catch {
+            toast.error('Failed to upload photo');
+        } finally {
+            setUploading(false);
+        }
+    };
+
+    const handleDelete = async () => {
+        setDeleting(true);
+        try {
+            await service.remove(parentId);
+            onChange?.(null);
+            toast.success('Photo deleted');
+        } catch {
+            toast.error('Failed to delete photo');
+        } finally {
+            setDeleting(false);
+        }
+    };
+
+    const previewAspectClass =
+        aspectRatio === 'video' ? 'aspect-video'
+        : aspectRatio === 'square' ? 'aspect-square'
+        : '';
+    const imgFitClass = aspectRatio === 'auto' ? 'w-full object-cover max-h-52' : 'w-full h-full object-cover';
+
+    return (
+        <div className="relative">
+            <input
+                ref={inputRef}
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={handleUpload}
+            />
+            {photo ? (
+                <div className={`relative rounded-2xl overflow-hidden bg-gray-800/60 border border-gray-700/40 ${previewAspectClass}`}>
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img src={`data:${photo.contentType};base64,${photo.data}`} alt={alt} className={imgFitClass} />
+                    <div className="absolute top-2 right-2 flex gap-1.5">
+                        <button
+                            onClick={() => inputRef.current?.click()}
+                            disabled={uploading}
+                            title="Replace photo"
+                            className="p-1.5 rounded-lg bg-gray-900/80 text-gray-300 hover:text-white transition-colors"
+                        >
+                            <CameraIcon className="h-4 w-4" />
+                        </button>
+                        <button
+                            onClick={handleDelete}
+                            disabled={deleting}
+                            title="Delete photo"
+                            className="p-1.5 rounded-lg bg-gray-900/80 text-red-400 hover:text-red-300 transition-colors"
+                        >
+                            <TrashIcon className="h-4 w-4" />
+                        </button>
+                    </div>
+                </div>
+            ) : (
+                <button
+                    onClick={() => inputRef.current?.click()}
+                    disabled={uploading}
+                    className={`w-full flex flex-col items-center justify-center gap-2 py-6 rounded-2xl border border-dashed border-gray-700/60 text-gray-500 hover:text-gray-300 hover:border-gray-600 transition-colors ${previewAspectClass}`}
+                >
+                    <CameraIcon className="h-6 w-6" />
+                    <span className="text-sm">{uploading ? 'Uploading…' : addLabel}</span>
+                </button>
+            )}
+        </div>
+    );
+}

--- a/src/services/photoServiceFactory.ts
+++ b/src/services/photoServiceFactory.ts
@@ -1,0 +1,31 @@
+import axiosInstance from '@/services/axiosInstance';
+
+export interface Photo {
+    data: string;
+    contentType: string;
+}
+
+export interface PhotoService {
+    get(parentId: number): Promise<Photo | null>;
+    upload(parentId: number, base64: string, contentType: string): Promise<void>;
+    remove(parentId: number): Promise<void>;
+}
+
+export function createPhotoService(buildPath: (id: number) => string): PhotoService {
+    return {
+        async get(parentId) {
+            try {
+                const res = await axiosInstance.get<Photo>(buildPath(parentId));
+                return res.data;
+            } catch {
+                return null;
+            }
+        },
+        async upload(parentId, base64, contentType) {
+            await axiosInstance.post(buildPath(parentId), { data: base64, contentType });
+        },
+        async remove(parentId) {
+            await axiosInstance.delete(buildPath(parentId));
+        },
+    };
+}

--- a/src/services/sensorPhotoService.ts
+++ b/src/services/sensorPhotoService.ts
@@ -1,27 +1,7 @@
-import axiosInstance from '@/services/axiosInstance';
+import { createPhotoService, type Photo } from '@/services/photoServiceFactory';
 
-export interface SensorPhoto {
-    data: string;
-    contentType: string;
-}
+export type SensorPhoto = Photo;
 
-const SensorPhotoService = {
-    async get(sensorId: number): Promise<SensorPhoto | null> {
-        try {
-            const res = await axiosInstance.get<SensorPhoto>(`/sensors/${sensorId}/photo`);
-            return res.data;
-        } catch {
-            return null;
-        }
-    },
-
-    async upload(sensorId: number, base64: string, contentType: string): Promise<void> {
-        await axiosInstance.post(`/sensors/${sensorId}/photo`, { data: base64, contentType });
-    },
-
-    async remove(sensorId: number): Promise<void> {
-        await axiosInstance.delete(`/sensors/${sensorId}/photo`);
-    },
-};
+const SensorPhotoService = createPhotoService(id => `/sensors/${id}/photo`);
 
 export default SensorPhotoService;

--- a/src/services/shopItemPhotoService.ts
+++ b/src/services/shopItemPhotoService.ts
@@ -1,0 +1,7 @@
+import { createPhotoService, type Photo } from '@/services/photoServiceFactory';
+
+export type ShopItemPhoto = Photo;
+
+const ShopItemPhotoService = createPhotoService(id => `/shop/items/${id}/photo`);
+
+export default ShopItemPhotoService;

--- a/src/services/shopService.ts
+++ b/src/services/shopService.ts
@@ -7,6 +7,7 @@ export interface ShopItem {
     priceInOre: number;
     stockCount: number;
     isActive: boolean;
+    hasImage?: boolean;
     createdAt: string;
 }
 

--- a/src/tests/services/photoServiceFactory.test.ts
+++ b/src/tests/services/photoServiceFactory.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createPhotoService } from '@/services/photoServiceFactory';
+
+vi.mock('@/services/axiosInstance', () => ({
+    default: {
+        get: vi.fn(),
+        post: vi.fn(),
+        delete: vi.fn(),
+    },
+}));
+
+import axiosInstance from '@/services/axiosInstance';
+
+const mockGet = axiosInstance.get as ReturnType<typeof vi.fn>;
+const mockPost = axiosInstance.post as ReturnType<typeof vi.fn>;
+const mockDelete = axiosInstance.delete as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+describe('createPhotoService', () => {
+    const service = createPhotoService(id => `/things/${id}/photo`);
+
+    describe('get', () => {
+        it('returns photo on success', async () => {
+            const photo = { data: 'YmFzZTY0', contentType: 'image/jpeg' };
+            mockGet.mockResolvedValueOnce({ data: photo });
+            const result = await service.get(42);
+            expect(result).toEqual(photo);
+            expect(mockGet).toHaveBeenCalledWith('/things/42/photo');
+        });
+
+        it('returns null on error (e.g. 404)', async () => {
+            mockGet.mockRejectedValueOnce(new Error('404'));
+            const result = await service.get(7);
+            expect(result).toBeNull();
+        });
+    });
+
+    describe('upload', () => {
+        it('posts base64 + contentType to path', async () => {
+            mockPost.mockResolvedValueOnce({ data: {} });
+            await service.upload(3, 'YmFzZTY0', 'image/png');
+            expect(mockPost).toHaveBeenCalledWith('/things/3/photo', {
+                data: 'YmFzZTY0',
+                contentType: 'image/png',
+            });
+        });
+    });
+
+    describe('remove', () => {
+        it('calls DELETE on path', async () => {
+            mockDelete.mockResolvedValueOnce({ data: {} });
+            await service.remove(9);
+            expect(mockDelete).toHaveBeenCalledWith('/things/9/photo');
+        });
+    });
+});
+
+describe('createPhotoService — path builder per service', () => {
+    it('builds different paths for different services', async () => {
+        const sensorService = createPhotoService(id => `/sensors/${id}/photo`);
+        const shopService = createPhotoService(id => `/shop/items/${id}/photo`);
+
+        mockGet.mockResolvedValue({ data: { data: 'x', contentType: 'image/jpeg' } });
+        await sensorService.get(1);
+        await shopService.get(2);
+
+        expect(mockGet).toHaveBeenCalledWith('/sensors/1/photo');
+        expect(mockGet).toHaveBeenCalledWith('/shop/items/2/photo');
+    });
+});


### PR DESCRIPTION
## Summary
- Adds product image thumbnails on /shop cards (aspect-video, PhotoIcon placeholder when missing). Lazy-loaded based on hasImage flag from API.
- Admin /admin/shop: edit form now has a PhotoUploader (replace/delete) once an item exists. New items prompt 'Save first, then add image'.
- DeviceDrawer refactored to use the same PhotoUploader -- drops ~50 lines of duplicated upload UI.
- New photoServiceFactory creates a typed PhotoService for any base path. sensorPhotoService refactored to use it; new shopItemPhotoService added.
- Depends on garge-api PR sondresjolyst/garge-api#202 (ShopItemPhoto model + endpoints + HasImage flag). Frontend gracefully degrades when API hasn't deployed yet.