### PR TITLE
feat(subscription): quantity for AddOns + primary Active state on shop

### DIFF
--- a/src/app/(protected)/profile/billing/page.tsx
+++ b/src/app/(protected)/profile/billing/page.tsx
@@ -9,6 +9,7 @@ import TestModeBanner from '@/components/TestModeBanner';
 import TestPill from '@/components/TestPill';
 import RedirectingOverlay from '@/components/RedirectingOverlay';
 import ConfirmModal from '@/components/ConfirmModal';
+import QuantityChangeModal from '@/components/QuantityChangeModal';
 import { toast } from 'sonner';
 import AdminService, { AppSettings } from '@/services/adminService';
 import SubscriptionService, { Subscription } from '@/services/subscriptionService';
@@ -36,6 +37,8 @@ export default function BillingPage() {
     const [appSettings, setAppSettings] = useState<AppSettings | null>(null);
     const [loading, setLoading] = useState(true);
     const [cancelTarget, setCancelTarget] = useState<Subscription | null>(null);
+    const [qtyTarget, setQtyTarget] = useState<Subscription | null>(null);
+    const [updatingQty, setUpdatingQty] = useState(false);
     const [resuming, setResuming] = useState<number | null>(null);
     const [downloading, setDownloading] = useState<number | null>(null);
     const [redirecting, setRedirecting] = useState(false);
@@ -71,6 +74,21 @@ export default function BillingPage() {
             setSubscriptions(await SubscriptionService.getMySubscriptions());
         } catch (err) {
             toast.error(formatApiError(err, 'Failed to cancel subscription'));
+        }
+    }
+
+    async function handleQuantityUpdate(newQty: number) {
+        if (!qtyTarget) return;
+        setUpdatingQty(true);
+        try {
+            const res = await SubscriptionService.updateSubscriptionQuantity(qtyTarget.id, newQty);
+            toast.success(res.message ?? 'Quantity updated. Confirm in Vipps app.');
+            setQtyTarget(null);
+            setSubscriptions(await SubscriptionService.getMySubscriptions());
+        } catch (err) {
+            toast.error(formatApiError(err, 'Failed to update quantity'));
+        } finally {
+            setUpdatingQty(false);
         }
     }
 
@@ -121,13 +139,18 @@ export default function BillingPage() {
                                         <div>
                                             <div className="flex items-center gap-2 flex-wrap">
                                                 <p className="text-sm font-semibold text-gray-100">{sub.productName}</p>
+                                                {sub.quantity > 1 && (
+                                                    <span className="px-1.5 py-0.5 bg-gray-700/50 border border-gray-600/40 text-gray-300 text-xs font-medium rounded tabular-nums">
+                                                        × {sub.quantity}
+                                                    </span>
+                                                )}
                                                 <span className={`px-1.5 py-0.5 border rounded text-xs font-medium ${sub.productType === 'Primary' ? 'bg-sky-900/30 border-sky-700/40 text-sky-400' : 'bg-purple-900/30 border-purple-700/40 text-purple-400'}`}>
                                                     {sub.productType === 'Primary' ? 'Primary' : 'Add-on'}
                                                 </span>
                                                 <TestPill visible={sub.isTest} />
                                             </div>
                                             <p className="text-xs text-gray-500 mt-0.5">
-                                                {formatNok(effectivePriceInOre(sub.priceInOre, vatEnabled))} / {sub.interval === 'Monthly' ? 'month' : 'year'} · {vatLabel(vatEnabled)}
+                                                {formatNok(effectivePriceInOre(sub.priceInOre, vatEnabled) * sub.quantity)} / {sub.interval === 'Monthly' ? 'month' : 'year'} · {vatLabel(vatEnabled)}
                                             </p>
                                         </div>
                                         <span className={`px-2 py-0.5 border rounded text-xs font-medium ${statusColor(sub.status)}`}>
@@ -164,12 +187,22 @@ export default function BillingPage() {
                                     )}
 
                                     {sub.status === 'Active' && (
-                                        <button
-                                            onClick={() => setCancelTarget(sub)}
-                                            className="mt-1 px-3 py-1.5 bg-gray-700/60 hover:bg-red-900/40 hover:border-red-700/50 border border-gray-600/40 text-gray-400 hover:text-red-400 text-xs rounded-lg transition-all"
-                                        >
-                                            Cancel
-                                        </button>
+                                        <div className="flex items-center gap-2 mt-1">
+                                            {sub.productType === 'AddOn' && (
+                                                <button
+                                                    onClick={() => setQtyTarget(sub)}
+                                                    className="px-3 py-1.5 bg-gray-700/60 hover:bg-gray-700 border border-gray-600/40 text-gray-300 text-xs rounded-lg transition-all"
+                                                >
+                                                    Change quantity
+                                                </button>
+                                            )}
+                                            <button
+                                                onClick={() => setCancelTarget(sub)}
+                                                className="px-3 py-1.5 bg-gray-700/60 hover:bg-red-900/40 hover:border-red-700/50 border border-gray-600/40 text-gray-400 hover:text-red-400 text-xs rounded-lg transition-all"
+                                            >
+                                                Cancel
+                                            </button>
+                                        </div>
                                     )}
                                 </li>
                             );
@@ -248,6 +281,16 @@ export default function BillingPage() {
                     confirmLabel="Cancel subscription"
                     onConfirm={handleCancel}
                     onCancel={() => setCancelTarget(null)}
+                />
+            )}
+
+            {qtyTarget && (
+                <QuantityChangeModal
+                    subscription={qtyTarget}
+                    vatEnabled={vatEnabled}
+                    submitting={updatingQty}
+                    onConfirm={handleQuantityUpdate}
+                    onCancel={() => setQtyTarget(null)}
                 />
             )}
 

--- a/src/app/(protected)/shop/page.tsx
+++ b/src/app/(protected)/shop/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { MinusIcon, PlusIcon } from '@heroicons/react/24/outline';
+import Link from 'next/link';
+import { CheckBadgeIcon, MinusIcon, PlusIcon } from '@heroicons/react/24/outline';
 import Section from '@/components/Section';
 import LoadingDots from '@/components/LoadingDots';
 import TestModeBanner from '@/components/TestModeBanner';
@@ -26,7 +27,8 @@ export default function ShopPage() {
     const [loading, setLoading] = useState(true);
 
     const [phoneItemModal, setPhoneItemModal] = useState<{ item: ShopItem; quantity: number } | null>(null);
-    const [phoneSubModal, setPhoneSubModal] = useState<Product | null>(null);
+    const [phoneSubModal, setPhoneSubModal] = useState<{ product: Product; quantity: number } | null>(null);
+    const [subQuantities, setSubQuantities] = useState<Record<number, number>>({});
     const [savedPhone, setSavedPhone] = useLocalStorage('garge-phone', '');
     const [profilePhone, setProfilePhone] = useState('');
     const [purchasing, setPurchasing] = useState(false);
@@ -69,12 +71,21 @@ export default function ShopPage() {
         setPhoneItemModal({ item, quantity: getQty(item.id) });
     }
 
-    function openSubModal(product: Product) {
+    function getSubQty(productId: number): number {
+        return subQuantities[productId] ?? 1;
+    }
+
+    function setSubQty(productId: number, q: number) {
+        const clamped = Math.max(1, Math.min(q, 50));
+        setSubQuantities(prev => ({ ...prev, [productId]: clamped }));
+    }
+
+    function openSubModal(product: Product, quantity: number) {
         if (product.type === 'AddOn' && !hasActivePrimary) {
             toast.error('Subscribe to the primary plan first.');
             return;
         }
-        setPhoneSubModal(product);
+        setPhoneSubModal({ product, quantity });
     }
 
     async function handleCheckout(item: ShopItem, quantity: number, msisdn: string) {
@@ -93,13 +104,14 @@ export default function ShopPage() {
         }
     }
 
-    async function handleInitiate(product: Product, msisdn: string) {
+    async function handleInitiate(product: Product, quantity: number, msisdn: string) {
         setPurchasing(true);
         try {
             const res = await SubscriptionService.initiateSubscription({
                 productId: product.id,
                 phoneNumber: msisdn,
                 consentToWaiveWithdrawal: true,
+                quantity,
             });
             setSavedPhone(msisdn);
             setRedirecting(true);
@@ -193,18 +205,23 @@ export default function ShopPage() {
                 ) : (
                     <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                         {products.map(p => {
-                            const addOnLocked = p.type === 'AddOn' && !hasActivePrimary;
+                            const isPrimary = p.type === 'Primary';
+                            const primaryActive = isPrimary && hasActivePrimary;
+                            const addOnLocked = !isPrimary && !hasActivePrimary;
+                            const dimmed = primaryActive || addOnLocked;
+                            const subQty = isPrimary ? 1 : getSubQty(p.id);
+                            const lineTotal = effectivePriceInOre(p.priceInOre, vatEnabled) * subQty;
                             return (
                                 <div
                                     key={p.id}
                                     className={`bg-gray-900/40 border border-gray-700/30 rounded-xl p-4 flex flex-col gap-3 ${
-                                        addOnLocked ? 'opacity-60 grayscale' : ''
+                                        dimmed ? 'opacity-60 grayscale' : ''
                                     }`}
                                 >
                                     <div className="flex-1">
                                         <p className="text-sm font-semibold text-gray-100">{p.name}</p>
                                         <p className="text-lg font-bold text-sky-400 mt-1">
-                                            {formatNok(effectivePriceInOre(p.priceInOre, vatEnabled))}
+                                            {formatNok(lineTotal)}
                                             <span className="text-xs font-normal text-gray-500 ml-1">
                                                 / {p.interval === 'Monthly' ? 'month' : 'year'} · {vatLabel(vatEnabled)}
                                             </span>
@@ -214,17 +231,61 @@ export default function ShopPage() {
                                             <p className="text-xs text-amber-400 mt-2">Requires an active primary subscription</p>
                                         )}
                                     </div>
-                                    <button
-                                        onClick={() => openSubModal(p)}
-                                        disabled={addOnLocked}
-                                        className={`w-full px-4 py-2 text-white text-sm font-medium rounded-lg transition-colors ${
-                                            addOnLocked
-                                                ? 'bg-gray-700 cursor-not-allowed'
-                                                : 'bg-sky-600 hover:bg-sky-500'
-                                        }`}
-                                    >
-                                        Subscribe
-                                    </button>
+
+                                    {primaryActive ? (
+                                        <div className="flex items-center justify-between gap-2">
+                                            <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-sky-500/15 text-sky-400 text-xs font-semibold">
+                                                <CheckBadgeIcon className="h-4 w-4" />
+                                                Active
+                                            </span>
+                                            <Link
+                                                href="/profile/billing"
+                                                className="text-xs text-sky-400 hover:text-sky-300 transition-colors"
+                                            >
+                                                Manage →
+                                            </Link>
+                                        </div>
+                                    ) : !isPrimary && !addOnLocked ? (
+                                        <div className="flex items-center gap-2">
+                                            <div className="flex items-center gap-1 bg-gray-800/60 border border-gray-700/40 rounded-lg p-0.5">
+                                                <button
+                                                    onClick={() => setSubQty(p.id, subQty - 1)}
+                                                    disabled={subQty <= 1}
+                                                    aria-label="Decrease quantity"
+                                                    className="p-1.5 rounded text-gray-400 hover:text-gray-200 hover:bg-gray-700 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                                                >
+                                                    <MinusIcon className="h-3.5 w-3.5" />
+                                                </button>
+                                                <span className="text-sm font-medium text-gray-100 w-6 text-center tabular-nums">{subQty}</span>
+                                                <button
+                                                    onClick={() => setSubQty(p.id, subQty + 1)}
+                                                    disabled={subQty >= 50}
+                                                    aria-label="Increase quantity"
+                                                    className="p-1.5 rounded text-gray-400 hover:text-gray-200 hover:bg-gray-700 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                                                >
+                                                    <PlusIcon className="h-3.5 w-3.5" />
+                                                </button>
+                                            </div>
+                                            <button
+                                                onClick={() => openSubModal(p, subQty)}
+                                                className="flex-1 px-4 py-2 bg-sky-600 hover:bg-sky-500 text-white text-sm font-medium rounded-lg transition-colors"
+                                            >
+                                                {subQty > 1 ? `Subscribe × ${subQty}` : 'Subscribe'}
+                                            </button>
+                                        </div>
+                                    ) : (
+                                        <button
+                                            onClick={() => openSubModal(p, 1)}
+                                            disabled={addOnLocked}
+                                            className={`w-full px-4 py-2 text-white text-sm font-medium rounded-lg transition-colors ${
+                                                addOnLocked
+                                                    ? 'bg-gray-700 cursor-not-allowed'
+                                                    : 'bg-sky-600 hover:bg-sky-500'
+                                            }`}
+                                        >
+                                            Subscribe
+                                        </button>
+                                    )}
                                 </div>
                             );
                         })}
@@ -255,15 +316,16 @@ export default function ShopPage() {
                     title="Pay with Vipps"
                     summary={
                         <>
-                            <span className="text-gray-300">{phoneSubModal.name}</span>
+                            <span className="text-gray-300">{phoneSubModal.product.name}</span>
+                            {phoneSubModal.quantity > 1 && <> {' × '}{phoneSubModal.quantity}</>}
                             {' — '}
-                            {formatNok(effectivePriceInOre(phoneSubModal.priceInOre, vatEnabled))} / {phoneSubModal.interval === 'Monthly' ? 'month' : 'year'} · {vatLabel(vatEnabled)}
+                            {formatNok(effectivePriceInOre(phoneSubModal.product.priceInOre, vatEnabled) * phoneSubModal.quantity)} / {phoneSubModal.product.interval === 'Monthly' ? 'month' : 'year'} · {vatLabel(vatEnabled)}
                         </>
                     }
                     requireConsent
                     initialPhone={profilePhone || savedPhone}
                     submitting={purchasing}
-                    onSubmit={(msisdn) => handleInitiate(phoneSubModal, msisdn)}
+                    onSubmit={(msisdn) => handleInitiate(phoneSubModal.product, phoneSubModal.quantity, msisdn)}
                     onCancel={() => setPhoneSubModal(null)}
                 />
             )}

--- a/src/components/QuantityChangeModal.tsx
+++ b/src/components/QuantityChangeModal.tsx
@@ -77,9 +77,15 @@ export default function QuantityChangeModal({
                     </span>
                 </div>
 
-                <p className="text-[11px] text-gray-500">
-                    The next scheduled charge will reflect the new total. No Vipps action required.
-                </p>
+                {qty > subscription.quantity ? (
+                    <p className="text-[11px] text-amber-400">
+                        Increasing quantity raises the agreement ceiling. Confirm the change in your Vipps app before the next charge.
+                    </p>
+                ) : qty < subscription.quantity ? (
+                    <p className="text-[11px] text-gray-500">
+                        Decreasing quantity takes effect on the next charge. No Vipps action required.
+                    </p>
+                ) : null}
 
                 <div className="flex gap-2">
                     <button

--- a/src/components/QuantityChangeModal.tsx
+++ b/src/components/QuantityChangeModal.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useState } from 'react';
+import { MinusIcon, PlusIcon } from '@heroicons/react/24/outline';
+import { useEscapeKey } from '@/lib/useEscapeKey';
+import { effectivePriceInOre, vatLabel } from '@/lib/pricing';
+import { formatNok } from '@/lib/formatUtils';
+import type { Subscription } from '@/services/subscriptionService';
+
+export interface QuantityChangeModalProps {
+    subscription: Subscription;
+    vatEnabled: boolean;
+    submitting: boolean;
+    onConfirm: (qty: number) => void;
+    onCancel: () => void;
+}
+
+export default function QuantityChangeModal({
+    subscription,
+    vatEnabled,
+    submitting,
+    onConfirm,
+    onCancel,
+}: QuantityChangeModalProps) {
+    const [qty, setQty] = useState(subscription.quantity);
+
+    useEscapeKey(!submitting, onCancel);
+
+    const unitPrice = effectivePriceInOre(subscription.priceInOre, vatEnabled);
+    const newTotal = unitPrice * qty;
+    const intervalLabel = subscription.interval === 'Monthly' ? 'month' : 'year';
+    const changed = qty !== subscription.quantity;
+
+    function clamp(n: number) {
+        return Math.max(1, Math.min(50, n));
+    }
+
+    return (
+        <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="qty-change-title"
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+        >
+            <div className="absolute inset-0" aria-hidden onClick={() => { if (!submitting) onCancel(); }} />
+            <div className="relative bg-gray-900 border border-gray-700/60 rounded-2xl p-5 w-full max-w-sm space-y-4 shadow-2xl">
+                <div>
+                    <p id="qty-change-title" className="text-sm font-semibold text-gray-100">Change quantity</p>
+                    <p className="text-xs text-gray-500 mt-1">{subscription.productName} — currently × {subscription.quantity}</p>
+                </div>
+
+                <div className="flex items-center justify-center gap-3">
+                    <button
+                        onClick={() => setQty(clamp(qty - 1))}
+                        disabled={qty <= 1 || submitting}
+                        aria-label="Decrease quantity"
+                        className="p-2 rounded-lg bg-gray-800/60 border border-gray-700/40 text-gray-300 hover:bg-gray-700 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                    >
+                        <MinusIcon className="h-4 w-4" />
+                    </button>
+                    <span className="text-2xl font-bold text-gray-100 w-12 text-center tabular-nums">{qty}</span>
+                    <button
+                        onClick={() => setQty(clamp(qty + 1))}
+                        disabled={qty >= 50 || submitting}
+                        aria-label="Increase quantity"
+                        className="p-2 rounded-lg bg-gray-800/60 border border-gray-700/40 text-gray-300 hover:bg-gray-700 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+                    >
+                        <PlusIcon className="h-4 w-4" />
+                    </button>
+                </div>
+
+                <div className="flex items-center justify-between text-xs">
+                    <span className="text-gray-500">New price</span>
+                    <span className="text-sky-400 font-semibold tabular-nums">
+                        {formatNok(newTotal)} / {intervalLabel}
+                        <span className="text-gray-600 font-normal ml-1">{vatLabel(vatEnabled)}</span>
+                    </span>
+                </div>
+
+                <p className="text-[11px] text-amber-400">
+                    You will need to confirm the new price in your Vipps app before it takes effect.
+                </p>
+
+                <div className="flex gap-2">
+                    <button
+                        onClick={() => onConfirm(qty)}
+                        disabled={!changed || submitting}
+                        className="flex-1 px-4 py-2 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded-lg transition-colors"
+                    >
+                        {submitting ? 'Updating…' : 'Update quantity'}
+                    </button>
+                    <button
+                        onClick={onCancel}
+                        disabled={submitting}
+                        className="px-4 py-2 bg-gray-700/60 hover:bg-gray-700 text-gray-300 text-sm rounded-lg transition-colors disabled:opacity-50"
+                    >
+                        Cancel
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/components/QuantityChangeModal.tsx
+++ b/src/components/QuantityChangeModal.tsx
@@ -77,8 +77,8 @@ export default function QuantityChangeModal({
                     </span>
                 </div>
 
-                <p className="text-[11px] text-amber-400">
-                    You will need to confirm the new price in your Vipps app before it takes effect.
+                <p className="text-[11px] text-gray-500">
+                    The next scheduled charge will reflect the new total. No Vipps action required.
                 </p>
 
                 <div className="flex gap-2">

--- a/src/services/subscriptionService.ts
+++ b/src/services/subscriptionService.ts
@@ -10,6 +10,7 @@ export interface Subscription {
     productName: string;
     productType: SubscriptionProductType;
     priceInOre: number;
+    quantity: number;
     interval: string;
     vippsAgreementId: string;
     status: SubscriptionStatus;
@@ -24,6 +25,7 @@ export interface InitiateSubscriptionPayload {
     productId: number;
     phoneNumber: string;
     consentToWaiveWithdrawal: boolean;
+    quantity?: number;
 }
 
 export interface InitiateSubscriptionResponse {
@@ -40,6 +42,7 @@ export interface AdminSubscription {
     productName: string;
     productType: SubscriptionProductType;
     priceInOre: number;
+    quantity: number;
     interval: string;
     status: SubscriptionStatus;
     isTest: boolean;
@@ -92,6 +95,14 @@ const SubscriptionService = {
 
     async cancelSubscription(id: number): Promise<void> {
         await axiosInstance.post(`/subscriptions/cancel/${id}`);
+    },
+
+    async updateSubscriptionQuantity(id: number, quantity: number): Promise<{ subscription: Subscription; message: string }> {
+        const res = await axiosInstance.patch<{ subscription: Subscription; message: string }>(
+            `/subscriptions/${id}/quantity`,
+            { quantity }
+        );
+        return res.data;
     },
 
     async getConfirmationUrl(id: number): Promise<string> {

--- a/src/tests/services/subscriptionService.test.ts
+++ b/src/tests/services/subscriptionService.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import SubscriptionService from '@/services/subscriptionService';
+
+vi.mock('@/services/axiosInstance', () => ({
+    default: {
+        get: vi.fn(),
+        post: vi.fn(),
+        patch: vi.fn(),
+        delete: vi.fn(),
+    },
+}));
+
+import axiosInstance from '@/services/axiosInstance';
+
+const mockPatch = axiosInstance.patch as ReturnType<typeof vi.fn>;
+const mockPost = axiosInstance.post as ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+describe('SubscriptionService.initiateSubscription', () => {
+    it('passes quantity when provided', async () => {
+        mockPost.mockResolvedValueOnce({ data: { subscriptionId: 1, vippsConfirmationUrl: 'x', vippsAgreementId: 'a' } });
+        await SubscriptionService.initiateSubscription({
+            productId: 7, phoneNumber: '4791234567', consentToWaiveWithdrawal: true, quantity: 3,
+        });
+        expect(mockPost).toHaveBeenCalledWith('/subscriptions/initiate', {
+            productId: 7, phoneNumber: '4791234567', consentToWaiveWithdrawal: true, quantity: 3,
+        });
+    });
+});
+
+describe('SubscriptionService.updateSubscriptionQuantity', () => {
+    it('PATCHes /subscriptions/{id}/quantity with new qty', async () => {
+        mockPatch.mockResolvedValueOnce({ data: { subscription: { id: 5, quantity: 4 }, message: 'ok' } });
+        const res = await SubscriptionService.updateSubscriptionQuantity(5, 4);
+        expect(mockPatch).toHaveBeenCalledWith('/subscriptions/5/quantity', { quantity: 4 });
+        expect(res.message).toBe('ok');
+    });
+});


### PR DESCRIPTION
## Summary
- /shop subscription plan cards now grey out Primary with 'Active' badge + Manage link when the user has an active primary.
- AddOn cards (when primary exists) gain a quantity stepper (1..50) and 'Subscribe x N' button. Vipps modal summary shows 'x N' + line total.
- /profile/billing displays 'x N' badge on multi-quantity rows, line total reflects quantity, and Active AddOns get a 'Change quantity' button opening a new QuantityChangeModal (stepper + new-price preview + Vipps re-confirmation notice).
- Service: optional quantity in InitiateSubscriptionPayload; new updateSubscriptionQuantity(id, qty) calling PATCH /subscriptions/{id}/quantity.
- Tests added for both service methods.
- Depends on garge-api PR sondresjolyst/garge-api#204.