### PR TITLE
feat(battery): consume server-side health analyzer fields + add calibration

### DIFF
--- a/src/app/DeviceDrawer.tsx
+++ b/src/app/DeviceDrawer.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback, useEffect, useState } from 'react';
 import dynamic from 'next/dynamic';
-import { XMarkIcon, PencilIcon, CheckIcon } from '@heroicons/react/24/outline';
+import { XMarkIcon, PencilIcon, CheckIcon, InformationCircleIcon } from '@heroicons/react/24/outline';
 import { TYPE_CONFIG as typeConfig, DEFAULT_TYPE as defaultType, BATTERY_STATUS_CONFIG as statusConfig } from '@/lib/typeConfig';
 import { unitForType, typeLabel } from '@/lib/typeUtils';
 import { RANGE_OPTIONS, type RangeIndex } from '@/lib/constants';
@@ -23,6 +23,47 @@ const TimeSeriesChart = dynamic(() => import('@/components/TimeSeriesChart'), { 
 interface DeviceDrawerProps {
     device: UnifiedDevice;
     onClose: () => void;
+}
+
+function InfoLabel({ children, tooltip }: { children: React.ReactNode; tooltip: string }) {
+    const [open, setOpen] = useState(false);
+    const ref = React.useRef<HTMLSpanElement>(null);
+
+    useEffect(() => {
+        if (!open) return;
+        const handler = (e: MouseEvent | TouchEvent) => {
+            if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+        };
+        document.addEventListener('mousedown', handler);
+        document.addEventListener('touchstart', handler);
+        return () => {
+            document.removeEventListener('mousedown', handler);
+            document.removeEventListener('touchstart', handler);
+        };
+    }, [open]);
+
+    return (
+        <span ref={ref} className="relative text-gray-500 inline-flex items-center gap-1">
+            {children}
+            <button
+                type="button"
+                onClick={() => setOpen(v => !v)}
+                aria-label={tooltip}
+                aria-expanded={open}
+                className="inline-flex items-center justify-center w-5 h-5 -m-0.5 text-gray-600 hover:text-gray-400 active:text-gray-300"
+            >
+                <InformationCircleIcon className="w-3.5 h-3.5 shrink-0" />
+            </button>
+            {open && (
+                <span
+                    role="tooltip"
+                    className="absolute left-0 top-full mt-1 z-20 w-56 px-3 py-2 rounded-lg bg-gray-900 border border-gray-700 text-gray-200 text-xs font-normal normal-case leading-snug shadow-lg"
+                >
+                    {tooltip}
+                </span>
+            )}
+        </span>
+    );
 }
 
 // ── Socket timeline helpers ───────────────────────────────────────────────────
@@ -418,6 +459,13 @@ const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose }) => {
                         )
                     )}
 
+                    {/* Last seen */}
+                    {device.latestTimestamp && (
+                        <p className="text-xs text-gray-600 text-center">
+                            Last seen {formatDateTime(device.latestTimestamp)}
+                        </p>
+                    )}
+
                     {/* Battery health details — server-side analyzer output */}
                     {health && healthCfg && (
                         <div className="bg-gray-800/60 border border-gray-700/40 rounded-2xl p-4 space-y-3">
@@ -432,12 +480,16 @@ const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose }) => {
                             </div>
                             <div className="space-y-2.5">
                                 <div className="flex items-center justify-between text-sm">
-                                    <span className="text-gray-500">Status</span>
+                                    <InfoLabel tooltip="Overall battery health. Needs ≥14 days of data and at least one charge event to assess.">
+                                        Status
+                                    </InfoLabel>
                                     <span className={`font-medium ${healthCfg.color}`}>{healthCfg.label}</span>
                                 </div>
 
                                 <div className="flex items-center justify-between text-sm">
-                                    <span className="text-gray-500">Charger</span>
+                                    <InfoLabel tooltip="Whether the battery is currently being charged.">
+                                        Charger
+                                    </InfoLabel>
                                     {health.onChargerNow ? (
                                         <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-amber-500/15 text-amber-400 text-xs font-medium">
                                             ⚡ On charger
@@ -448,7 +500,9 @@ const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose }) => {
                                 </div>
 
                                 <div className="flex items-center justify-between text-sm">
-                                    <span className="text-gray-500">Last full charge</span>
+                                    <InfoLabel tooltip="When the battery was last detected as fully charged.">
+                                        Last full charge
+                                    </InfoLabel>
                                     <span className="text-gray-200 font-medium text-right">
                                         {health.onChargerNow
                                             ? 'Charging now'
@@ -460,13 +514,17 @@ const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose }) => {
 
                                 {health.fullChargesLast30d > 0 && (
                                     <div className="flex items-center justify-between text-sm">
-                                        <span className="text-gray-500">Full charges (30d)</span>
+                                        <InfoLabel tooltip="Charge events detected in the last 30 days.">
+                                            Full charges (30d)
+                                        </InfoLabel>
                                         <span className="text-gray-200 font-medium tabular-nums">{health.fullChargesLast30d}</span>
                                     </div>
                                 )}
 
                                 <div className="flex items-center justify-between text-sm">
-                                    <span className="text-gray-500">Resting voltage</span>
+                                    <InfoLabel tooltip="Battery's idle voltage, smoothed over 14 days.">
+                                        Resting voltage
+                                    </InfoLabel>
                                     <span className="text-gray-200 font-medium tabular-nums">
                                         {health.restingMedian.toFixed(2)} V
                                         {health.calibrationOffsetV !== null && (
@@ -479,7 +537,9 @@ const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose }) => {
 
                                 {health.voltageMin24h !== null && (
                                     <div className="flex items-center justify-between text-sm">
-                                        <span className="text-gray-500">Min (24h)</span>
+                                        <InfoLabel tooltip="Lowest reading in the last 24 hours.">
+                                            Min (24h)
+                                        </InfoLabel>
                                         <span className="text-gray-200 font-medium tabular-nums">{health.voltageMin24h.toFixed(2)} V</span>
                                     </div>
                                 )}
@@ -487,13 +547,15 @@ const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose }) => {
                                 {health.status !== 'learning' && (
                                     <>
                                         <div className="flex items-center justify-between text-sm">
-                                            <span className="text-gray-500">Drop from peak</span>
+                                            <InfoLabel tooltip="How much resting voltage has dropped from its 90-day peak. Includes natural self-discharge.">
+                                                Drop from peak
+                                            </InfoLabel>
                                             <span className="text-gray-200 font-medium tabular-nums">{health.dropPct.toFixed(1)}%</span>
                                         </div>
                                         <div className="flex items-center justify-between text-sm">
-                                            <span className="text-gray-500" title="Slope of resting voltage over last 30 days, as % per week">
+                                            <InfoLabel tooltip="Trend of resting voltage over the last 30 days.">
                                                 Weekly decline
-                                            </span>
+                                            </InfoLabel>
                                             <span className="text-gray-200 font-medium tabular-nums">
                                                 {health.dailyDropPctPerWeek < 0
                                                     ? `${(-health.dailyDropPctPerWeek).toFixed(2)}% / wk`
@@ -505,9 +567,9 @@ const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose }) => {
 
                                 {health.chargeAcceptanceRatio !== null && (
                                     <div className="flex items-center justify-between text-sm">
-                                        <span className="text-gray-500" title="Peak charging voltage as a ratio of resting voltage. Healthy battery accepts charge to ≥1.10×.">
+                                        <InfoLabel tooltip="How well the battery accepts charge. Healthy ≥1.10×.">
                                             Charge response
-                                        </span>
+                                        </InfoLabel>
                                         <span className="text-gray-200 font-medium tabular-nums">{health.chargeAcceptanceRatio.toFixed(2)}×</span>
                                     </div>
                                 )}
@@ -531,13 +593,6 @@ const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose }) => {
                     {/* Activities (sensors only — e.g. log motorcycle activities for a voltmeter) */}
                     {device.kind === 'sensor' && (
                         <ActivitiesSection sensorId={device.id} />
-                    )}
-
-                    {/* Last seen */}
-                    {device.latestTimestamp && (
-                        <p className="text-xs text-gray-600 text-center pb-2">
-                            Last seen {formatDateTime(device.latestTimestamp)}
-                        </p>
                     )}
 
                 </div>

--- a/src/app/DeviceDrawer.tsx
+++ b/src/app/DeviceDrawer.tsx
@@ -10,11 +10,12 @@ import LoadingDots from '@/components/LoadingDots';
 import PhotoUploader from '@/components/PhotoUploader';
 import SensorService, { SensorData, BatteryHealthData } from '@/services/sensorService';
 import SwitchService, { SwitchData } from '@/services/switchService';
-import { formatDateTime } from '@/lib/dateUtils';
+import { formatDateTime, formatRelative } from '@/lib/dateUtils';
 import SensorPhotoService from '@/services/sensorPhotoService';
 import type { Photo } from '@/services/photoServiceFactory';
 import { toast } from 'sonner';
 import ActivitiesSection from '@/components/ActivitiesSection';
+import CalibrationModal from '@/components/CalibrationModal';
 import type { UnifiedDevice } from './DeviceDashboard';
 
 const TimeSeriesChart = dynamic(() => import('@/components/TimeSeriesChart'), { ssr: false });
@@ -110,6 +111,7 @@ const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose }) => {
 
     // Photo (sensors only)
     const [photo, setPhoto] = useState<Photo | null | undefined>(undefined);
+    const [showCalibration, setShowCalibration] = useState(false);
 
     // Inline name editing (sensors + sockets)
     const [editingName, setEditingName] = useState(false);
@@ -416,39 +418,114 @@ const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose }) => {
                         )
                     )}
 
-                    {/* Battery health details */}
+                    {/* Battery health details — server-side analyzer output */}
                     {health && healthCfg && (
                         <div className="bg-gray-800/60 border border-gray-700/40 rounded-2xl p-4 space-y-3">
-                            <h3 className="text-sm font-semibold text-gray-300">Battery Health</h3>
+                            <div className="flex items-center justify-between">
+                                <h3 className="text-sm font-semibold text-gray-300">Battery Health</h3>
+                                <button
+                                    onClick={() => setShowCalibration(true)}
+                                    className="text-xs text-sky-400 hover:text-sky-300 transition-colors"
+                                >
+                                    Calibrate
+                                </button>
+                            </div>
                             <div className="space-y-2.5">
                                 <div className="flex items-center justify-between text-sm">
                                     <span className="text-gray-500">Status</span>
                                     <span className={`font-medium ${healthCfg.color}`}>{healthCfg.label}</span>
                                 </div>
-                                {health.status !== 'learning' && health.dropPct > 0 && (
-                                    <div className="flex items-center justify-between text-sm">
-                                        <span className="text-gray-500">Daily drop</span>
-                                        <span className="text-gray-200 font-medium">{health.dropPct.toFixed(1)}%</span>
-                                    </div>
-                                )}
+
                                 <div className="flex items-center justify-between text-sm">
-                                    <span className="text-gray-500">Last charged</span>
+                                    <span className="text-gray-500">Charger</span>
+                                    {health.onChargerNow ? (
+                                        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-amber-500/15 text-amber-400 text-xs font-medium">
+                                            ⚡ On charger
+                                        </span>
+                                    ) : (
+                                        <span className="text-gray-400 text-xs">Resting</span>
+                                    )}
+                                </div>
+
+                                <div className="flex items-center justify-between text-sm">
+                                    <span className="text-gray-500">Last full charge</span>
                                     <span className="text-gray-200 font-medium text-right">
-                                        {health.lastChargedAt
-                                            ? formatDateTime(health.lastChargedAt)
-                                            : 'No charge recorded yet'}
+                                        {health.onChargerNow
+                                            ? 'Charging now'
+                                            : health.lastFullChargeAt
+                                                ? formatRelative(health.lastFullChargeAt)
+                                                : 'None detected'}
                                     </span>
                                 </div>
-                                {health.chargesRecorded > 0 && (
+
+                                {health.fullChargesLast30d > 0 && (
                                     <div className="flex items-center justify-between text-sm">
-                                        <span className="text-gray-500" title="Number of times the battery has been detected as charged based on voltage rise patterns">
-                                            Charge cycles detected
+                                        <span className="text-gray-500">Full charges (30d)</span>
+                                        <span className="text-gray-200 font-medium tabular-nums">{health.fullChargesLast30d}</span>
+                                    </div>
+                                )}
+
+                                <div className="flex items-center justify-between text-sm">
+                                    <span className="text-gray-500">Resting voltage</span>
+                                    <span className="text-gray-200 font-medium tabular-nums">
+                                        {health.restingMedian.toFixed(2)} V
+                                        {health.calibrationOffsetV !== null && (
+                                            <span className="text-gray-500 text-xs ml-1">
+                                                ≈ {(health.restingMedian + health.calibrationOffsetV).toFixed(2)} V actual
+                                            </span>
+                                        )}
+                                    </span>
+                                </div>
+
+                                {health.voltageMin24h !== null && (
+                                    <div className="flex items-center justify-between text-sm">
+                                        <span className="text-gray-500">Min (24h)</span>
+                                        <span className="text-gray-200 font-medium tabular-nums">{health.voltageMin24h.toFixed(2)} V</span>
+                                    </div>
+                                )}
+
+                                {health.status !== 'learning' && (
+                                    <>
+                                        <div className="flex items-center justify-between text-sm">
+                                            <span className="text-gray-500">Drop from peak</span>
+                                            <span className="text-gray-200 font-medium tabular-nums">{health.dropPct.toFixed(1)}%</span>
+                                        </div>
+                                        <div className="flex items-center justify-between text-sm">
+                                            <span className="text-gray-500" title="Slope of resting voltage over last 30 days, as % per week">
+                                                Weekly decline
+                                            </span>
+                                            <span className="text-gray-200 font-medium tabular-nums">
+                                                {health.dailyDropPctPerWeek < 0
+                                                    ? `${(-health.dailyDropPctPerWeek).toFixed(2)}% / wk`
+                                                    : 'stable'}
+                                            </span>
+                                        </div>
+                                    </>
+                                )}
+
+                                {health.chargeAcceptanceRatio !== null && (
+                                    <div className="flex items-center justify-between text-sm">
+                                        <span className="text-gray-500" title="Peak charging voltage as a ratio of resting voltage. Healthy battery accepts charge to ≥1.10×.">
+                                            Charge response
                                         </span>
-                                        <span className="text-gray-200 font-medium">{health.chargesRecorded}</span>
+                                        <span className="text-gray-200 font-medium tabular-nums">{health.chargeAcceptanceRatio.toFixed(2)}×</span>
                                     </div>
                                 )}
                             </div>
                         </div>
+                    )}
+
+                    {showCalibration && health && device.sensorName && (
+                        <CalibrationModal
+                            sensorName={device.sensorName}
+                            currentSensorReading={health.currentVoltage}
+                            existingOffset={health.calibrationOffsetV}
+                            onClose={() => setShowCalibration(false)}
+                            onSaved={() => {
+                                setShowCalibration(false);
+                                toast.message('Calibration applied. Voltage display will update on next refresh.');
+                            }}
+                        />
                     )}
 
                     {/* Activities (sensors only — e.g. log motorcycle activities for a voltmeter) */}

--- a/src/components/CalibrationModal.tsx
+++ b/src/components/CalibrationModal.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { useEscapeKey } from '@/lib/useEscapeKey';
+import SensorService from '@/services/sensorService';
+
+export interface CalibrationModalProps {
+    sensorName: string;
+    currentSensorReading: number;
+    existingOffset: number | null;
+    onClose: () => void;
+    onSaved: () => void;
+}
+
+export default function CalibrationModal({
+    sensorName,
+    currentSensorReading,
+    existingOffset,
+    onClose,
+    onSaved,
+}: CalibrationModalProps) {
+    const [value, setValue] = useState<string>('');
+    const [submitting, setSubmitting] = useState(false);
+    useEscapeKey(!submitting, onClose);
+
+    const parsed = parseFloat(value);
+    const valid = !Number.isNaN(parsed) && parsed > 0 && parsed < 100;
+
+    async function handleSave() {
+        if (!valid || submitting) return;
+        setSubmitting(true);
+        try {
+            await SensorService.calibrateBattery(sensorName, parsed);
+            toast.success('Calibration saved');
+            onSaved();
+        } catch {
+            toast.error('Failed to save calibration');
+            setSubmitting(false);
+        }
+    }
+
+    async function handleClear() {
+        setSubmitting(true);
+        try {
+            await SensorService.clearCalibration(sensorName);
+            toast.success('Calibration cleared');
+            onSaved();
+        } catch {
+            toast.error('Failed to clear calibration');
+            setSubmitting(false);
+        }
+    }
+
+    return (
+        <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="cal-title"
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+        >
+            <div className="absolute inset-0" aria-hidden onClick={() => { if (!submitting) onClose(); }} />
+            <div className="relative bg-gray-900 border border-gray-700/60 rounded-2xl p-5 w-full max-w-sm space-y-4 shadow-2xl">
+                <div>
+                    <p id="cal-title" className="text-sm font-semibold text-gray-100">Calibrate voltage</p>
+                    <p className="text-xs text-gray-500 mt-1">
+                        Sensor reads <span className="text-gray-300 tabular-nums">{currentSensorReading.toFixed(2)}V</span> right now.
+                        Measure the battery with a multimeter and enter the actual voltage below.
+                    </p>
+                </div>
+
+                <div className="space-y-1">
+                    <label className="block text-[11px] font-medium text-gray-500 uppercase tracking-wider">
+                        Multimeter reading (V)
+                    </label>
+                    <input
+                        type="number"
+                        inputMode="decimal"
+                        step="0.01"
+                        min="0"
+                        max="30"
+                        autoFocus
+                        value={value}
+                        onChange={e => setValue(e.target.value)}
+                        onKeyDown={e => { if (e.key === 'Enter') handleSave(); }}
+                        disabled={submitting}
+                        placeholder="12.45"
+                        className="w-full bg-gray-800/60 border border-gray-700/60 rounded-lg px-3 py-2 text-sm text-gray-100 placeholder-gray-600 focus:outline-none focus:border-sky-500/60 transition-colors disabled:opacity-50"
+                    />
+                </div>
+
+                {existingOffset !== null && (
+                    <p className="text-[11px] text-gray-500">
+                        Current offset: <span className="text-gray-300 tabular-nums">{existingOffset.toFixed(2)}V</span>
+                    </p>
+                )}
+
+                <div className="flex gap-2">
+                    <button
+                        onClick={handleSave}
+                        disabled={!valid || submitting}
+                        className="flex-1 px-4 py-2 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded-lg transition-colors"
+                    >
+                        {submitting ? 'Saving…' : 'Save'}
+                    </button>
+                    {existingOffset !== null && (
+                        <button
+                            onClick={handleClear}
+                            disabled={submitting}
+                            className="px-4 py-2 bg-gray-700/60 hover:bg-red-900/40 hover:border-red-700/50 border border-gray-600/40 text-gray-400 hover:text-red-400 text-sm rounded-lg transition-all disabled:opacity-50"
+                        >
+                            Remove
+                        </button>
+                    )}
+                    <button
+                        onClick={onClose}
+                        disabled={submitting}
+                        className="px-4 py-2 bg-gray-700/60 hover:bg-gray-700 text-gray-300 text-sm rounded-lg transition-colors disabled:opacity-50"
+                    >
+                        Cancel
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/src/lib/dateUtils.ts
+++ b/src/lib/dateUtils.ts
@@ -20,3 +20,21 @@ export function formatDate(date: Date | string | number): string {
 export function formatDateTime(date: Date | string | number): string {
     return new Date(date).toLocaleString(LOCALE, DATETIME_OPTIONS)
 }
+
+export function formatRelative(date: Date | string | number, now: Date = new Date()): string {
+    const then = new Date(date)
+    const diffMs = now.getTime() - then.getTime()
+    if (diffMs < 0) return 'just now'
+    const sec = Math.round(diffMs / 1000)
+    if (sec < 60) return 'just now'
+    const min = Math.round(sec / 60)
+    if (min < 60) return `${min} min ago`
+    const hr = Math.round(min / 60)
+    if (hr < 24) return `${hr} h ago`
+    const days = Math.round(hr / 24)
+    if (days < 30) return `${days} d ago`
+    const months = Math.round(days / 30)
+    if (months < 12) return `${months} mo ago`
+    const years = Math.round(months / 12)
+    return `${years} y ago`
+}

--- a/src/services/sensorService.ts
+++ b/src/services/sensorService.ts
@@ -23,12 +23,36 @@ export interface BatteryHealthData {
     id: number;
     sensorId: number;
     status: string;
+    // Legacy fields. Will be dropped in phase 2.
     baseline: number;
     lastCharge: number;
     dropPct: number;
     chargesRecorded: number;
-    timestamp: string;
     lastChargedAt: string | null;
+    // Analyzer-computed fields.
+    currentVoltage: number;
+    restingMedian: number;
+    peakResting: number;
+    onChargerNow: boolean;
+    lastFullChargeAt: string | null;
+    lastFullChargePeak: number | null;
+    voltageMin24h: number | null;
+    fullChargesLast30d: number;
+    dailyDropPctPerWeek: number;
+    chargeAcceptanceRatio: number | null;
+    calibrationOffsetV: number | null;
+    timestamp: string;
+}
+
+export interface BatteryChargeEvent {
+    id: number;
+    sensorId: number;
+    startedAt: string;
+    endedAt: string;
+    peakVoltage: number;
+    restingAtTime: number;
+    peakRatio: number;
+    durationMinutes: number;
 }
 
 export interface PagedResponse<T> {
@@ -193,6 +217,27 @@ const SensorService = {
                 throw new Error('An unknown error occurred');
             }
         }
+    },
+
+    async getBatteryChargeEvents(sensorName: string, since?: string): Promise<BatteryChargeEvent[]> {
+        const params = since ? { since } : undefined;
+        const response = await axiosInstance.get<BatteryChargeEvent[]>(
+            `/battery-health/name/${encodeURIComponent(sensorName)}/events`,
+            { params }
+        );
+        return response.data;
+    },
+
+    async calibrateBattery(sensorName: string, multimeterVoltage: number): Promise<{ calibrationOffsetV: number }> {
+        const response = await axiosInstance.post<{ calibrationOffsetV: number }>(
+            `/battery-health/name/${encodeURIComponent(sensorName)}/calibration`,
+            { multimeterVoltage }
+        );
+        return response.data;
+    },
+
+    async clearCalibration(sensorName: string): Promise<void> {
+        await axiosInstance.delete(`/battery-health/name/${encodeURIComponent(sensorName)}/calibration`);
     },
 };
 

--- a/src/tests/lib/dateUtils.test.ts
+++ b/src/tests/lib/dateUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { formatDate, formatDateTime } from '@/lib/dateUtils'
+import { formatDate, formatDateTime, formatRelative } from '@/lib/dateUtils'
 
 describe('formatDate', () => {
     it('formats Date object in nb-NO locale', () => {
@@ -25,5 +25,27 @@ describe('formatDateTime', () => {
         expect(result).toContain('05.01.2024')
         expect(result).toContain('14')
         expect(result).toContain('30')
+    })
+})
+
+describe('formatRelative', () => {
+    const now = new Date('2026-01-01T12:00:00Z')
+    it('returns "just now" for < 1 min', () => {
+        expect(formatRelative(new Date('2026-01-01T11:59:40Z'), now)).toBe('just now')
+    })
+    it('returns minutes', () => {
+        expect(formatRelative(new Date('2026-01-01T11:55:00Z'), now)).toBe('5 min ago')
+    })
+    it('returns hours', () => {
+        expect(formatRelative(new Date('2026-01-01T09:00:00Z'), now)).toBe('3 h ago')
+    })
+    it('returns days', () => {
+        expect(formatRelative(new Date('2025-12-29T12:00:00Z'), now)).toBe('3 d ago')
+    })
+    it('returns months', () => {
+        expect(formatRelative(new Date('2025-10-01T12:00:00Z'), now)).toBe('3 mo ago')
+    })
+    it('returns years', () => {
+        expect(formatRelative(new Date('2023-01-01T12:00:00Z'), now)).toBe('3 y ago')
     })
 })


### PR DESCRIPTION
## Summary
- Pairs with garge-api PR sondresjolyst/garge-api#209 (server-side battery health analyzer). Reads the new analyzer-computed fields and renders an updated DeviceDrawer battery-health section.
- Drops the lifetime 'Charge cycles detected' counter (unfalsifiable, inflated from false positives) in favour of 'Full charges (30d)'.
- Adds 'Calibrate' button + CalibrationModal for legacy voltage sensors with calibration drift. Saves a per-sensor offset; displayed voltage shows '≈X.XV actual'. Health logic itself is ratio-based and ignores the offset.
- 'Last charged' now reflects the real end of the most recent detected charge event (or 'Charging now') instead of a 24h-backdated fudge.
- 'Learning' status now means <14 days of data, not firmware NVS state.
- Adds formatRelative helper in lib/dateUtils for human-readable relative times.
- 6 new dateUtils tests; existing 91 still pass.