### PR TITLE
refactor(battery-ui): drop legacy battery health fields (phase 2) (#277)

### DIFF
--- a/src/app/DeviceDrawer.tsx
+++ b/src/app/DeviceDrawer.tsx
@@ -550,7 +550,12 @@ const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose }) => {
                                             <InfoLabel tooltip="How much resting voltage has dropped from its 90-day peak. Includes natural self-discharge.">
                                                 Drop from peak
                                             </InfoLabel>
-                                            <span className="text-gray-200 font-medium tabular-nums">{health.dropPct.toFixed(1)}%</span>
+                                            <span className="text-gray-200 font-medium tabular-nums">
+                                                {(health.peakResting > 0
+                                                    ? ((health.peakResting - health.restingMedian) / health.peakResting) * 100
+                                                    : 0
+                                                ).toFixed(1)}%
+                                            </span>
                                         </div>
                                         <div className="flex items-center justify-between text-sm">
                                             <InfoLabel tooltip="Trend of resting voltage over the last 30 days.">

--- a/src/services/sensorService.ts
+++ b/src/services/sensorService.ts
@@ -23,13 +23,6 @@ export interface BatteryHealthData {
     id: number;
     sensorId: number;
     status: string;
-    // Legacy fields. Will be dropped in phase 2.
-    baseline: number;
-    lastCharge: number;
-    dropPct: number;
-    chargesRecorded: number;
-    lastChargedAt: string | null;
-    // Analyzer-computed fields.
     currentVoltage: number;
     restingMedian: number;
     peakResting: number;


### PR DESCRIPTION
Mirrors https://github.com/sondresjolyst/garge-api/issues/210 phase 2 cleanup.

- Drop baseline, lastCharge, dropPct, chargesRecorded, lastChargedAt from the BatteryHealthData interface — analyzer fields fully cover the same information now.
- DeviceDrawer "Drop from peak" now derives from peakResting and restingMedian instead of reading the dropped dropPct field.

Closes https://github.com/sondresjolyst/garge-api/issues/210 on the frontend side.