### PR TITLE
fix(battery-ui): clarify resting voltage tooltip

### DIFF
--- a/src/app/DeviceDrawer.tsx
+++ b/src/app/DeviceDrawer.tsx
@@ -522,7 +522,7 @@ const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose }) => {
                                 )}
 
                                 <div className="flex items-center justify-between text-sm">
-                                    <InfoLabel tooltip="Battery's idle voltage, smoothed over 14 days.">
+                                    <InfoLabel tooltip="Battery's current rested voltage (3-day median, charging periods excluded).">
                                         Resting voltage
                                     </InfoLabel>
                                     <span className="text-gray-200 font-medium tabular-nums">


### PR DESCRIPTION
## Summary

Backend (garge-api fix-resting-median-split, PR #217) now persists the 3-day `currentResting` in this field instead of the 14d historical low, so the displayed value reflects the battery's present rested state. Updates the "Resting voltage" tooltip text to match the new semantic.

Pairs with https://github.com/sondresjolyst/garge-api/pull/217.