### PR TITLE
fix(battery-ui): handle null weekly decline (cycle-anchored slope)

### DIFF
--- a/src/app/DeviceDrawer.tsx
+++ b/src/app/DeviceDrawer.tsx
@@ -558,13 +558,15 @@ const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose }) => {
                                             </span>
                                         </div>
                                         <div className="flex items-center justify-between text-sm">
-                                            <InfoLabel tooltip="Trend of resting voltage over the last 30 days.">
+                                            <InfoLabel tooltip="Trend across post-charge resting voltage over recent charge cycles. Needs at least 3 charge cycles to compute.">
                                                 Weekly decline
                                             </InfoLabel>
-                                            <span className="text-gray-200 font-medium tabular-nums">
-                                                {health.dailyDropPctPerWeek < 0
-                                                    ? `${(-health.dailyDropPctPerWeek).toFixed(2)}% / wk`
-                                                    : 'stable'}
+                                            <span className="text-gray-200 font-medium tabular-nums text-right">
+                                                {health.dailyDropPctPerWeek === null
+                                                    ? <span className="text-gray-500 text-xs">Needs more charge cycles</span>
+                                                    : health.dailyDropPctPerWeek < 0
+                                                        ? `${(-health.dailyDropPctPerWeek).toFixed(2)}% / wk`
+                                                        : 'stable'}
                                             </span>
                                         </div>
                                     </>

--- a/src/services/sensorService.ts
+++ b/src/services/sensorService.ts
@@ -31,7 +31,7 @@ export interface BatteryHealthData {
     lastFullChargePeak: number | null;
     voltageMin24h: number | null;
     fullChargesLast30d: number;
-    dailyDropPctPerWeek: number;
+    dailyDropPctPerWeek: number | null;
     chargeAcceptanceRatio: number | null;
     calibrationOffsetV: number | null;
     timestamp: string;


### PR DESCRIPTION
## Summary

garge-api PR https://github.com/sondresjolyst/garge-api/pull/221 redefines S2 slope as a cycle-anchored measurement and returns null when fewer than 3 charge-cycle anchors exist. Frontend:

- `BatteryHealthData.dailyDropPctPerWeek`: `number` → `number | null`.
- `DeviceDrawer` "Weekly decline" row renders "Needs more charge cycles" when null.
- Tooltip updated to describe the new semantic: trend across post-charge resting voltage over recent charge cycles.