### PR TITLE
fix(battery-ui): handle null weekly decline (cycle-anchored slope) (#…

### DIFF
--- a/src/app/DeviceDrawer.tsx
+++ b/src/app/DeviceDrawer.tsx
@@ -558,13 +558,15 @@ const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose }) => {
                                             </span>
                                         </div>
                                         <div className="flex items-center justify-between text-sm">
-                                            <InfoLabel tooltip="Trend of resting voltage over the last 30 days.">
+                                            <InfoLabel tooltip="Trend across post-charge resting voltage over recent charge cycles. Needs at least 3 charge cycles to compute.">
                                                 Weekly decline
                                             </InfoLabel>
-                                            <span className="text-gray-200 font-medium tabular-nums">
-                                                {health.dailyDropPctPerWeek < 0
-                                                    ? `${(-health.dailyDropPctPerWeek).toFixed(2)}% / wk`
-                                                    : 'stable'}
+                                            <span className="text-gray-200 font-medium tabular-nums text-right">
+                                                {health.dailyDropPctPerWeek === null
+                                                    ? <span className="text-gray-500 text-xs">Needs more charge cycles</span>
+                                                    : health.dailyDropPctPerWeek < 0
+                                                        ? `${(-health.dailyDropPctPerWeek).toFixed(2)}% / wk`
+                                                        : 'stable'}
                                             </span>
                                         </div>
                                     </>

--- a/src/services/sensorService.ts
+++ b/src/services/sensorService.ts
@@ -31,7 +31,7 @@ export interface BatteryHealthData {
     lastFullChargePeak: number | null;
     voltageMin24h: number | null;
     fullChargesLast30d: number;
-    dailyDropPctPerWeek: number;
+    dailyDropPctPerWeek: number | null;
     chargeAcceptanceRatio: number | null;
     calibrationOffsetV: number | null;
     timestamp: string;


### PR DESCRIPTION
…282)

garge-api now returns dailyDropPctPerWeek=null when there are fewer than 3 cycle anchors (post-charge resting samples). Show "Needs more charge cycles" in that case instead of misrendering. Update tooltip to reflect the new semantic (post-charge resting trend across cycles, not calendar-time linear fit).

Pairs with garge-api fix-s2-cycle-anchored-slope.