### PR TITLE
feat(admin): bulk reanalyze battery health from admin page

### DIFF
--- a/src/app/(protected)/admin/page.tsx
+++ b/src/app/(protected)/admin/page.tsx
@@ -13,6 +13,7 @@ import { toast } from 'sonner';
 
 const TimeSeriesChart = dynamic(() => import('@/components/TimeSeriesChart'), { ssr: false });
 import AdminService, { AdminStats, AdminUser, StatSnapshot, EmailStats, AppSettings } from '@/services/adminService';
+import SensorService from '@/services/sensorService';
 import { formatNok } from '@/lib/formatUtils';
 
 type StatKey = 'totalUsers' | 'totalSensors' | 'totalSwitches' | 'totalAutomations';
@@ -56,6 +57,7 @@ export default function AdminPage() {
 
     const [appSettings, setAppSettings] = useState<AppSettings | null>(null);
     const [appSettingsLoading, setAppSettingsLoading] = useState(false);
+    const [reanalyzingBattery, setReanalyzingBattery] = useState(false);
 
     const load = useCallback(async () => {
         setLoading(true);
@@ -135,6 +137,19 @@ export default function AdminPage() {
             toast.error('Failed to update setting');
         } finally {
             setAppSettingsLoading(false);
+        }
+    };
+
+    const handleReanalyzeBattery = async () => {
+        setReanalyzingBattery(true);
+        try {
+            const result = await SensorService.reanalyzeBatteryHealth();
+            const failureSuffix = result.failed > 0 ? ` (${result.failed} failed)` : '';
+            toast.success(`Reanalyzed ${result.processed}/${result.total} sensors${failureSuffix}`);
+        } catch {
+            toast.error('Reanalyze failed');
+        } finally {
+            setReanalyzingBattery(false);
         }
     };
 
@@ -429,6 +444,23 @@ export default function AdminPage() {
                                     </button>
                                 )}
                             </div>
+                        </div>
+                    </Section>
+
+                    {/* Battery health */}
+                    <Section title="Battery health">
+                        <div className="flex items-center justify-between bg-gray-900/50 border border-gray-700/40 rounded-xl p-4">
+                            <div>
+                                <p className="text-sm font-medium text-gray-200">Reanalyze all voltage sensors</p>
+                                <p className="text-xs text-gray-500 mt-0.5">Rebuilds each sensor&apos;s battery-health row from its full voltage history. Use after deploying a new analyzer version.</p>
+                            </div>
+                            <button
+                                onClick={handleReanalyzeBattery}
+                                disabled={reanalyzingBattery}
+                                className="shrink-0 px-3 py-1.5 text-sm font-medium text-gray-100 bg-sky-600 hover:bg-sky-500 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                                {reanalyzingBattery ? 'Reanalyzing…' : 'Reanalyze'}
+                            </button>
                         </div>
                     </Section>
 

--- a/src/services/sensorService.ts
+++ b/src/services/sensorService.ts
@@ -232,6 +232,13 @@ const SensorService = {
     async clearCalibration(sensorName: string): Promise<void> {
         await axiosInstance.delete(`/battery-health/name/${encodeURIComponent(sensorName)}/calibration`);
     },
+
+    async reanalyzeBatteryHealth(): Promise<{ processed: number; failed: number; total: number }> {
+        const response = await axiosInstance.post<{ processed: number; failed: number; total: number }>(
+            '/battery-health/admin/reanalyze'
+        );
+        return response.data;
+    },
 };
 
 export default SensorService;


### PR DESCRIPTION
## Summary

Surfaces `POST /api/battery-health/admin/reanalyze` (garge-api PR https://github.com/sondresjolyst/garge-api/pull/224) as a button on the admin page so battery rows can be rebuilt for the whole fleet without waiting for each sensor's next NOTIFY.

After deploying a new analyzer version, one click rewrites every `BatteryHealthData` row. Toast shows `Reanalyzed N/M sensors (K failed)` based on the endpoint's `{ processed, failed, total }` response.

Admin/SensorAdmin only — page already gates on `isAdmin` and the endpoint enforces the role server-side.

Pairs with https://github.com/sondresjolyst/garge-api/pull/224. Merge order: API first (or in parallel; UI gracefully toasts "Reanalyze failed" if the endpoint isn't deployed yet).