### PR TITLE
fix(battery-ui): rename resting voltage rows to 3d / 90d, show difference

### DIFF
--- a/src/app/DeviceDrawer.tsx
+++ b/src/app/DeviceDrawer.tsx
@@ -522,8 +522,8 @@ const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose }) => {
                                 )}
 
                                 <div className="flex items-center justify-between text-sm">
-                                    <InfoLabel tooltip="Battery's current rested voltage (3-day median, charging periods excluded).">
-                                        Resting voltage
+                                    <InfoLabel tooltip="Battery's current rested voltage, smoothed over the last 3 days.">
+                                        Resting voltage (3d)
                                     </InfoLabel>
                                     <span className="text-gray-200 font-medium tabular-nums">
                                         {health.restingMedian.toFixed(2)} V
@@ -547,14 +547,30 @@ const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose }) => {
                                 {health.status !== 'learning' && (
                                     <>
                                         <div className="flex items-center justify-between text-sm">
-                                            <InfoLabel tooltip="How much resting voltage has dropped from its 90-day peak. Includes natural self-discharge.">
-                                                Drop from peak
+                                            <InfoLabel tooltip="Long-term resting voltage baseline observed over the last 90 days.">
+                                                Resting voltage (90d)
                                             </InfoLabel>
                                             <span className="text-gray-200 font-medium tabular-nums">
-                                                {(health.peakResting > 0
-                                                    ? ((health.peakResting - health.restingMedian) / health.peakResting) * 100
-                                                    : 0
-                                                ).toFixed(1)}%
+                                                {health.peakResting.toFixed(2)} V
+                                                {health.calibrationOffsetV !== null && (
+                                                    <span className="text-gray-500 text-xs ml-1">
+                                                        ≈ {(health.peakResting + health.calibrationOffsetV).toFixed(2)} V actual
+                                                    </span>
+                                                )}
+                                            </span>
+                                        </div>
+                                        <div className="flex items-center justify-between text-sm">
+                                            <InfoLabel tooltip="How the current 3-day resting voltage compares to the 90-day baseline.">
+                                                Difference
+                                            </InfoLabel>
+                                            <span className="text-gray-200 font-medium tabular-nums text-right">
+                                                {(() => {
+                                                    const delta = health.peakResting > 0
+                                                        ? ((health.restingMedian - health.peakResting) / health.peakResting) * 100
+                                                        : 0;
+                                                    if (Math.abs(delta) < 0.05) return '0.0%';
+                                                    return `${Math.abs(delta).toFixed(1)}% ${delta > 0 ? 'above' : 'below'}`;
+                                                })()}
                                             </span>
                                         </div>
                                         <div className="flex items-center justify-between text-sm">


### PR DESCRIPTION
## Summary

Single `Resting voltage` label hid the fact that the displayed number is the 3d bottom-25 median, while `Drop from peak` compared it to `peakResting` (a 90d stat). When battery recently recovered from a deep discharge, `peakResting` < `restingMedian` and the row read as negative — confusing with any drop/peak/best framing.

Pure relabel — no backend or status logic change. Both backend values (`restingMedian`, `peakResting`) untouched. UI now shows them side by side with explicit time windows, plus a neutral difference row:

```nResting voltage (3d)    12.73 V
Resting voltage (90d)   12.55 V
Difference              1.4% above
```nThe 3d/90d qualifiers describe time windows, not min/max, so the edge case where 90d is below 3d (recovery from a recent discharge) reads as informative rather than contradictory.