### PR TITLE
feat: deterministic sort for automation rules

### DIFF
--- a/src/app/(protected)/automations/page.tsx
+++ b/src/app/(protected)/automations/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import AutomationService from '@/services/automationService';
 import SwitchService, { Switch } from '@/services/switchService';
 import SensorService, { Sensor } from '@/services/sensorService';
@@ -10,6 +10,7 @@ import { CreateAutomationRuleDto } from '@/dto/Automation/CreateAutomationRuleDt
 import { UpdateAutomationRuleDto } from '@/dto/Automation/UpdateAutomationRuleDto';
 import { unitForType } from '@/lib/typeUtils';
 import { formatDateTime } from '@/lib/dateUtils';
+import { sortAutomationRules } from '@/lib/automationSort';
 import { AxiosError } from 'axios';
 import ConfirmModal from '@/components/ConfirmModal';
 import {
@@ -227,6 +228,11 @@ const AutomationsPage: React.FC = () => {
     const [defaultPriceArea, setDefaultPriceArea] = useState<string>('NO2');
     const [deleteTargetId, setDeleteTargetId]     = useState<number | null>(null);
     const [latestValueMap, setLatestValueMap] = useState<Record<number, number>>({});
+
+    const sortedRules = useMemo(
+        () => sortAutomationRules(rules, switches, sensors),
+        [rules, switches, sensors],
+    );
 
     useEffect(() => {
         Promise.all([fetchRules(), fetchSwitches(), fetchSensors(), fetchUserPriceZone()])
@@ -753,14 +759,7 @@ const AutomationsPage: React.FC = () => {
                 emptyState
             ) : (
                 <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 device-card-grid">
-                    {[...rules]
-                        .sort((a, b) => {
-                            if (a.isEnabled !== b.isEnabled) return a.isEnabled ? -1 : 1;
-                            const nameA = (switches.find(sw => sw.id === a.targetId)?.customName ?? switches.find(sw => sw.id === a.targetId)?.name ?? '').toLowerCase();
-                            const nameB = (switches.find(sw => sw.id === b.targetId)?.customName ?? switches.find(sw => sw.id === b.targetId)?.name ?? '').toLowerCase();
-                            return nameA.localeCompare(nameB);
-                        })
-                        .map(rule => renderRuleCard(rule))}
+                    {sortedRules.map(rule => renderRuleCard(rule))}
                 </div>
             )}
 

--- a/src/lib/automationSort.ts
+++ b/src/lib/automationSort.ts
@@ -1,0 +1,32 @@
+import { AutomationRuleDto } from '@/dto/Automation/AutomationRuleDto';
+import { Switch } from '@/services/switchService';
+import { Sensor } from '@/services/sensorService';
+
+const switchDisplayName = (sw: Switch | undefined): string =>
+    (sw?.customName ?? sw?.name ?? '').toLowerCase();
+
+const sensorDisplayName = (s: Sensor | undefined): string =>
+    (s?.customName ?? s?.defaultName ?? s?.name ?? '').toLowerCase();
+
+export function sortAutomationRules(
+    rules: AutomationRuleDto[],
+    switches: Switch[],
+    sensors: Sensor[],
+): AutomationRuleDto[] {
+    const switchById = new Map(switches.map(sw => [sw.id, switchDisplayName(sw)]));
+    const sensorById = new Map(sensors.map(s => [s.id, sensorDisplayName(s)]));
+
+    return [...rules].sort((a, b) => {
+        if (a.isEnabled !== b.isEnabled) return a.isEnabled ? -1 : 1;
+
+        const switchCmp = (switchById.get(a.targetId) ?? '').localeCompare(switchById.get(b.targetId) ?? '');
+        if (switchCmp !== 0) return switchCmp;
+
+        const sensorCmp = (sensorById.get(a.sensorId) ?? '').localeCompare(sensorById.get(b.sensorId) ?? '');
+        if (sensorCmp !== 0) return sensorCmp;
+
+        if (a.threshold !== b.threshold) return a.threshold - b.threshold;
+
+        return a.id - b.id;
+    });
+}

--- a/src/tests/lib/automationSort.test.ts
+++ b/src/tests/lib/automationSort.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest'
+import { sortAutomationRules } from '@/lib/automationSort'
+import { AutomationRuleDto } from '@/dto/Automation/AutomationRuleDto'
+import { Switch } from '@/services/switchService'
+import { Sensor } from '@/services/sensorService'
+
+function rule(partial: Partial<AutomationRuleDto> & { id: number }): AutomationRuleDto {
+    return {
+        targetType: 'switch',
+        targetId: 0,
+        sensorType: 'temperature',
+        sensorId: 0,
+        condition: '<',
+        threshold: 0,
+        action: 'on',
+        isEnabled: true,
+        lastTriggeredAt: null,
+        ...partial,
+    }
+}
+
+function sw(id: number, name: string, customName?: string): Switch {
+    return { id, name, customName } as Switch
+}
+
+function sensor(id: number, name: string, customName?: string, defaultName?: string): Sensor {
+    return { id, name, customName: customName ?? '', defaultName: defaultName ?? '' } as Sensor
+}
+
+describe('sortAutomationRules', () => {
+    it('puts enabled rules before disabled ones', () => {
+        const rules = [
+            rule({ id: 1, isEnabled: false, targetId: 1 }),
+            rule({ id: 2, isEnabled: true,  targetId: 1 }),
+        ]
+        const switches = [sw(1, 'heater')]
+        const result = sortAutomationRules(rules, switches, [])
+        expect(result.map(r => r.id)).toEqual([2, 1])
+    })
+
+    it('sorts by target switch name (customName preferred)', () => {
+        const rules = [
+            rule({ id: 1, targetId: 3 }),
+            rule({ id: 2, targetId: 1 }),
+            rule({ id: 3, targetId: 2 }),
+        ]
+        const switches = [
+            sw(1, 'sw-a', 'Charlie'),
+            sw(2, 'sw-b', 'Alpha'),
+            sw(3, 'sw-c', 'Bravo'),
+        ]
+        const result = sortAutomationRules(rules, switches, [])
+        expect(result.map(r => r.id)).toEqual([3, 1, 2])
+    })
+
+    it('breaks ties on same switch by sensor name', () => {
+        const rules = [
+            rule({ id: 1, targetId: 1, sensorId: 2 }),
+            rule({ id: 2, targetId: 1, sensorId: 1 }),
+        ]
+        const switches = [sw(1, 'heater')]
+        const sensors = [
+            sensor(1, 's-1', 'Zebra'),
+            sensor(2, 's-2', 'Apple'),
+        ]
+        const result = sortAutomationRules(rules, switches, sensors)
+        expect(result.map(r => r.id)).toEqual([1, 2])
+    })
+
+    it('breaks ties on same switch + sensor by threshold ascending', () => {
+        const rules = [
+            rule({ id: 1, targetId: 1, sensorId: 1, threshold: 20 }),
+            rule({ id: 2, targetId: 1, sensorId: 1, threshold: 10 }),
+        ]
+        const switches = [sw(1, 'heater')]
+        const sensors = [sensor(1, 's-1', 'Apple')]
+        const result = sortAutomationRules(rules, switches, sensors)
+        expect(result.map(r => r.id)).toEqual([2, 1])
+    })
+
+    it('falls back to id when all keys equal', () => {
+        const rules = [
+            rule({ id: 5, targetId: 1, sensorId: 1, threshold: 10 }),
+            rule({ id: 2, targetId: 1, sensorId: 1, threshold: 10 }),
+            rule({ id: 8, targetId: 1, sensorId: 1, threshold: 10 }),
+        ]
+        const switches = [sw(1, 'heater')]
+        const sensors = [sensor(1, 's-1', 'Apple')]
+        const result = sortAutomationRules(rules, switches, sensors)
+        expect(result.map(r => r.id)).toEqual([2, 5, 8])
+    })
+
+    it('handles missing switch or sensor lookup gracefully', () => {
+        const rules = [
+            rule({ id: 1, targetId: 999, sensorId: 999 }),
+            rule({ id: 2, targetId: 1, sensorId: 1 }),
+        ]
+        const switches = [sw(1, 'heater')]
+        const sensors = [sensor(1, 's-1', 'Apple')]
+        const result = sortAutomationRules(rules, switches, sensors)
+        expect(result.map(r => r.id)).toEqual([1, 2])
+    })
+
+    it('does not mutate the input array', () => {
+        const rules = [
+            rule({ id: 1, isEnabled: false }),
+            rule({ id: 2, isEnabled: true }),
+        ]
+        const original = rules.map(r => r.id)
+        sortAutomationRules(rules, [], [])
+        expect(rules.map(r => r.id)).toEqual(original)
+    })
+})


### PR DESCRIPTION
## Summary
- Extract automations grid sort into `src/lib/automationSort.ts` so it has tests and a clear contract.
- Sort order: enabled rules first, then by target switch name, then by sensor name, then by threshold ascending, then by id. Same-switch rules now have a stable secondary order instead of relying on fetch order.
- Pre-index switch and sensor names by id once per render — the previous inline sort called `switches.find` twice per comparison, which was O(N^2) on the rule list.
- New tests in `src/tests/lib/automationSort.test.ts` cover each tiebreaker, missing lookups, and that the input array is not mutated.