### PR TITLE
fix: prevent description text from collapsing on profile page rows

### DIFF
--- a/src/app/(protected)/admin/orders/page.tsx
+++ b/src/app/(protected)/admin/orders/page.tsx
@@ -104,17 +104,17 @@ export default function AdminOrdersPage() {
                                 return (
                                     <li key={order.id} className="bg-gray-900/40 border border-gray-700/30 rounded-xl p-4 space-y-3">
                                         <div className="flex items-start justify-between gap-3">
-                                            <div>
+                                            <div className="min-w-0 flex-1">
                                                 <div className="flex items-center gap-2">
                                                     <p className="text-sm font-medium text-gray-100">Order #{order.id}</p>
                                                     <TestPill visible={order.isTest} />
                                                 </div>
-                                                <p className="text-xs text-gray-500 mt-0.5">
+                                                <p className="text-xs text-gray-500 mt-0.5 break-words">
                                                     {order.userName} · {order.userEmail}
                                                 </p>
                                                 <p className="text-xs text-gray-600 mt-0.5">{formatDate(order.createdAt)}</p>
                                             </div>
-                                            <div className="flex flex-col items-end gap-1.5">
+                                            <div className="flex flex-col items-end gap-1.5 flex-shrink-0">
                                                 <span className={`px-2 py-0.5 border rounded text-xs font-medium ${statusColor(order.status)}`}>
                                                     {order.status}
                                                 </span>

--- a/src/app/(protected)/admin/page.tsx
+++ b/src/app/(protected)/admin/page.tsx
@@ -253,12 +253,12 @@ export default function AdminPage() {
                     </Section>
 
                     {/* Live / Test toggle for the commerce stats */}
-                    <div className="flex items-center justify-between bg-gray-900/40 border border-gray-700/30 rounded-xl px-4 py-3">
-                        <div>
+                    <div className="flex items-center justify-between gap-4 bg-gray-900/40 border border-gray-700/30 rounded-xl px-4 py-3">
+                        <div className="min-w-0 flex-1">
                             <p className="text-xs text-gray-500 uppercase tracking-widest font-semibold">Commerce data</p>
                             <p className="text-sm text-gray-300 mt-0.5">{statsTest ? 'Showing Vipps test orders + subscriptions' : 'Showing live orders + subscriptions'}</p>
                         </div>
-                        <div className="flex bg-gray-800/60 border border-gray-700/40 rounded-lg p-0.5">
+                        <div className="flex bg-gray-800/60 border border-gray-700/40 rounded-lg p-0.5 flex-shrink-0">
                             {([
                                 { label: 'Live', value: false },
                                 { label: 'Test', value: true },
@@ -390,8 +390,8 @@ export default function AdminPage() {
                     {/* Site Settings */}
                     <Section title="Site Settings">
                         <div className="space-y-3">
-                            <div className="flex items-center justify-between bg-gray-900/50 border border-gray-700/40 rounded-xl p-4">
-                                <div>
+                            <div className="flex items-center justify-between gap-4 bg-gray-900/50 border border-gray-700/40 rounded-xl p-4">
+                                <div className="min-w-0 flex-1">
                                     <p className="text-sm font-medium text-gray-200">Cookie consent banner</p>
                                     <p className="text-xs text-gray-500 mt-0.5">Show banner asking users to accept cookies</p>
                                 </div>
@@ -408,8 +408,8 @@ export default function AdminPage() {
                                     </button>
                                 )}
                             </div>
-                            <div className="flex items-center justify-between bg-gray-900/50 border border-gray-700/40 rounded-xl p-4">
-                                <div>
+                            <div className="flex items-center justify-between gap-4 bg-gray-900/50 border border-gray-700/40 rounded-xl p-4">
+                                <div className="min-w-0 flex-1">
                                     <p className="text-sm font-medium text-gray-200">VAT (mva 25%)</p>
                                     <p className="text-xs text-gray-500 mt-0.5">Add 25% VAT to prices. Disable if below the 50,000 NOK threshold.</p>
                                 </div>
@@ -426,8 +426,8 @@ export default function AdminPage() {
                                     </button>
                                 )}
                             </div>
-                            <div className="flex items-center justify-between bg-gray-900/50 border border-amber-700/30 rounded-xl p-4">
-                                <div>
+                            <div className="flex items-center justify-between gap-4 bg-gray-900/50 border border-amber-700/30 rounded-xl p-4">
+                                <div className="min-w-0 flex-1">
                                     <p className="text-sm font-medium text-gray-200">Vipps test mode</p>
                                     <p className="text-xs text-gray-500 mt-0.5">Use Vipps test environment. Test subscriptions only gate access while this is on.</p>
                                 </div>
@@ -449,8 +449,8 @@ export default function AdminPage() {
 
                     {/* Battery health */}
                     <Section title="Battery health">
-                        <div className="flex items-center justify-between bg-gray-900/50 border border-gray-700/40 rounded-xl p-4">
-                            <div>
+                        <div className="flex items-center justify-between gap-4 bg-gray-900/50 border border-gray-700/40 rounded-xl p-4">
+                            <div className="min-w-0 flex-1">
                                 <p className="text-sm font-medium text-gray-200">Reanalyze all voltage sensors</p>
                                 <p className="text-xs text-gray-500 mt-0.5">Rebuilds each sensor&apos;s battery-health row from its full voltage history. Use after deploying a new analyzer version.</p>
                             </div>
@@ -476,9 +476,9 @@ export default function AdminPage() {
                                 <Link
                                     key={href}
                                     href={href}
-                                    className="flex items-center justify-between bg-gray-900/40 border border-gray-700/30 rounded-xl p-4 hover:border-gray-600/60 hover:bg-gray-900/60 transition-all group"
+                                    className="flex items-center justify-between gap-4 bg-gray-900/40 border border-gray-700/30 rounded-xl p-4 hover:border-gray-600/60 hover:bg-gray-900/60 transition-all group"
                                 >
-                                    <div>
+                                    <div className="min-w-0 flex-1">
                                         <p className="text-sm font-medium text-gray-200 group-hover:text-gray-100">{label}</p>
                                         <p className="text-xs text-gray-500 mt-0.5">{description}</p>
                                     </div>

--- a/src/app/(protected)/admin/products/page.tsx
+++ b/src/app/(protected)/admin/products/page.tsx
@@ -144,7 +144,7 @@ export default function AdminProductsPage() {
                             )}
                             {products.map(p => (
                                 <li key={p.id} className="bg-gray-900/40 border border-gray-700/30 rounded-xl p-4 flex items-center justify-between gap-3">
-                                    <div className="min-w-0">
+                                    <div className="min-w-0 flex-1">
                                         <div className="flex items-center gap-2 flex-wrap">
                                             <span className="text-sm font-semibold text-gray-100">{p.name}</span>
                                             <span className="text-xs font-medium text-sky-400">

--- a/src/app/(protected)/admin/shop/page.tsx
+++ b/src/app/(protected)/admin/shop/page.tsx
@@ -153,7 +153,7 @@ export default function AdminShopPage() {
                             )}
                             {items.map(item => (
                                 <li key={item.id} className="bg-gray-900/40 border border-gray-700/30 rounded-xl p-4 flex items-center justify-between gap-3">
-                                    <div className="min-w-0">
+                                    <div className="min-w-0 flex-1">
                                         <div className="flex items-center gap-2 flex-wrap">
                                             <span className="text-sm font-semibold text-gray-100">{item.name}</span>
                                             <span className="text-xs font-medium text-sky-400">{formatNok(item.priceInOre)}</span>

--- a/src/app/(protected)/admin/subscriptions/page.tsx
+++ b/src/app/(protected)/admin/subscriptions/page.tsx
@@ -82,18 +82,18 @@ export default function AdminSubscriptionsPage() {
                                 return (
                                     <li key={sub.id} className="bg-gray-900/40 border border-gray-700/30 rounded-xl p-4 space-y-3">
                                         <div className="flex items-start justify-between gap-3">
-                                            <div>
+                                            <div className="min-w-0 flex-1">
                                                 <div className="flex items-center gap-2">
                                                     <p className="text-sm font-medium text-gray-100">Subscription #{sub.id}</p>
                                                     <TestPill visible={sub.isTest} />
                                                 </div>
-                                                <p className="text-xs text-gray-500 mt-0.5">
+                                                <p className="text-xs text-gray-500 mt-0.5 break-words">
                                                     {sub.userName} · {sub.userEmail}
                                                 </p>
                                                 <p className="text-xs text-gray-600 mt-0.5">{sub.productName} · {sub.productType} · {sub.interval}</p>
                                                 <p className="text-xs text-gray-600 mt-0.5">Created {formatDate(sub.createdAt)}</p>
                                             </div>
-                                            <div className="flex flex-col items-end gap-1.5">
+                                            <div className="flex flex-col items-end gap-1.5 flex-shrink-0">
                                                 <span className={`px-2 py-0.5 border rounded text-xs font-medium ${statusColor(sub.status)}`}>
                                                     {sub.status}
                                                 </span>

--- a/src/app/(protected)/profile/page.tsx
+++ b/src/app/(protected)/profile/page.tsx
@@ -539,12 +539,12 @@ const Profile: React.FC = () => {
 
                 <div id="settings">
                 <Section title="Settings">
-                    <div className="flex items-center justify-between">
-                        <div>
+                    <div className="flex items-center justify-between gap-4">
+                        <div className="min-w-0 flex-1">
                             <p className="text-sm text-gray-100 font-medium">Electricity price zone</p>
                             <p className="text-xs text-gray-500 mt-0.5">Used on the Electricity page. Norway price zones NO1–NO5.</p>
                         </div>
-                        <div className="flex items-center gap-2">
+                        <div className="flex items-center gap-2 flex-shrink-0">
                             {profileLoading ? (
                                 <div className="w-8 h-8 flex items-center justify-center">
                                     <svg className="animate-spin h-4 w-4 text-sky-500" viewBox="0 0 24 24" fill="none">
@@ -578,7 +578,7 @@ const Profile: React.FC = () => {
                     ) : (
                         <div className="space-y-4">
                             <div className="flex items-center justify-between gap-4">
-                                <div className="min-w-0">
+                                <div className="min-w-0 flex-1">
                                     <p className="text-sm text-gray-100 font-medium">Offline alerts</p>
                                     <p className="text-xs text-gray-500 mt-0.5">Notify when a sensor has not reported for a while. Requires the app to be installed.</p>
                                 </div>
@@ -592,12 +592,12 @@ const Profile: React.FC = () => {
                                 </button>
                             </div>
                             {pushEnabled && (
-                                <div className="flex items-center justify-between">
-                                    <div>
+                                <div className="flex items-center justify-between gap-4">
+                                    <div className="min-w-0 flex-1">
                                         <p className="text-sm text-gray-100 font-medium">Alert after</p>
                                         <p className="text-xs text-gray-500 mt-0.5">Hours of no data before notifying (1–168).</p>
                                     </div>
-                                    <div className="flex items-center gap-2">
+                                    <div className="flex items-center gap-2 flex-shrink-0">
                                         <input
                                             type="number"
                                             min={1}
@@ -611,15 +611,15 @@ const Profile: React.FC = () => {
                                 </div>
                             )}
                             {pushEnabled && (
-                                <div className="flex items-center justify-between">
-                                    <div>
+                                <div className="flex items-center justify-between gap-4">
+                                    <div className="min-w-0 flex-1">
                                         <p className="text-sm text-gray-100 font-medium">Test notification</p>
                                         <p className="text-xs text-gray-500 mt-0.5">Send a test to confirm notifications are working.</p>
                                     </div>
                                     <button
                                         onClick={handleSendTestNotification}
                                         disabled={testNotifLoading}
-                                        className="px-4 py-2 bg-gray-700 hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded-xl transition-all whitespace-nowrap"
+                                        className="px-4 py-2 bg-gray-700 hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded-xl transition-all whitespace-nowrap flex-shrink-0"
                                     >
                                         {testNotifLoading ? 'Sending…' : 'Send test'}
                                     </button>
@@ -634,28 +634,28 @@ const Profile: React.FC = () => {
 
                 <Section title="Your data">
                     <div className="space-y-4">
-                        <div className="flex items-center justify-between">
-                            <div>
+                        <div className="flex items-center justify-between gap-4">
+                            <div className="min-w-0 flex-1">
                                 <p className="text-sm text-gray-100 font-medium">Download your data</p>
                                 <p className="text-xs text-gray-500 mt-0.5">Export your account and device data as JSON (GDPR Article 20).</p>
                             </div>
                             <button
                                 onClick={handleExportData}
                                 disabled={!user?.id || exportLoading}
-                                className="px-4 py-2 bg-gray-700 hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded-xl transition-all whitespace-nowrap"
+                                className="px-4 py-2 bg-gray-700 hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded-xl transition-all whitespace-nowrap flex-shrink-0"
                             >
                                 {exportLoading ? 'Exporting…' : 'Download'}
                             </button>
                         </div>
-                        <div className="border-t border-gray-700/40 pt-4 flex items-center justify-between">
-                            <div>
+                        <div className="border-t border-gray-700/40 pt-4 flex items-center justify-between gap-4">
+                            <div className="min-w-0 flex-1">
                                 <p className="text-sm text-red-400 font-medium">Delete account</p>
                                 <p className="text-xs text-gray-500 mt-0.5">Permanently deletes your account and personal data.</p>
                             </div>
                             <button
                                 onClick={() => setShowDeleteAccount(true)}
                                 disabled={!user?.id || deleteAccountLoading}
-                                className="px-4 py-2 bg-red-600/20 hover:bg-red-600/30 border border-red-600/40 disabled:opacity-50 disabled:cursor-not-allowed text-red-400 text-sm font-medium rounded-xl transition-all whitespace-nowrap"
+                                className="px-4 py-2 bg-red-600/20 hover:bg-red-600/30 border border-red-600/40 disabled:opacity-50 disabled:cursor-not-allowed text-red-400 text-sm font-medium rounded-xl transition-all whitespace-nowrap flex-shrink-0"
                             >
                                 Delete account
                             </button>

--- a/src/app/(protected)/shop/page.tsx
+++ b/src/app/(protected)/shop/page.tsx
@@ -165,7 +165,7 @@ export default function ShopPage() {
                             return (
                                 <div
                                     key={item.id}
-                                    className={`relative bg-gray-900/40 border border-gray-700/30 rounded-xl overflow-hidden flex flex-col ${
+                                    className={`relative bg-gray-900/40 border border-gray-700/30 rounded-xl overflow-hidden flex flex-col min-w-0 ${
                                         outOfStock ? 'opacity-60 grayscale' : ''
                                     }`}
                                 >
@@ -252,7 +252,7 @@ export default function ShopPage() {
                             return (
                                 <div
                                     key={p.id}
-                                    className={`bg-gray-900/40 border border-gray-700/30 rounded-xl p-4 flex flex-col gap-3 ${
+                                    className={`bg-gray-900/40 border border-gray-700/30 rounded-xl p-4 flex flex-col gap-3 min-w-0 ${
                                         dimmed ? 'opacity-60 grayscale' : ''
                                     }`}
                                 >

--- a/src/components/MarkdownText.tsx
+++ b/src/components/MarkdownText.tsx
@@ -22,15 +22,15 @@ export default function MarkdownText({ children, className = '' }: MarkdownTextP
                             {...props}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="text-sky-400 hover:text-sky-300 underline"
+                            className="text-sky-400 hover:text-sky-300 underline break-all"
                         />
                     ),
                     ul: ({ ...props }) => <ul {...props} className="list-disc list-inside space-y-0.5 text-xs text-gray-500" />,
                     ol: ({ ...props }) => <ol {...props} className="list-decimal list-inside space-y-0.5 text-xs text-gray-500" />,
-                    li: ({ ...props }) => <li {...props} className="text-xs text-gray-500" />,
+                    li: ({ ...props }) => <li {...props} className="text-xs text-gray-500 break-words" />,
                     strong: ({ ...props }) => <strong {...props} className="font-semibold text-gray-300" />,
                     em: ({ ...props }) => <em {...props} className="italic text-gray-400" />,
-                    p: ({ ...props }) => <p {...props} className="text-xs text-gray-500" />,
+                    p: ({ ...props }) => <p {...props} className="text-xs text-gray-500 break-words" />,
                     code: ({ ...props }) => <code {...props} className="px-1 py-0.5 rounded bg-gray-800/60 text-gray-300 text-[11px] font-mono" />,
                     h1: ({ ...props }) => <h1 {...props} className="text-sm font-semibold text-gray-200 mt-1" />,
                     h2: ({ ...props }) => <h2 {...props} className="text-sm font-semibold text-gray-200 mt-1" />,


### PR DESCRIPTION
## Summary
- The flex rows in the Settings, Notifications, and Your data sections of the profile page used `flex items-center justify-between` without giving the text block `min-w-0` or `flex-1`. Flex items default to `min-width: auto`, so the description text could only shrink to its longest word, producing the one-word-per-line column behavior on narrow viewports.
- Add `min-w-0 flex-1` to each text container so the description wraps inside the remaining width, and `flex-shrink-0` to the right-side control so it keeps its size.