### PR TITLE
chore: rerun dependabot-title workflow on edit and synchronize

### DIFF
--- a/.github/workflows/dependabot-title.yml
+++ b/.github/workflows/dependabot-title.yml
@@ -2,7 +2,7 @@ name: 📝 Format Dependabot PR titles
 
 on:
   pull_request_target:
-    types: [opened, reopened]
+    types: [opened, reopened, edited, synchronize]
 
 permissions: {}
 


### PR DESCRIPTION
## Summary
- Add `edited` and `synchronize` to the `pull_request_target` types so the title-rewriter also runs when dependabot rebases a PR (e.g. version bump 25.6.0->25.7.0 becomes 25.6.0->25.8.0).
- The workflow already exits early when the title contains a backtick, so the extra runs short-circuit cheaply and do not loop on the workflow's own edits.