### PR TITLE
fix: surface backend message when claim is forbidden

### DIFF
--- a/src/app/(protected)/automations/page.tsx
+++ b/src/app/(protected)/automations/page.tsx
@@ -270,7 +270,7 @@ const AutomationsPage: React.FC = () => {
         .catch(handleError);
     const fetchSwitches = async () => {
         try { setSwitches(await SwitchService.getAllSwitches()); }
-        catch (e) { handleError(e, 'Failed to fetch switches'); }
+        catch (e) { handleError(e, 'Failed to fetch sockets'); }
     };
     const fetchSensors  = async () => {
         try { setSensors(await SensorService.getAllSensors()); }
@@ -592,7 +592,7 @@ const AutomationsPage: React.FC = () => {
                 {[
                     { step: '1', title: 'Choose a socket', desc: 'Pick which socket to control' },
                     { step: '2', title: 'Set a trigger',   desc: 'Select a sensor and the condition that fires the rule' },
-                    { step: '3', title: 'Define the action', desc: 'Turn the switch on or off when conditions are met' },
+                    { step: '3', title: 'Define the action', desc: 'Turn the socket on or off when conditions are met' },
                 ].map(item => (
                     <div key={item.step} className="flex items-start gap-3 p-3 bg-gray-800/40 rounded-xl border border-gray-700/30">
                         <span className="flex-shrink-0 w-6 h-6 rounded-full bg-sky-600/20 border border-sky-500/30 text-sky-400 text-xs font-bold flex items-center justify-center mt-0.5">

--- a/src/lib/errorMessages.ts
+++ b/src/lib/errorMessages.ts
@@ -9,7 +9,7 @@ export function formatApiError(err: unknown, fallback: string): string {
             : (typeof data === 'object' && data && 'message' in data ? String((data as { message: unknown }).message) : '');
 
         if (status === 400 && serverMessage) return serverMessage;
-        if (status === 401 || status === 403) return 'Not authorized.';
+        if (status === 401 || status === 403) return serverMessage || 'Not authorized.';
         if (status === 404) return serverMessage || 'Not found.';
         if (status === 409) return serverMessage || 'Conflict — already exists.';
         if (status === 502 || status === 503) return 'Vipps unreachable. Try again in a moment.';

--- a/src/services/sensorService.ts
+++ b/src/services/sensorService.ts
@@ -1,5 +1,6 @@
 import axiosInstance from '@/services/axiosInstance';
 import { AxiosError } from 'axios';
+import { formatApiError } from '@/lib/errorMessages';
 
 export interface Sensor {
     id: number;
@@ -165,11 +166,7 @@ const SensorService = {
             const response = await axiosInstance.post<{ message: string }>('/sensors/claim', { registrationCode });
             return response.data;
         } catch (error: unknown) {
-            if (error instanceof AxiosError) {
-                throw new Error(error.response?.data.message || 'Failed to claim sensor');
-            } else {
-                throw new Error('An unknown error occurred');
-            }
+            throw new Error(formatApiError(error, 'Failed to claim sensor'));
         }
     },
 
@@ -191,11 +188,7 @@ const SensorService = {
             const response = await axiosInstance.delete<{ message: string }>(`/sensors/${id}/claim`);
             return response.data;
         } catch (error: unknown) {
-            if (error instanceof AxiosError) {
-                throw new Error(error.response?.data.message || 'Failed to remove sensor');
-            } else {
-                throw new Error('An unknown error occurred');
-            }
+            throw new Error(formatApiError(error, 'Failed to remove sensor'));
         }
     },
 

--- a/src/services/switchService.ts
+++ b/src/services/switchService.ts
@@ -1,5 +1,6 @@
 import axiosInstance from '@/services/axiosInstance';
 import { AxiosError } from 'axios';
+import { formatApiError } from '@/lib/errorMessages';
 
 export interface Switch {
     id: number;
@@ -146,11 +147,7 @@ const SwitchService = {
             const response = await axiosInstance.post<{ switchId: number; registrationCode: string }>('/switches/claim', { registrationCode });
             return response.data;
         } catch (error: unknown) {
-            if (error instanceof AxiosError) {
-                throw new Error(error.response?.data.message || 'Failed to claim switch');
-            } else {
-                throw new Error('An unknown error occurred');
-            }
+            throw new Error(formatApiError(error, 'Failed to claim switch'));
         }
     },
 
@@ -158,11 +155,7 @@ const SwitchService = {
         try {
             await axiosInstance.delete(`/switches/${switchId}/claim`);
         } catch (error: unknown) {
-            if (error instanceof AxiosError) {
-                throw new Error(error.response?.data.message || 'Failed to unclaim switch');
-            } else {
-                throw new Error('An unknown error occurred');
-            }
+            throw new Error(formatApiError(error, 'Failed to unclaim switch'));
         }
     }
 };

--- a/src/services/switchService.ts
+++ b/src/services/switchService.ts
@@ -55,7 +55,7 @@ const SwitchService = {
             return response.data;
         } catch (error: unknown) {
             if (error instanceof AxiosError) {
-                throw new Error(error.response?.data.message || 'Failed to fetch switches');
+                throw new Error(error.response?.data.message || 'Failed to fetch sockets');
             } else {
                 throw new Error('An unknown error occurred');
             }
@@ -70,7 +70,7 @@ const SwitchService = {
             return response.data;
         } catch (error: unknown) {
             if (error instanceof AxiosError) {
-                throw new Error(error.response?.data.message || 'Failed to fetch switch data');
+                throw new Error(error.response?.data.message || 'Failed to fetch socket data');
             } else {
                 throw new Error('An unknown error occurred');
             }
@@ -84,7 +84,7 @@ const SwitchService = {
             return response.data.value;
         } catch (error: unknown) {
             if (error instanceof AxiosError) {
-                throw new Error(error.response?.data.message || 'Failed to fetch switch state');
+                throw new Error(error.response?.data.message || 'Failed to fetch socket state');
             } else {
                 throw new Error('An unknown error occurred');
             }
@@ -120,8 +120,8 @@ const SwitchService = {
             return dataMap;
         } catch (error: unknown) {
             if (error instanceof AxiosError) {
-                console.error('API Error:', error.response?.data.message || 'Failed to fetch multiple switches data');
-                throw new Error(error.response?.data.message || 'Failed to fetch multiple switches data');
+                console.error('API Error:', error.response?.data.message || 'Failed to fetch multiple sockets data');
+                throw new Error(error.response?.data.message || 'Failed to fetch multiple sockets data');
             } else {
                 console.error('Unknown Error:', error);
                 throw new Error('An unknown error occurred');
@@ -135,7 +135,7 @@ const SwitchService = {
             return response.data;
         } catch (error: unknown) {
             if (error instanceof AxiosError) {
-                throw new Error(error.response?.data.message || 'Failed to update switch name');
+                throw new Error(error.response?.data.message || 'Failed to update socket name');
             } else {
                 throw new Error('An unknown error occurred');
             }
@@ -147,7 +147,7 @@ const SwitchService = {
             const response = await axiosInstance.post<{ switchId: number; registrationCode: string }>('/switches/claim', { registrationCode });
             return response.data;
         } catch (error: unknown) {
-            throw new Error(formatApiError(error, 'Failed to claim switch'));
+            throw new Error(formatApiError(error, 'Failed to claim socket'));
         }
     },
 
@@ -155,7 +155,7 @@ const SwitchService = {
         try {
             await axiosInstance.delete(`/switches/${switchId}/claim`);
         } catch (error: unknown) {
-            throw new Error(formatApiError(error, 'Failed to unclaim switch'));
+            throw new Error(formatApiError(error, 'Failed to unclaim socket'));
         }
     }
 };

--- a/src/tests/lib/errorMessages.test.ts
+++ b/src/tests/lib/errorMessages.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest'
+import { AxiosError, AxiosHeaders } from 'axios'
+import { formatApiError } from '@/lib/errorMessages'
+
+function axiosErrorWith(status: number, data: unknown): AxiosError {
+    const headers = new AxiosHeaders()
+    const err = new AxiosError('request failed', String(status))
+    err.response = {
+        status,
+        statusText: '',
+        headers,
+        config: { headers } as never,
+        data,
+    }
+    return err
+}
+
+describe('formatApiError', () => {
+    it('returns the fallback for a non-AxiosError', () => {
+        expect(formatApiError(new Error('boom'), 'fallback')).toBe('fallback')
+        expect(formatApiError(null, 'fallback')).toBe('fallback')
+        expect(formatApiError('string', 'fallback')).toBe('fallback')
+    })
+
+    it('returns the server message on 400', () => {
+        const err = axiosErrorWith(400, { message: 'Bad input.' })
+        expect(formatApiError(err, 'fallback')).toBe('Bad input.')
+    })
+
+    it('returns the fallback on 400 when the body has no message', () => {
+        const err = axiosErrorWith(400, {})
+        expect(formatApiError(err, 'fallback')).toBe('fallback')
+    })
+
+    it('returns the server message on 403 when present', () => {
+        const err = axiosErrorWith(403, {
+            message: 'You need an active subscription to claim more sensors or switches.',
+        })
+        expect(formatApiError(err, 'Failed to claim sensor')).toBe(
+            'You need an active subscription to claim more sensors or switches.',
+        )
+    })
+
+    it('returns "Not authorized." on 403 with no body', () => {
+        const err = axiosErrorWith(403, undefined)
+        expect(formatApiError(err, 'fallback')).toBe('Not authorized.')
+    })
+
+    it('returns the server message on 401 when present', () => {
+        const err = axiosErrorWith(401, { message: 'Token expired.' })
+        expect(formatApiError(err, 'fallback')).toBe('Token expired.')
+    })
+
+    it('returns "Not authorized." on 401 with no body', () => {
+        const err = axiosErrorWith(401, null)
+        expect(formatApiError(err, 'fallback')).toBe('Not authorized.')
+    })
+
+    it('returns the server message on 404 when present', () => {
+        const err = axiosErrorWith(404, { message: 'Sensor not found.' })
+        expect(formatApiError(err, 'fallback')).toBe('Sensor not found.')
+    })
+
+    it('returns "Not found." on 404 with no body', () => {
+        const err = axiosErrorWith(404, {})
+        expect(formatApiError(err, 'fallback')).toBe('Not found.')
+    })
+
+    it('returns the server message on 409 when present', () => {
+        const err = axiosErrorWith(409, { message: 'Already claimed.' })
+        expect(formatApiError(err, 'fallback')).toBe('Already claimed.')
+    })
+
+    it('returns the conflict fallback on 409 with no body', () => {
+        const err = axiosErrorWith(409, {})
+        expect(formatApiError(err, 'fallback')).toBe('Conflict — already exists.')
+    })
+
+    it('returns a Vipps-specific message on 502/503', () => {
+        expect(formatApiError(axiosErrorWith(502, {}), 'fallback')).toBe('Vipps unreachable. Try again in a moment.')
+        expect(formatApiError(axiosErrorWith(503, {}), 'fallback')).toBe('Vipps unreachable. Try again in a moment.')
+    })
+
+    it('returns a rate-limit message on 429', () => {
+        expect(formatApiError(axiosErrorWith(429, {}), 'fallback')).toBe('Too many requests. Wait a moment.')
+    })
+
+    it('falls back to a string body when the response body is a plain string', () => {
+        const err = axiosErrorWith(500, 'Something broke.')
+        expect(formatApiError(err, 'fallback')).toBe('Something broke.')
+    })
+
+    it('returns the fallback when status is unknown and no message is present', () => {
+        const err = axiosErrorWith(500, {})
+        expect(formatApiError(err, 'fallback')).toBe('fallback')
+    })
+})


### PR DESCRIPTION
## Summary
- `formatApiError` in `src/lib/errorMessages.ts` now prefers the server's `message` on 401/403 before falling back to "Not authorized." Existing fallback preserved when there is no body.
- `sensorService.claimSensor`, `sensorService.unclaimSensor`, `switchService.claimSwitch` and `switchService.unclaimSwitch` now route their AxiosError through `formatApiError` instead of pulling `data.message` directly. The existing call sites (`SetupWizard.tsx`, profile sensors page, profile sockets page) already surface `e.message`.
- New `src/tests/lib/errorMessages.test.ts` covers every status branch including the new 401/403 server-message preference. 15 new tests, 131/131 overall.