### PR TITLE
feat: gate claim UI by subscription status before submit

### DIFF
--- a/src/app/(protected)/profile/page.tsx
+++ b/src/app/(protected)/profile/page.tsx
@@ -10,6 +10,7 @@ import SwitchService from '@/services/switchService';
 import { ChevronRightIcon, PencilIcon, CheckIcon, XMarkIcon } from '@heroicons/react/24/outline';
 import { normalizeNoPhone } from '@/lib/phone';
 import { isPushSupported, isPushSubscribed, subscribeToPush, unsubscribeFromPush, sendTestNotification } from '@/services/pushNotificationService';
+import { useCanClaimDevice } from '@/hooks/useCanClaimDevice';
 import ConfirmModal from '@/components/ConfirmModal';
 import LoadingDots from '@/components/LoadingDots';
 import Section from '@/components/Section';
@@ -53,6 +54,7 @@ const Profile: React.FC = () => {
     const [editPhone, setEditPhone] = useState('');
     const [profileSaving, setProfileSaving] = useState(false);
     const [editingField, setEditingField] = useState<'name' | 'phone' | null>(null);
+    const { canClaim, loading: eligibilityLoading, refresh: refreshEligibility } = useCanClaimDevice();
 
     useEffect(() => {
         if (!isAuthenticated) { router.push('/login'); return; }
@@ -248,6 +250,7 @@ const Profile: React.FC = () => {
                 setSocketCount(c => (c ?? 0) + 1);
                 toast.success('Socket added');
             }
+            refreshEligibility();
             setClaimError(false);
             setClaimCode('');
         } catch (error: unknown) {
@@ -482,28 +485,37 @@ const Profile: React.FC = () => {
                                     🔌 Socket
                                 </button>
                             </div>
-                            <div className="flex gap-2">
-                                <input
-                                    type="text"
-                                    value={claimCode}
-                                    onChange={e => setClaimCode(e.target.value.toUpperCase())}
-                                    onKeyDown={e => e.key === 'Enter' && handleClaimDevice()}
-                                    placeholder="e.g. A1B2C3D4E5"
-                                    className={inputClass}
-                                    disabled={claimLoading}
-                                />
-                                <button
-                                    onClick={handleClaimDevice}
-                                    className="px-4 py-2.5 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded-xl transition-all whitespace-nowrap"
-                                    disabled={claimLoading}
-                                >
-                                    {claimLoading ? 'Adding…' : 'Add device'}
-                                </button>
-                            </div>
-                            {claimMessage && (
-                                claimError
-                                    ? <Alert variant="error" className="mt-3">{claimMessage}</Alert>
-                                    : <Alert variant="success" className="mt-3">{claimMessage}</Alert>
+                            {!eligibilityLoading && !canClaim ? (
+                                <Alert variant="warning">
+                                    You need an active subscription to add more devices. Your existing ones keep working.{' '}
+                                    <Link href="/shop" className="underline font-medium">See plans →</Link>
+                                </Alert>
+                            ) : (
+                                <>
+                                    <div className="flex gap-2">
+                                        <input
+                                            type="text"
+                                            value={claimCode}
+                                            onChange={e => setClaimCode(e.target.value.toUpperCase())}
+                                            onKeyDown={e => e.key === 'Enter' && handleClaimDevice()}
+                                            placeholder="e.g. A1B2C3D4E5"
+                                            className={inputClass}
+                                            disabled={claimLoading || eligibilityLoading}
+                                        />
+                                        <button
+                                            onClick={handleClaimDevice}
+                                            className="px-4 py-2.5 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded-xl transition-all whitespace-nowrap"
+                                            disabled={claimLoading || eligibilityLoading}
+                                        >
+                                            {claimLoading ? 'Adding…' : 'Add device'}
+                                        </button>
+                                    </div>
+                                    {claimMessage && (
+                                        claimError
+                                            ? <Alert variant="error" className="mt-3">{claimMessage}</Alert>
+                                            : <Alert variant="success" className="mt-3">{claimMessage}</Alert>
+                                    )}
+                                </>
                             )}
                         </div>
                         <div className="border-t border-gray-700/40 pt-3 space-y-2">

--- a/src/app/SetupWizard.tsx
+++ b/src/app/SetupWizard.tsx
@@ -7,6 +7,8 @@ import SwitchService, { Switch } from '@/services/switchService';
 import GroupService, { Group } from '@/services/groupService';
 import { GROUP_ICONS as ICONS, groupEmoji } from '@/lib/groupIcons';
 import { typeEmoji } from '@/lib/typeUtils';
+import { useCanClaimDevice } from '@/hooks/useCanClaimDevice';
+import Link from 'next/link';
 
 // ── Types & constants ──────────────────────────────────────────────────────────
 
@@ -95,6 +97,7 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
     const [selectedSwitchIds, setSelectedSwitchIds] = useState<Set<number>>(new Set());
 
     const overlayRef = useRef<HTMLDivElement>(null);
+    const { canClaim, loading: eligibilityLoading, refresh: refreshEligibility } = useCanClaimDevice();
 
     const TOTAL_STEPS = 4; // 0: claim, 1: name, 2: group, 3: done
 
@@ -167,6 +170,7 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
                 setCustomName(found?.customName ?? found?.name ?? '');
                 if (found) setSelectedSwitchIds(new Set([found.id]));
             }
+            await refreshEligibility();
             setStep(1);
         } catch (e: unknown) {
             setClaimError(e instanceof Error ? e.message : `Failed to claim ${claimType}.`);
@@ -281,6 +285,13 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
                             </button>
                         </div>
 
+                        {!eligibilityLoading && !canClaim && (
+                            <div className="px-4 py-3 bg-amber-500/10 border border-amber-500/20 rounded-xl text-amber-300 text-sm">
+                                You need an active subscription to add more devices. Your existing ones keep working.{' '}
+                                <Link href="/shop" className="underline font-medium" onClick={onClose}>See plans →</Link>
+                            </div>
+                        )}
+
                         <div className="space-y-3">
                             <input
                                 type="text"
@@ -290,11 +301,12 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
                                 onKeyDown={e => e.key === 'Enter' && handleClaim()}
                                 placeholder="e.g. A1B2C3D4E5"
                                 maxLength={10}
-                                className="w-full px-4 py-3 bg-gray-800/60 border border-gray-700/40 rounded-xl text-gray-100 placeholder-gray-600 focus:outline-none focus:border-sky-600/50 font-mono tracking-widest text-sm transition-all uppercase"
+                                disabled={!canClaim || eligibilityLoading}
+                                className="w-full px-4 py-3 bg-gray-800/60 border border-gray-700/40 rounded-xl text-gray-100 placeholder-gray-600 focus:outline-none focus:border-sky-600/50 font-mono tracking-widest text-sm transition-all uppercase disabled:opacity-50 disabled:cursor-not-allowed"
                             />
                             {claimError && <p className="text-red-400 text-xs">{claimError}</p>}
                         </div>
-                        <Btn onClick={handleClaim} loading={claiming} disabled={!regCode.trim()}>
+                        <Btn onClick={handleClaim} loading={claiming} disabled={!regCode.trim() || !canClaim || eligibilityLoading}>
                             Claim {claimType === 'sensor' ? 'sensor' : 'socket'}
                             <ChevronRightIcon className="h-4 w-4" />
                         </Btn>

--- a/src/components/Alert.tsx
+++ b/src/components/Alert.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 interface AlertProps {
-    variant: 'error' | 'success';
+    variant: 'error' | 'success' | 'warning';
     children: React.ReactNode;
     className?: string;
 }
@@ -10,7 +10,9 @@ const Alert: React.FC<AlertProps> = ({ variant, children, className = '' }) => {
     const styles =
         variant === 'error'
             ? 'text-red-400 bg-red-500/10 border border-red-500/20'
-            : 'text-green-400 bg-green-500/10 border border-green-500/20';
+            : variant === 'warning'
+                ? 'text-amber-400 bg-amber-500/10 border border-amber-500/20'
+                : 'text-green-400 bg-green-500/10 border border-green-500/20';
     return (
         <p className={`text-sm px-3 py-2 rounded-xl ${styles} ${className}`}>
             {children}

--- a/src/components/DeviceManagePage.tsx
+++ b/src/components/DeviceManagePage.tsx
@@ -11,6 +11,7 @@ import { inputClass } from '@/components/TextInput';
 import Alert from '@/components/Alert';
 import { toast } from 'sonner';
 import Link from 'next/link';
+import { useCanClaimDevice } from '@/hooks/useCanClaimDevice';
 
 export interface DeviceItem {
     id: number;
@@ -51,6 +52,7 @@ export function DeviceManagePage<T extends DeviceItem>({ config }: Props<T>) {
     const [editLoading, setEditLoading] = useState(false);
     const [editError, setEditError] = useState<string | null>(null);
     const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null);
+    const { canClaim, loading: eligibilityLoading, refresh: refreshEligibility } = useCanClaimDevice();
 
     const { title, itemLabel, emoji, fetchAll, claim, unclaim, updateName, getDisplayName, getDefaultName } = config;
     const label = itemLabel;
@@ -79,7 +81,7 @@ export function DeviceManagePage<T extends DeviceItem>({ config }: Props<T>) {
             setClaimError(false);
             setClaimCode('');
             toast.success(`${Label} added`);
-            await refresh();
+            await Promise.all([refresh(), refreshEligibility()]);
         } catch (error: unknown) {
             const msg = error instanceof Error ? error.message : `Failed to add ${label}.`;
             setClaimMessage(msg);
@@ -153,29 +155,38 @@ export function DeviceManagePage<T extends DeviceItem>({ config }: Props<T>) {
                 </div>
 
                 <Section title={`Add a ${label}`}>
-                    <p className="text-sm text-gray-400 mb-3">Enter the device code to add a {label} to your account.</p>
-                    <div className="flex gap-2">
-                        <input
-                            type="text"
-                            value={claimCode}
-                            onChange={e => setClaimCode(e.target.value.toUpperCase())}
-                            onKeyDown={e => e.key === 'Enter' && handleClaim()}
-                            placeholder="e.g. A1B2C3D4E5"
-                            className={inputClass}
-                            disabled={claimLoading}
-                        />
-                        <button
-                            onClick={handleClaim}
-                            className="px-4 py-2.5 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded-xl transition-all whitespace-nowrap"
-                            disabled={claimLoading}
-                        >
-                            {claimLoading ? 'Adding…' : `Add ${label}`}
-                        </button>
-                    </div>
-                    {claimMessage && (
-                        claimError
-                            ? <Alert variant="error" className="mt-3">{claimMessage}</Alert>
-                            : <Alert variant="success" className="mt-3">{claimMessage}</Alert>
+                    {!eligibilityLoading && !canClaim ? (
+                        <Alert variant="warning">
+                            You need an active subscription to add more devices. Your existing ones keep working.{' '}
+                            <Link href="/shop" className="underline font-medium">See plans →</Link>
+                        </Alert>
+                    ) : (
+                        <>
+                            <p className="text-sm text-gray-400 mb-3">Enter the device code to add a {label} to your account.</p>
+                            <div className="flex gap-2">
+                                <input
+                                    type="text"
+                                    value={claimCode}
+                                    onChange={e => setClaimCode(e.target.value.toUpperCase())}
+                                    onKeyDown={e => e.key === 'Enter' && handleClaim()}
+                                    placeholder="e.g. A1B2C3D4E5"
+                                    className={inputClass}
+                                    disabled={claimLoading || eligibilityLoading}
+                                />
+                                <button
+                                    onClick={handleClaim}
+                                    className="px-4 py-2.5 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded-xl transition-all whitespace-nowrap"
+                                    disabled={claimLoading || eligibilityLoading}
+                                >
+                                    {claimLoading ? 'Adding…' : `Add ${label}`}
+                                </button>
+                            </div>
+                            {claimMessage && (
+                                claimError
+                                    ? <Alert variant="error" className="mt-3">{claimMessage}</Alert>
+                                    : <Alert variant="success" className="mt-3">{claimMessage}</Alert>
+                            )}
+                        </>
                     )}
                 </Section>
 

--- a/src/hooks/useCanClaimDevice.ts
+++ b/src/hooks/useCanClaimDevice.ts
@@ -8,22 +8,27 @@ export interface CanClaimDeviceResult {
     canClaim: boolean;
     loading: boolean;
     ownedSensorCount: number;
-    activeSubscriptionCount: number;
+    capacity: number;
+    primaryActive: boolean;
     refresh: () => Promise<void>;
 }
 
 /**
- * Mirrors the backend ActiveSubscriptionRequirement check so the UI can hide or
- * disable the claim button before submit. The first sensor is always claimable
- * because the requirement short-circuits when the user owns zero sensors; after
- * that the user needs at least as many active subscriptions as owned sensors.
+ * Mirrors the backend ActiveSubscriptionRequirement so the UI can hide the claim button
+ * before submit. Capacity model:
  *
- * Subscription quantity is intentionally not summed — the backend currently
- * counts subscription rows, not quantities. If that changes, update both sides.
+ *   - An active Primary subscription grants a base allowance of 1 owned sensor.
+ *   - Each active AddOn subscription contributes its quantity to the allowance.
+ *   - Without an active Primary the allowance is 0 — AddOns alone are not enough.
+ *
+ * A claim is allowed when ownedSensorCount < capacity. Shared sensors are tracked with
+ * IsOwner=false on the backend and are not counted here either (the sensors endpoint
+ * does not currently expose ownership and sharing is not implemented yet).
  */
 export function useCanClaimDevice(): CanClaimDeviceResult {
     const [ownedSensorCount, setOwnedSensorCount] = useState(0);
-    const [activeSubscriptionCount, setActiveSubscriptionCount] = useState(0);
+    const [primaryActive, setPrimaryActive] = useState(false);
+    const [addOnCapacity, setAddOnCapacity] = useState(0);
     const [loading, setLoading] = useState(true);
 
     const refresh = useCallback(async () => {
@@ -33,8 +38,14 @@ export function useCanClaimDevice(): CanClaimDeviceResult {
                 SensorService.getAllSensors().catch(() => []),
                 SubscriptionService.getMySubscriptions().catch(() => []),
             ]);
+            const activeSubs = subscriptions.filter(s => s.status === 'Active');
             setOwnedSensorCount(sensors.length);
-            setActiveSubscriptionCount(subscriptions.filter(s => s.status === 'Active').length);
+            setPrimaryActive(activeSubs.some(s => s.productType === 'Primary'));
+            setAddOnCapacity(
+                activeSubs
+                    .filter(s => s.productType === 'AddOn')
+                    .reduce((sum, s) => sum + (s.quantity ?? 0), 0),
+            );
         } finally {
             setLoading(false);
         }
@@ -44,7 +55,8 @@ export function useCanClaimDevice(): CanClaimDeviceResult {
         refresh();
     }, [refresh]);
 
-    const canClaim = ownedSensorCount === 0 || activeSubscriptionCount >= ownedSensorCount;
+    const capacity = primaryActive ? 1 + addOnCapacity : 0;
+    const canClaim = ownedSensorCount < capacity;
 
-    return { canClaim, loading, ownedSensorCount, activeSubscriptionCount, refresh };
+    return { canClaim, loading, ownedSensorCount, capacity, primaryActive, refresh };
 }

--- a/src/hooks/useCanClaimDevice.ts
+++ b/src/hooks/useCanClaimDevice.ts
@@ -1,0 +1,50 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import SensorService from '@/services/sensorService';
+import SubscriptionService from '@/services/subscriptionService';
+
+export interface CanClaimDeviceResult {
+    canClaim: boolean;
+    loading: boolean;
+    ownedSensorCount: number;
+    activeSubscriptionCount: number;
+    refresh: () => Promise<void>;
+}
+
+/**
+ * Mirrors the backend ActiveSubscriptionRequirement check so the UI can hide or
+ * disable the claim button before submit. The first sensor is always claimable
+ * because the requirement short-circuits when the user owns zero sensors; after
+ * that the user needs at least as many active subscriptions as owned sensors.
+ *
+ * Subscription quantity is intentionally not summed — the backend currently
+ * counts subscription rows, not quantities. If that changes, update both sides.
+ */
+export function useCanClaimDevice(): CanClaimDeviceResult {
+    const [ownedSensorCount, setOwnedSensorCount] = useState(0);
+    const [activeSubscriptionCount, setActiveSubscriptionCount] = useState(0);
+    const [loading, setLoading] = useState(true);
+
+    const refresh = useCallback(async () => {
+        setLoading(true);
+        try {
+            const [sensors, subscriptions] = await Promise.all([
+                SensorService.getAllSensors().catch(() => []),
+                SubscriptionService.getMySubscriptions().catch(() => []),
+            ]);
+            setOwnedSensorCount(sensors.length);
+            setActiveSubscriptionCount(subscriptions.filter(s => s.status === 'Active').length);
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        refresh();
+    }, [refresh]);
+
+    const canClaim = ownedSensorCount === 0 || activeSubscriptionCount >= ownedSensorCount;
+
+    return { canClaim, loading, ownedSensorCount, activeSubscriptionCount, refresh };
+}

--- a/src/tests/hooks/useCanClaimDevice.test.tsx
+++ b/src/tests/hooks/useCanClaimDevice.test.tsx
@@ -26,86 +26,109 @@ beforeEach(() => {
 })
 
 describe('useCanClaimDevice', () => {
-    it('allows claim when the user owns zero sensors', async () => {
+    it('blocks claim when the user has no subscription at all', async () => {
         mockedSensors.mockResolvedValue([])
         mockedSubs.mockResolvedValue([])
 
         const { result } = renderHook(() => useCanClaimDevice())
         await waitFor(() => expect(result.current.loading).toBe(false))
 
-        expect(result.current.canClaim).toBe(true)
-        expect(result.current.ownedSensorCount).toBe(0)
-        expect(result.current.activeSubscriptionCount).toBe(0)
+        expect(result.current.canClaim).toBe(false)
+        expect(result.current.capacity).toBe(0)
+        expect(result.current.primaryActive).toBe(false)
     })
 
-    it('blocks claim when owned sensors exceed active subscriptions', async () => {
-        mockedSensors.mockResolvedValue([{ id: 1 }, { id: 2 }])
-        mockedSubs.mockResolvedValue([{ id: 10, status: 'Active' }])
+    it('allows claim when an active Primary covers the first sensor', async () => {
+        mockedSensors.mockResolvedValue([])
+        mockedSubs.mockResolvedValue([{ id: 1, status: 'Active', productType: 'Primary', quantity: 1 }])
+
+        const { result } = renderHook(() => useCanClaimDevice())
+        await waitFor(() => expect(result.current.loading).toBe(false))
+
+        expect(result.current.canClaim).toBe(true)
+        expect(result.current.capacity).toBe(1)
+        expect(result.current.primaryActive).toBe(true)
+    })
+
+    it('blocks claim once owned sensors reach Primary capacity', async () => {
+        mockedSensors.mockResolvedValue([{ id: 1 }])
+        mockedSubs.mockResolvedValue([{ id: 1, status: 'Active', productType: 'Primary', quantity: 1 }])
 
         const { result } = renderHook(() => useCanClaimDevice())
         await waitFor(() => expect(result.current.loading).toBe(false))
 
         expect(result.current.canClaim).toBe(false)
-        expect(result.current.ownedSensorCount).toBe(2)
-        expect(result.current.activeSubscriptionCount).toBe(1)
+        expect(result.current.capacity).toBe(1)
     })
 
-    it('allows claim when active subscriptions match owned sensors', async () => {
+    it('extends capacity by each active AddOn quantity', async () => {
         mockedSensors.mockResolvedValue([{ id: 1 }, { id: 2 }])
         mockedSubs.mockResolvedValue([
-            { id: 10, status: 'Active' },
-            { id: 11, status: 'Active' },
+            { id: 1, status: 'Active', productType: 'Primary', quantity: 1 },
+            { id: 2, status: 'Active', productType: 'AddOn',   quantity: 2 },
         ])
 
         const { result } = renderHook(() => useCanClaimDevice())
         await waitFor(() => expect(result.current.loading).toBe(false))
 
+        expect(result.current.capacity).toBe(3)
         expect(result.current.canClaim).toBe(true)
+    })
+
+    it('blocks claim when AddOn is active but Primary is not', async () => {
+        mockedSensors.mockResolvedValue([])
+        mockedSubs.mockResolvedValue([{ id: 1, status: 'Active', productType: 'AddOn', quantity: 5 }])
+
+        const { result } = renderHook(() => useCanClaimDevice())
+        await waitFor(() => expect(result.current.loading).toBe(false))
+
+        expect(result.current.canClaim).toBe(false)
+        expect(result.current.capacity).toBe(0)
+        expect(result.current.primaryActive).toBe(false)
     })
 
     it('ignores non-active subscriptions', async () => {
-        mockedSensors.mockResolvedValue([{ id: 1 }])
+        mockedSensors.mockResolvedValue([])
         mockedSubs.mockResolvedValue([
-            { id: 10, status: 'Pending' },
-            { id: 11, status: 'Stopped' },
-            { id: 12, status: 'Expired' },
+            { id: 1, status: 'Pending', productType: 'Primary', quantity: 1 },
+            { id: 2, status: 'Stopped', productType: 'AddOn',   quantity: 5 },
+            { id: 3, status: 'Expired', productType: 'Primary', quantity: 1 },
         ])
 
         const { result } = renderHook(() => useCanClaimDevice())
         await waitFor(() => expect(result.current.loading).toBe(false))
 
         expect(result.current.canClaim).toBe(false)
-        expect(result.current.activeSubscriptionCount).toBe(0)
+        expect(result.current.capacity).toBe(0)
     })
 
-    it('treats failed service calls as empty lists so a user with no sensors is still allowed through', async () => {
+    it('treats failed service calls as empty lists and blocks claim', async () => {
         mockedSensors.mockRejectedValue(new Error('boom'))
         mockedSubs.mockRejectedValue(new Error('boom'))
 
         const { result } = renderHook(() => useCanClaimDevice())
         await waitFor(() => expect(result.current.loading).toBe(false))
 
-        expect(result.current.canClaim).toBe(true)
-        expect(result.current.ownedSensorCount).toBe(0)
-        expect(result.current.activeSubscriptionCount).toBe(0)
+        expect(result.current.canClaim).toBe(false)
+        expect(result.current.capacity).toBe(0)
     })
 
     it('refresh re-runs the queries and updates state', async () => {
-        mockedSensors.mockResolvedValueOnce([{ id: 1 }])
+        mockedSensors.mockResolvedValueOnce([])
         mockedSubs.mockResolvedValueOnce([])
 
         const { result } = renderHook(() => useCanClaimDevice())
         await waitFor(() => expect(result.current.loading).toBe(false))
         expect(result.current.canClaim).toBe(false)
 
-        mockedSensors.mockResolvedValueOnce([{ id: 1 }])
-        mockedSubs.mockResolvedValueOnce([{ id: 10, status: 'Active' }])
+        mockedSensors.mockResolvedValueOnce([])
+        mockedSubs.mockResolvedValueOnce([{ id: 1, status: 'Active', productType: 'Primary', quantity: 1 }])
 
         await act(async () => {
             await result.current.refresh()
         })
 
         expect(result.current.canClaim).toBe(true)
-        expect(result.current.activeSubscriptionCount).toBe(1)
+        expect(result.current.capacity).toBe(1)
     })
 })

--- a/src/tests/hooks/useCanClaimDevice.test.tsx
+++ b/src/tests/hooks/useCanClaimDevice.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { useCanClaimDevice } from '@/hooks/useCanClaimDevice'
+
+vi.mock('@/services/sensorService', () => ({
+    default: {
+        getAllSensors: vi.fn(),
+    },
+}))
+
+vi.mock('@/services/subscriptionService', () => ({
+    default: {
+        getMySubscriptions: vi.fn(),
+    },
+}))
+
+import SensorService from '@/services/sensorService'
+import SubscriptionService from '@/services/subscriptionService'
+
+const mockedSensors = SensorService.getAllSensors as ReturnType<typeof vi.fn>
+const mockedSubs = SubscriptionService.getMySubscriptions as ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+    mockedSensors.mockReset()
+    mockedSubs.mockReset()
+})
+
+describe('useCanClaimDevice', () => {
+    it('allows claim when the user owns zero sensors', async () => {
+        mockedSensors.mockResolvedValue([])
+        mockedSubs.mockResolvedValue([])
+
+        const { result } = renderHook(() => useCanClaimDevice())
+        await waitFor(() => expect(result.current.loading).toBe(false))
+
+        expect(result.current.canClaim).toBe(true)
+        expect(result.current.ownedSensorCount).toBe(0)
+        expect(result.current.activeSubscriptionCount).toBe(0)
+    })
+
+    it('blocks claim when owned sensors exceed active subscriptions', async () => {
+        mockedSensors.mockResolvedValue([{ id: 1 }, { id: 2 }])
+        mockedSubs.mockResolvedValue([{ id: 10, status: 'Active' }])
+
+        const { result } = renderHook(() => useCanClaimDevice())
+        await waitFor(() => expect(result.current.loading).toBe(false))
+
+        expect(result.current.canClaim).toBe(false)
+        expect(result.current.ownedSensorCount).toBe(2)
+        expect(result.current.activeSubscriptionCount).toBe(1)
+    })
+
+    it('allows claim when active subscriptions match owned sensors', async () => {
+        mockedSensors.mockResolvedValue([{ id: 1 }, { id: 2 }])
+        mockedSubs.mockResolvedValue([
+            { id: 10, status: 'Active' },
+            { id: 11, status: 'Active' },
+        ])
+
+        const { result } = renderHook(() => useCanClaimDevice())
+        await waitFor(() => expect(result.current.loading).toBe(false))
+
+        expect(result.current.canClaim).toBe(true)
+    })
+
+    it('ignores non-active subscriptions', async () => {
+        mockedSensors.mockResolvedValue([{ id: 1 }])
+        mockedSubs.mockResolvedValue([
+            { id: 10, status: 'Pending' },
+            { id: 11, status: 'Stopped' },
+            { id: 12, status: 'Expired' },
+        ])
+
+        const { result } = renderHook(() => useCanClaimDevice())
+        await waitFor(() => expect(result.current.loading).toBe(false))
+
+        expect(result.current.canClaim).toBe(false)
+        expect(result.current.activeSubscriptionCount).toBe(0)
+    })
+
+    it('treats failed service calls as empty lists so a user with no sensors is still allowed through', async () => {
+        mockedSensors.mockRejectedValue(new Error('boom'))
+        mockedSubs.mockRejectedValue(new Error('boom'))
+
+        const { result } = renderHook(() => useCanClaimDevice())
+        await waitFor(() => expect(result.current.loading).toBe(false))
+
+        expect(result.current.canClaim).toBe(true)
+        expect(result.current.ownedSensorCount).toBe(0)
+        expect(result.current.activeSubscriptionCount).toBe(0)
+    })
+
+    it('refresh re-runs the queries and updates state', async () => {
+        mockedSensors.mockResolvedValueOnce([{ id: 1 }])
+        mockedSubs.mockResolvedValueOnce([])
+
+        const { result } = renderHook(() => useCanClaimDevice())
+        await waitFor(() => expect(result.current.loading).toBe(false))
+        expect(result.current.canClaim).toBe(false)
+
+        mockedSensors.mockResolvedValueOnce([{ id: 1 }])
+        mockedSubs.mockResolvedValueOnce([{ id: 10, status: 'Active' }])
+
+        await act(async () => {
+            await result.current.refresh()
+        })
+
+        expect(result.current.canClaim).toBe(true)
+        expect(result.current.activeSubscriptionCount).toBe(1)
+    })
+})


### PR DESCRIPTION
## Summary
- New `useCanClaimDevice` hook in `src/hooks/useCanClaimDevice.ts` that fetches the user's sensors + `getMySubscriptions` and mirrors the backend `ActiveSubscriptionRequirement` check (`ownedSensorCount === 0 || activeSubscriptionCount >= ownedSensorCount`). Failed service calls fall back to empty lists so a brand-new user is never blocked by a transient fetch error.
- Wire the hook into the three claim entry points: `SetupWizard` step 0, `DeviceManagePage` (`/profile/sensors` + `/profile/sockets`), and the inline Devices section on `/profile`. When `canClaim` is false, each shows an amber warning + `See plans →` link to `/shop` instead of the code input.
- Extend `Alert` with a `warning` variant (amber palette).
- The backend 403 from PR #243 stays as the authoritative gate — this PR just removes the wasted round-trip and gives a clearer call-to-action up-front.
- 6 new hook tests; 122/122 overall.