### PR TITLE
chore: finish formatApiError migration on remaining services

### DIFF
--- a/src/services/sensorActivityService.ts
+++ b/src/services/sensorActivityService.ts
@@ -1,5 +1,5 @@
 import axiosInstance from '@/services/axiosInstance';
-import { AxiosError } from 'axios';
+import { formatApiError } from '@/lib/errorMessages';
 
 export interface SensorActivity {
     id: number;
@@ -24,13 +24,6 @@ export interface CreateSensorActivityPayload {
 
 export type UpdateSensorActivityPayload = CreateSensorActivityPayload;
 
-const handleError = (error: unknown, fallback: string): never => {
-    if (error instanceof AxiosError) {
-        throw new Error(error.response?.data?.message || fallback);
-    }
-    throw new Error('An unknown error occurred');
-};
-
 const SensorActivityService = {
     async list(sensorId: number): Promise<SensorActivity[]> {
         try {
@@ -42,7 +35,7 @@ const SensorActivityService = {
             if (Array.isArray(data)) return data;
             return data?.$values ?? [];
         } catch (error: unknown) {
-            return handleError(error, 'Failed to fetch activities');
+            throw new Error(formatApiError(error, 'Failed to fetch activities'));
         }
     },
 
@@ -54,7 +47,7 @@ const SensorActivityService = {
             );
             return response.data;
         } catch (error: unknown) {
-            return handleError(error, 'Failed to create activity');
+            throw new Error(formatApiError(error, 'Failed to create activity'));
         }
     },
 
@@ -66,7 +59,7 @@ const SensorActivityService = {
             );
             return response.data;
         } catch (error: unknown) {
-            return handleError(error, 'Failed to update activity');
+            throw new Error(formatApiError(error, 'Failed to update activity'));
         }
     },
 
@@ -74,7 +67,7 @@ const SensorActivityService = {
         try {
             await axiosInstance.delete(`/sensors/${sensorId}/activities/${activityId}`);
         } catch (error: unknown) {
-            handleError(error, 'Failed to delete activity');
+            throw new Error(formatApiError(error, 'Failed to delete activity'));
         }
     },
 };

--- a/src/services/shopService.ts
+++ b/src/services/shopService.ts
@@ -1,4 +1,5 @@
 import axiosInstance from '@/services/axiosInstance';
+import { formatApiError } from '@/lib/errorMessages';
 
 export interface ShopItem {
     id: number;
@@ -65,65 +66,113 @@ export interface CheckoutResponse {
 
 const ShopService = {
     async getShopItems(): Promise<ShopItem[]> {
-        const res = await axiosInstance.get<ShopItem[]>('/shop/items');
-        return res.data;
+        try {
+            const res = await axiosInstance.get<ShopItem[]>('/shop/items');
+            return res.data;
+        } catch (error: unknown) {
+            throw new Error(formatApiError(error, 'Failed to fetch shop items'));
+        }
     },
 
     async getShopItem(id: number): Promise<ShopItem> {
-        const res = await axiosInstance.get<ShopItem>(`/shop/items/${id}`);
-        return res.data;
+        try {
+            const res = await axiosInstance.get<ShopItem>(`/shop/items/${id}`);
+            return res.data;
+        } catch (error: unknown) {
+            throw new Error(formatApiError(error, 'Failed to fetch shop item'));
+        }
     },
 
     async createShopItem(payload: CreateShopItemPayload): Promise<ShopItem> {
-        const res = await axiosInstance.post<ShopItem>('/shop/items', payload);
-        return res.data;
+        try {
+            const res = await axiosInstance.post<ShopItem>('/shop/items', payload);
+            return res.data;
+        } catch (error: unknown) {
+            throw new Error(formatApiError(error, 'Failed to create shop item'));
+        }
     },
 
     async updateShopItem(id: number, payload: UpdateShopItemPayload): Promise<void> {
-        await axiosInstance.put(`/shop/items/${id}`, payload);
+        try {
+            await axiosInstance.put(`/shop/items/${id}`, payload);
+        } catch (error: unknown) {
+            throw new Error(formatApiError(error, 'Failed to update shop item'));
+        }
     },
 
     async deleteShopItem(id: number): Promise<void> {
-        await axiosInstance.delete(`/shop/items/${id}`);
+        try {
+            await axiosInstance.delete(`/shop/items/${id}`);
+        } catch (error: unknown) {
+            throw new Error(formatApiError(error, 'Failed to delete shop item'));
+        }
     },
 
     async checkout(payload: CheckoutPayload): Promise<CheckoutResponse> {
-        const res = await axiosInstance.post<CheckoutResponse>('/shop/checkout', payload);
-        return res.data;
+        try {
+            const res = await axiosInstance.post<CheckoutResponse>('/shop/checkout', payload);
+            return res.data;
+        } catch (error: unknown) {
+            throw new Error(formatApiError(error, 'Failed to initiate checkout'));
+        }
     },
 
     async getMyOrders(): Promise<Order[]> {
-        const res = await axiosInstance.get<Order[]>('/shop/orders/my');
-        return res.data;
+        try {
+            const res = await axiosInstance.get<Order[]>('/shop/orders/my');
+            return res.data;
+        } catch (error: unknown) {
+            throw new Error(formatApiError(error, 'Failed to fetch orders'));
+        }
     },
 
     async getAllOrders(): Promise<AdminOrder[]> {
-        const res = await axiosInstance.get<AdminOrder[]>('/shop/orders');
-        return res.data;
+        try {
+            const res = await axiosInstance.get<AdminOrder[]>('/shop/orders');
+            return res.data;
+        } catch (error: unknown) {
+            throw new Error(formatApiError(error, 'Failed to fetch orders'));
+        }
     },
 
     async captureOrder(id: number): Promise<void> {
-        await axiosInstance.post(`/shop/orders/${id}/capture`);
+        try {
+            await axiosInstance.post(`/shop/orders/${id}/capture`);
+        } catch (error: unknown) {
+            throw new Error(formatApiError(error, 'Failed to capture order'));
+        }
     },
 
     async cancelOrder(id: number): Promise<void> {
-        await axiosInstance.post(`/shop/orders/${id}/cancel`);
+        try {
+            await axiosInstance.post(`/shop/orders/${id}/cancel`);
+        } catch (error: unknown) {
+            throw new Error(formatApiError(error, 'Failed to cancel order'));
+        }
     },
 
     async refundOrder(id: number): Promise<void> {
-        await axiosInstance.post(`/shop/orders/${id}/refund`);
+        try {
+            await axiosInstance.post(`/shop/orders/${id}/refund`);
+        } catch (error: unknown) {
+            throw new Error(formatApiError(error, 'Failed to refund order'));
+        }
     },
 
     async downloadInvoice(orderId: number): Promise<void> {
-        const res = await axiosInstance.get(`/shop/orders/${orderId}/invoice`, { responseType: 'blob' });
-        const url = URL.createObjectURL(res.data as Blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = `invoice-order-${orderId}.pdf`;
-        document.body.appendChild(a);
-        a.click();
-        a.remove();
-        URL.revokeObjectURL(url);
+        try {
+            const res = await axiosInstance.get(`/shop/orders/${orderId}/invoice`, { responseType: 'blob' });
+            const url = URL.createObjectURL(res.data as Blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = `invoice-order-${orderId}.pdf`;
+            document.body.appendChild(a);
+            a.click();
+            a.remove();
+            URL.revokeObjectURL(url);
+        } catch (error: unknown) {
+            throw new Error(formatApiError(error, 'Failed to download invoice'));
+        }
     },
 };
 

--- a/src/services/subscriptionService.ts
+++ b/src/services/subscriptionService.ts
@@ -1,4 +1,5 @@
 import axiosInstance from '@/services/axiosInstance';
+import { formatApiError } from '@/lib/errorMessages';
 
 export type SubscriptionStatus = 'Pending' | 'Active' | 'Stopped' | 'Expired';
 export type SubscriptionProductType = 'Primary' | 'AddOn';
@@ -62,52 +63,84 @@ export interface SubscriptionInvoice {
 
 const SubscriptionService = {
     async getMySubscriptions(): Promise<Subscription[]> {
-        const res = await axiosInstance.get<Subscription[]>('/subscriptions/my');
-        return res.data;
+        try {
+            const res = await axiosInstance.get<Subscription[]>('/subscriptions/my');
+            return res.data;
+        } catch (error: unknown) {
+            throw new Error(formatApiError(error, 'Failed to fetch subscriptions'));
+        }
     },
 
     async getAllSubscriptions(): Promise<AdminSubscription[]> {
-        const res = await axiosInstance.get<AdminSubscription[]>('/subscriptions/all');
-        return res.data;
+        try {
+            const res = await axiosInstance.get<AdminSubscription[]>('/subscriptions/all');
+            return res.data;
+        } catch (error: unknown) {
+            throw new Error(formatApiError(error, 'Failed to fetch subscriptions'));
+        }
     },
 
     async getSubscriptionInvoices(subscriptionId: number): Promise<SubscriptionInvoice[]> {
-        const res = await axiosInstance.get<SubscriptionInvoice[]>(`/subscriptions/${subscriptionId}/invoices`);
-        return res.data;
+        try {
+            const res = await axiosInstance.get<SubscriptionInvoice[]>(`/subscriptions/${subscriptionId}/invoices`);
+            return res.data;
+        } catch (error: unknown) {
+            throw new Error(formatApiError(error, 'Failed to fetch invoices'));
+        }
     },
 
     async downloadSubscriptionInvoice(invoiceId: number): Promise<void> {
-        const res = await axiosInstance.get(`/subscriptions/invoices/${invoiceId}/pdf`, { responseType: 'blob' });
-        const url = URL.createObjectURL(res.data as Blob);
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = `invoice-${invoiceId.toString().padStart(4, '0')}.pdf`;
-        document.body.appendChild(a);
-        a.click();
-        a.remove();
-        URL.revokeObjectURL(url);
+        try {
+            const res = await axiosInstance.get(`/subscriptions/invoices/${invoiceId}/pdf`, { responseType: 'blob' });
+            const url = URL.createObjectURL(res.data as Blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = `invoice-${invoiceId.toString().padStart(4, '0')}.pdf`;
+            document.body.appendChild(a);
+            a.click();
+            a.remove();
+            URL.revokeObjectURL(url);
+        } catch (error: unknown) {
+            throw new Error(formatApiError(error, 'Failed to download invoice'));
+        }
     },
 
     async initiateSubscription(payload: InitiateSubscriptionPayload): Promise<InitiateSubscriptionResponse> {
-        const res = await axiosInstance.post<InitiateSubscriptionResponse>('/subscriptions/initiate', payload);
-        return res.data;
+        try {
+            const res = await axiosInstance.post<InitiateSubscriptionResponse>('/subscriptions/initiate', payload);
+            return res.data;
+        } catch (error: unknown) {
+            throw new Error(formatApiError(error, 'Failed to initiate subscription'));
+        }
     },
 
     async cancelSubscription(id: number): Promise<void> {
-        await axiosInstance.post(`/subscriptions/cancel/${id}`);
+        try {
+            await axiosInstance.post(`/subscriptions/cancel/${id}`);
+        } catch (error: unknown) {
+            throw new Error(formatApiError(error, 'Failed to cancel subscription'));
+        }
     },
 
     async updateSubscriptionQuantity(id: number, quantity: number): Promise<{ subscription: Subscription; message: string }> {
-        const res = await axiosInstance.patch<{ subscription: Subscription; message: string }>(
-            `/subscriptions/${id}/quantity`,
-            { quantity }
-        );
-        return res.data;
+        try {
+            const res = await axiosInstance.patch<{ subscription: Subscription; message: string }>(
+                `/subscriptions/${id}/quantity`,
+                { quantity }
+            );
+            return res.data;
+        } catch (error: unknown) {
+            throw new Error(formatApiError(error, 'Failed to update subscription quantity'));
+        }
     },
 
     async getConfirmationUrl(id: number): Promise<string> {
-        const res = await axiosInstance.get<{ vippsConfirmationUrl: string }>(`/subscriptions/${id}/confirmation-url`);
-        return res.data.vippsConfirmationUrl;
+        try {
+            const res = await axiosInstance.get<{ vippsConfirmationUrl: string }>(`/subscriptions/${id}/confirmation-url`);
+            return res.data.vippsConfirmationUrl;
+        } catch (error: unknown) {
+            throw new Error(formatApiError(error, 'Failed to fetch confirmation URL'));
+        }
     },
 };
 


### PR DESCRIPTION
Closes #316.

## Summary
- `shopService.ts` had no error handling at all; wrap every call in try/catch + `formatApiError`.
- `subscriptionService.ts` same shape; same treatment.
- `sensorActivityService.ts` had a local `handleError` helper that lost 401/403 server messages and the Vipps/rate-limit branches. Replace with direct `formatApiError` calls; drop the helper.
- Verified: zero `error.response?.data.message` and zero `if (error instanceof AxiosError)` hits in `src/services/**` except the intentional `userService.register` branch that runs `parseValidationErrors` ahead of `formatApiError` for field-level ASP.NET errors.
- 140/140 tests pass, build clean.