### PR TITLE
fix: resolve subscription on billing return by id

### DIFF
--- a/src/app/(protected)/profile/billing/return/page.tsx
+++ b/src/app/(protected)/profile/billing/return/page.tsx
@@ -1,15 +1,25 @@
 'use client';
 
+import { useSearchParams } from 'next/navigation';
 import LoadingDots from '@/components/LoadingDots';
 import ReturnStatusPage from '@/components/ReturnStatusPage';
 import SubscriptionService, { Subscription } from '@/services/subscriptionService';
 import { usePollUntilFinal } from '@/lib/usePollUntilFinal';
 
 export default function BillingReturnPage() {
+    const searchParams = useSearchParams();
+    const subscriptionId = searchParams.get('subscriptionId');
+    const parsedId = subscriptionId ? parseInt(subscriptionId, 10) : NaN;
+
     const { data: subscription, loading, refresh } = usePollUntilFinal<Subscription | null>(
         async () => {
             const subs = await SubscriptionService.getMySubscriptions();
-            return subs.at(-1) ?? null;
+            if (!isNaN(parsedId)) {
+                return subs.find(s => s.id === parsedId) ?? null;
+            }
+            // No id in the return URL: fall back to the newest subscription
+            // (list is JWT-scoped, so only the current user's subs are visible).
+            return subs.length ? subs.reduce((a, b) => (b.id > a.id ? b : a)) : null;
         },
         (s) => s != null && s.status !== 'Pending',
     );

--- a/tests/e2e/return-pages.spec.ts
+++ b/tests/e2e/return-pages.spec.ts
@@ -18,6 +18,7 @@ const pendingSub = {
     isTest: false, startDate: null, nextChargeDate: null,
 }
 const activeSub = { ...pendingSub, id: 302, status: 'Active' }
+const stoppedSub = { ...pendingSub, id: 303, status: 'Stopped' }
 
 async function setupShopReturn(page: Page, orders: unknown[], orderId: number) {
     await mockSession(page, regularUser)
@@ -25,10 +26,11 @@ async function setupShopReturn(page: Page, orders: unknown[], orderId: number) {
     await page.goto(`/shop/return?orderId=${orderId}`)
 }
 
-async function setupBillingReturn(page: Page, subs: unknown[]) {
+async function setupBillingReturn(page: Page, subs: unknown[], subscriptionId?: number) {
     await mockSession(page, regularUser)
     await mockApi(page, '/subscriptions/my', subs)
-    await page.goto('/profile/billing/return')
+    const query = subscriptionId != null ? `?subscriptionId=${subscriptionId}` : ''
+    await page.goto(`/profile/billing/return${query}`)
 }
 
 test.describe('Shop return page', () => {
@@ -74,5 +76,18 @@ test.describe('Billing return page', () => {
     test('No sub returns failure state', async ({ page }) => {
         await setupBillingReturn(page, [])
         await expect(page.getByText(/subscription not found/i)).toBeVisible({ timeout: 45_000 })
+    })
+
+    test('picks the sub named in subscriptionId, not the last in the list', async ({ page }) => {
+        // Active sub bought now (302) sits before a later Stopped one (303);
+        // the param must win over array position.
+        await setupBillingReturn(page, [activeSub, stoppedSub], 302)
+        await expect(page.getByText(/subscription active/i)).toBeVisible()
+    })
+
+    test('without param falls back to newest sub by id', async ({ page }) => {
+        // Newest is the Active 302; an older Stopped 301 must not be picked.
+        await setupBillingReturn(page, [{ ...stoppedSub, id: 301 }, activeSub])
+        await expect(page.getByText(/subscription active/i)).toBeVisible()
     })
 })


### PR DESCRIPTION
## Summary

Billing return page picked `subs.at(-1)`, grabbing an arbitrary subscription when a user owns more than one. The wrong row could be non-Active, showing "Subscription not found" even though the newly bought subscription was active.

- Read the `subscriptionId` query param and find the exact subscription (mirrors the shop return `orderId` pattern).
- Fall back to the newest subscription by id when no param is present (list is JWT-scoped, so only the current user's subscriptions are visible).
- Added e2e tests: param beats array position; fallback picks newest by id.

Pairs with garge-api PR that appends `?subscriptionId=` to the subscription return URL.