### PR TITLE
feat: data-retention opt-out toggle + cancel/downgrade retention notice

### DIFF
--- a/src/app/(protected)/profile/billing/page.tsx
+++ b/src/app/(protected)/profile/billing/page.tsx
@@ -276,6 +276,9 @@ export default function BillingPage() {
                                     Cancelling Primary also cancels any active add-on subscriptions.
                                 </p>
                             )}
+                            <p className="mt-2 text-xs text-amber-400">
+                                After {deriveCancelEndDate(cancelTarget)}, sensors above your plan are turned off. We keep their data for 6 months so re-subscribing restores your full history; after that it&apos;s deleted or anonymized. You can export or remove any sensor anytime.
+                            </p>
                         </>
                     }
                     confirmLabel="Cancel subscription"

--- a/src/app/(protected)/profile/billing/page.tsx
+++ b/src/app/(protected)/profile/billing/page.tsx
@@ -277,7 +277,10 @@ export default function BillingPage() {
                                 </p>
                             )}
                             <p className="mt-2 text-xs text-amber-400">
-                                After {deriveCancelEndDate(cancelTarget)}, sensors above your plan are turned off. We keep their data for 6 months so re-subscribing restores your full history; after that it&apos;s deleted or anonymized. You can export or remove any sensor anytime.
+                                After {deriveCancelEndDate(cancelTarget)}, sensors above your plan are turned off.
+                            </p>
+                            <p className="mt-2 text-xs text-gray-400">
+                                Your history is kept for as long as you own the device, so if you come back — even after a seasonal break — you can pick up where you left off and compare year over year. You can turn this off in <Link href="/profile" className="text-sky-400 hover:text-sky-300">your profile</Link>, and you can export or remove any sensor anytime.
                             </p>
                         </>
                     }

--- a/src/app/(protected)/profile/page.tsx
+++ b/src/app/(protected)/profile/page.tsx
@@ -14,6 +14,7 @@ import { useCanClaimDevice } from '@/hooks/useCanClaimDevice';
 import ConfirmModal from '@/components/ConfirmModal';
 import LoadingDots from '@/components/LoadingDots';
 import Section from '@/components/Section';
+import ToggleSwitch from '@/components/ToggleSwitch';
 import { inputClass } from '@/components/TextInput';
 import Alert from '@/components/Alert';
 import { toast } from 'sonner';
@@ -618,14 +619,12 @@ const Profile: React.FC = () => {
                                     <p className="text-sm text-gray-100 font-medium">Offline alerts on this device</p>
                                     <p className="text-xs text-gray-500 mt-0.5">Receive a push notification here when a sensor stops reporting. Toggle is per-device — enable on each browser or installed app where you want alerts.</p>
                                 </div>
-                                <button
-                                    onClick={handleTogglePush}
+                                <ToggleSwitch
+                                    checked={pushEnabled}
+                                    onChange={handleTogglePush}
                                     disabled={pushLoading || profileLoading}
-                                    aria-label={pushEnabled ? 'Disable offline alerts on this device' : 'Enable offline alerts on this device'}
-                                    className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors disabled:opacity-50 ${pushEnabled ? 'bg-sky-600' : 'bg-gray-700'}`}
-                                >
-                                    <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${pushEnabled ? 'translate-x-6' : 'translate-x-1'}`} />
-                                </button>
+                                    ariaLabel={pushEnabled ? 'Disable offline alerts on this device' : 'Enable offline alerts on this device'}
+                                />
                             </div>
                             {pushEnabled && (
                                 <div className="flex items-center justify-between gap-4">
@@ -688,14 +687,12 @@ const Profile: React.FC = () => {
                                 <p className="text-sm text-gray-100 font-medium">Keep my history after my subscription ends</p>
                                 <p className="text-xs text-gray-500 mt-0.5">On (default): we keep your sensor history for as long as you own the device, so you can resume and compare year over year when you return. Off: once your subscription lapses, suspended devices are removed and their data deleted or anonymized after 6 months.</p>
                             </div>
-                            <button
-                                onClick={handleToggleRetention}
+                            <ToggleSwitch
+                                checked={retentionKeep}
+                                onChange={handleToggleRetention}
                                 disabled={retentionLoading || profileLoading || !user?.id}
-                                aria-label={retentionKeep ? 'Stop keeping history after subscription ends' : 'Keep history after subscription ends'}
-                                className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors disabled:opacity-50 ${retentionKeep ? 'bg-sky-600' : 'bg-gray-700'}`}
-                            >
-                                <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${retentionKeep ? 'translate-x-6' : 'translate-x-1'}`} />
-                            </button>
+                                ariaLabel={retentionKeep ? 'Stop keeping history after subscription ends' : 'Keep history after subscription ends'}
+                            />
                         </div>
                         <div className="border-t border-gray-700/40 pt-4 flex items-center justify-between gap-4">
                             <div className="min-w-0 flex-1">

--- a/src/app/(protected)/profile/page.tsx
+++ b/src/app/(protected)/profile/page.tsx
@@ -43,6 +43,8 @@ const Profile: React.FC = () => {
     const [showDeleteAccount, setShowDeleteAccount] = useState(false);
     const [deleteAccountLoading, setDeleteAccountLoading] = useState(false);
     const [exportLoading, setExportLoading] = useState(false);
+    const [retentionKeep, setRetentionKeep] = useState(true);
+    const [retentionLoading, setRetentionLoading] = useState(false);
     const [pushEnabled, setPushEnabled] = useState(false);
     const [pushLoading, setPushLoading] = useState(false);
     const [pushPermission, setPushPermission] = useState<NotificationPermission>('default');
@@ -62,6 +64,7 @@ const Profile: React.FC = () => {
             setUser(u);
             setPriceZone(u.priceZone ?? 'NO2');
             setOfflineThreshold(u.offlineAlertThresholdHours > 0 ? u.offlineAlertThresholdHours : 4);
+            if (u.id) UserService.getDataRetention(u.id).then(r => setRetentionKeep(!r.optOut)).catch(() => { });
         }).catch(console.error).finally(() => setProfileLoading(false));
         if (isPushSupported()) {
             setPushPermission(Notification.permission);
@@ -273,6 +276,23 @@ const Profile: React.FC = () => {
             toast.error('Failed to delete account. Please try again.');
             setDeleteAccountLoading(false);
             setShowDeleteAccount(false);
+        }
+    };
+
+    const handleToggleRetention = async () => {
+        if (!user?.id || retentionLoading) return;
+        const nextKeep = !retentionKeep;
+        setRetentionLoading(true);
+        try {
+            await UserService.updateDataRetention(user.id, !nextKeep); // store opt-out = !keep
+            setRetentionKeep(nextKeep);
+            toast.success(nextKeep
+                ? 'We\'ll keep your sensor history'
+                : 'History will be deleted 6 months after your subscription ends');
+        } catch (e: unknown) {
+            toast.error(e instanceof Error ? e.message : 'Failed to update retention preference');
+        } finally {
+            setRetentionLoading(false);
         }
     };
 
@@ -661,6 +681,20 @@ const Profile: React.FC = () => {
                                 className="px-4 py-2 bg-gray-700 hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium rounded-xl transition-all whitespace-nowrap flex-shrink-0"
                             >
                                 {exportLoading ? 'Exporting…' : 'Download'}
+                            </button>
+                        </div>
+                        <div className="border-t border-gray-700/40 pt-4 flex items-center justify-between gap-4">
+                            <div className="min-w-0 flex-1">
+                                <p className="text-sm text-gray-100 font-medium">Keep my history after my subscription ends</p>
+                                <p className="text-xs text-gray-500 mt-0.5">On (default): we keep your sensor history for as long as you own the device, so you can resume and compare year over year when you return. Off: once your subscription lapses, suspended devices are removed and their data deleted or anonymized after 6 months.</p>
+                            </div>
+                            <button
+                                onClick={handleToggleRetention}
+                                disabled={retentionLoading || profileLoading || !user?.id}
+                                aria-label={retentionKeep ? 'Stop keeping history after subscription ends' : 'Keep history after subscription ends'}
+                                className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors disabled:opacity-50 ${retentionKeep ? 'bg-sky-600' : 'bg-gray-700'}`}
+                            >
+                                <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${retentionKeep ? 'translate-x-6' : 'translate-x-1'}`} />
                             </button>
                         </div>
                         <div className="border-t border-gray-700/40 pt-4 flex items-center justify-between gap-4">

--- a/src/components/QuantityChangeModal.tsx
+++ b/src/components/QuantityChangeModal.tsx
@@ -82,8 +82,8 @@ export default function QuantityChangeModal({
                         Increasing quantity raises the agreement ceiling. Confirm the change in your Vipps app before the next charge.
                     </p>
                 ) : qty < subscription.quantity ? (
-                    <p className="text-[11px] text-gray-500">
-                        Decreasing quantity takes effect on the next charge. No Vipps action required.
+                    <p className="text-[11px] text-amber-400">
+                        Decreasing quantity takes effect on the next charge. No Vipps action required. Sensors above your new plan are then turned off — their data is kept for 6 months so re-subscribing restores it, after which it&apos;s deleted or anonymized. You can export or remove any sensor anytime.
                     </p>
                 ) : null}
 

--- a/src/components/QuantityChangeModal.tsx
+++ b/src/components/QuantityChangeModal.tsx
@@ -83,7 +83,7 @@ export default function QuantityChangeModal({
                     </p>
                 ) : qty < subscription.quantity ? (
                     <p className="text-[11px] text-amber-400">
-                        Decreasing quantity takes effect on the next charge. No Vipps action required. Sensors above your new plan are then turned off — their data is kept for 6 months so re-subscribing restores it, after which it&apos;s deleted or anonymized. You can export or remove any sensor anytime.
+                        Decreasing quantity takes effect on the next charge. No Vipps action required. Sensors above your new plan are then turned off — but their history is kept for as long as you own them, so re-subscribing restores it (and you keep year-over-year data). You can turn retention off in your profile, and export or remove any sensor anytime.
                     </p>
                 ) : null}
 

--- a/src/components/ToggleSwitch.tsx
+++ b/src/components/ToggleSwitch.tsx
@@ -1,0 +1,29 @@
+interface ToggleSwitchProps {
+    /** Current on/off state. */
+    checked: boolean;
+    /** Called when the user flips the switch. */
+    onChange: () => void;
+    disabled?: boolean;
+    /** Required for screen readers — describe what the switch controls. */
+    ariaLabel: string;
+}
+
+/**
+ * A small on/off pill switch. Use for boolean settings (e.g. notifications,
+ * data-retention) so the markup and accessibility semantics stay consistent.
+ */
+export default function ToggleSwitch({ checked, onChange, disabled = false, ariaLabel }: ToggleSwitchProps) {
+    return (
+        <button
+            type="button"
+            role="switch"
+            aria-checked={checked}
+            aria-label={ariaLabel}
+            onClick={onChange}
+            disabled={disabled}
+            className={`relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors disabled:opacity-50 ${checked ? 'bg-sky-600' : 'bg-gray-700'}`}
+        >
+            <span className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${checked ? 'translate-x-6' : 'translate-x-1'}`} />
+        </button>
+    );
+}

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -20,6 +20,11 @@ interface LoginData {
     password: string;
 }
 
+export interface DataRetention {
+    optOut: boolean;
+    optedOutAt: string | null;
+}
+
 const registerSchema = z.object({
     firstName: z
         .string()
@@ -191,6 +196,24 @@ const UserService = {
             return response.data;
         } catch (error: unknown) {
             throw new Error(formatApiError(error, 'Failed to export data'));
+        }
+    },
+
+    async getDataRetention(userId: string): Promise<DataRetention> {
+        try {
+            const response = await axiosInstance.get<DataRetention>(`/users/${userId}/data-retention`);
+            return response.data;
+        } catch (error: unknown) {
+            throw new Error(formatApiError(error, 'Failed to load retention preference'));
+        }
+    },
+
+    async updateDataRetention(userId: string, optOut: boolean): Promise<DataRetention> {
+        try {
+            const response = await axiosInstance.put<DataRetention>(`/users/${userId}/data-retention`, { optOut });
+            return response.data;
+        } catch (error: unknown) {
+            throw new Error(formatApiError(error, 'Failed to update retention preference'));
         }
     },
 };

--- a/src/tests/components/ToggleSwitch.test.tsx
+++ b/src/tests/components/ToggleSwitch.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import ToggleSwitch from '@/components/ToggleSwitch'
+
+describe('ToggleSwitch', () => {
+    it('exposes switch role with aria-checked reflecting state', () => {
+        render(<ToggleSwitch checked onChange={() => { }} ariaLabel="Keep history" />)
+        const sw = screen.getByRole('switch', { name: 'Keep history' })
+        expect(sw).toHaveAttribute('aria-checked', 'true')
+    })
+
+    it('reports unchecked state', () => {
+        render(<ToggleSwitch checked={false} onChange={() => { }} ariaLabel="Keep history" />)
+        expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'false')
+    })
+
+    it('calls onChange when clicked', () => {
+        const onChange = vi.fn()
+        render(<ToggleSwitch checked={false} onChange={onChange} ariaLabel="Keep history" />)
+        fireEvent.click(screen.getByRole('switch'))
+        expect(onChange).toHaveBeenCalledOnce()
+    })
+
+    it('does not call onChange when disabled', () => {
+        const onChange = vi.fn()
+        render(<ToggleSwitch checked={false} onChange={onChange} disabled ariaLabel="Keep history" />)
+        const sw = screen.getByRole('switch')
+        expect(sw).toBeDisabled()
+        fireEvent.click(sw)
+        expect(onChange).not.toHaveBeenCalled()
+    })
+})

--- a/src/tests/services/userService.test.ts
+++ b/src/tests/services/userService.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('@/services/axiosInstance', () => ({
+    default: {
+        get: vi.fn(),
+        post: vi.fn(),
+        put: vi.fn(),
+        delete: vi.fn(),
+    },
+}))
+vi.mock('next-auth/react', () => ({ getSession: vi.fn() }))
+
+import UserService from '@/services/userService'
+import axiosInstance from '@/services/axiosInstance'
+
+const mockGet = axiosInstance.get as ReturnType<typeof vi.fn>
+const mockPut = axiosInstance.put as ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+    vi.clearAllMocks()
+})
+
+describe('UserService.getDataRetention', () => {
+    it('GETs the data-retention endpoint and returns the preference', async () => {
+        mockGet.mockResolvedValueOnce({ data: { optOut: true, optedOutAt: '2026-01-01T00:00:00Z' } })
+        const result = await UserService.getDataRetention('u1')
+        expect(mockGet).toHaveBeenCalledWith('/users/u1/data-retention')
+        expect(result).toEqual({ optOut: true, optedOutAt: '2026-01-01T00:00:00Z' })
+    })
+})
+
+describe('UserService.updateDataRetention', () => {
+    it('PUTs optOut=true to opt out of retention', async () => {
+        mockPut.mockResolvedValueOnce({ data: { optOut: true, optedOutAt: '2026-05-21T00:00:00Z' } })
+        const result = await UserService.updateDataRetention('u1', true)
+        expect(mockPut).toHaveBeenCalledWith('/users/u1/data-retention', { optOut: true })
+        expect(result.optOut).toBe(true)
+    })
+
+    it('PUTs optOut=false to keep retention (clears the opt-out)', async () => {
+        mockPut.mockResolvedValueOnce({ data: { optOut: false, optedOutAt: null } })
+        const result = await UserService.updateDataRetention('u1', false)
+        expect(mockPut).toHaveBeenCalledWith('/users/u1/data-retention', { optOut: false })
+        expect(result.optedOutAt).toBeNull()
+    })
+
+    it('throws a friendly error when the request fails', async () => {
+        mockPut.mockRejectedValueOnce(new Error('network down'))
+        await expect(UserService.updateDataRetention('u1', true)).rejects.toThrow()
+    })
+})


### PR DESCRIPTION
## Summary

User-facing retention controls + transparency at cancel/downgrade.

- **Retention opt-out toggle** (profile → Your data): "Keep my history after my subscription ends" — on by default (the GDPR Art. 21 objection). Wired to new `UserService.getDataRetention`/`updateDataRetention`.
- **Cancel confirmation** (billing) + **quantity-downgrade modal:** reframed from a deletion warning to "your history is kept for as long as you own the device, so you can resume and compare year over year when you return"; points to the profile toggle; export/remove stay available.
- **`ToggleSwitch` component:** extracted reusable pill switch (`role="switch"` / `aria-checked`); used by both the new retention toggle and the existing push toggle.

Tests: `UserService` retention calls + `ToggleSwitch` component. Typecheck + full vitest green.

Pairs with the privacy policy (#322), the suspension UI (#323), and the API opt-out endpoints (garge-api #256).
