### PR TITLE
ci: allow on-demand dev deploy via workflow_dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: 🚀 Release
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -10,6 +11,7 @@ permissions: {}
 jobs:
   release-please:
     name: Release Please
+    if: ${{ github.event_name == 'push' }}
     uses: equinor/ops-actions/.github/workflows/release-please.yml@c1be86e02c64b0d2db5c2dba532b5580cdce168d # v9.38.0
     permissions:
       contents: write


### PR DESCRIPTION
Adds `workflow_dispatch` to the release workflow so the dev image can be deployed **on demand** from the Actions tab.

`release-please` is gated to `push` events, so a manual run only triggers `deploy-dev` — the prod deploy + chart update stay gated on `release_created`.

> The **Run workflow** button appears once this is merged to `main`.
