### PR TITLE
feat: show sensor capacity (X of Y used) in profile

### DIFF
--- a/src/app/(protected)/profile/page.tsx
+++ b/src/app/(protected)/profile/page.tsx
@@ -14,6 +14,7 @@ import { useCanClaimDevice } from '@/hooks/useCanClaimDevice';
 import ConfirmModal from '@/components/ConfirmModal';
 import LoadingDots from '@/components/LoadingDots';
 import Section from '@/components/Section';
+import CapacityMeter from '@/components/CapacityMeter';
 import ToggleSwitch from '@/components/ToggleSwitch';
 import { inputClass } from '@/components/TextInput';
 import Alert from '@/components/Alert';
@@ -57,7 +58,7 @@ const Profile: React.FC = () => {
     const [editPhone, setEditPhone] = useState('');
     const [profileSaving, setProfileSaving] = useState(false);
     const [editingField, setEditingField] = useState<'name' | 'phone' | null>(null);
-    const { canClaim, loading: eligibilityLoading, refresh: refreshEligibility } = useCanClaimDevice();
+    const { canClaim, loading: eligibilityLoading, refresh: refreshEligibility, capacity, ownedSensorCount, primaryActive } = useCanClaimDevice();
 
     useEffect(() => {
         if (!isAuthenticated) { router.push('/login'); return; }
@@ -489,6 +490,7 @@ const Profile: React.FC = () => {
 
                 <Section title="Devices">
                     <div className="space-y-4">
+                        <CapacityMeter used={ownedSensorCount} capacity={capacity} primaryActive={primaryActive} loading={eligibilityLoading} />
                         <div>
                             <div className="flex gap-2 p-1 bg-gray-800/60 rounded-xl mb-3">
                                 <button

--- a/src/components/CapacityMeter.tsx
+++ b/src/components/CapacityMeter.tsx
@@ -1,0 +1,54 @@
+import Link from 'next/link';
+
+interface CapacityMeterProps {
+    /** Active (non-suspended) owned sensors consuming capacity. */
+    used: number;
+    /** Sensors covered by the active subscription (1 Primary + add-on quantities). */
+    capacity: number;
+    primaryActive: boolean;
+    loading?: boolean;
+}
+
+/**
+ * Shows how much sensor capacity is in use ("3 of 6 used") with a segmented bar.
+ * Capacity is additive (Primary covers 1 + each add-on adds quantity) — there is no
+ * fixed plan tier, so this always reflects the current subscription.
+ */
+export default function CapacityMeter({ used, capacity, primaryActive, loading = false }: CapacityMeterProps) {
+    if (loading) {
+        return <div className="h-12 rounded-xl bg-gray-800/40 animate-pulse" />;
+    }
+
+    if (!primaryActive || capacity === 0) {
+        return (
+            <div className="flex items-center justify-between gap-3 rounded-xl bg-gray-900/50 border border-gray-700/40 px-3 py-2.5">
+                <p className="text-xs text-gray-400">No active subscription — no sensor capacity.</p>
+                <Link href="/shop" className="text-xs font-medium text-sky-400 hover:text-sky-300 whitespace-nowrap">See plans →</Link>
+            </div>
+        );
+    }
+
+    const atCapacity = used >= capacity;
+    const fillClass = atCapacity ? 'bg-amber-500' : 'bg-sky-500';
+
+    return (
+        <div className="rounded-xl bg-gray-900/50 border border-gray-700/40 px-3 py-2.5 space-y-2">
+            <div className="flex items-center justify-between gap-2">
+                <span className="text-xs text-gray-400">Sensor capacity</span>
+                <span className={`text-xs font-medium tabular-nums ${atCapacity ? 'text-amber-400' : 'text-gray-200'}`}>
+                    {used} of {capacity} used
+                </span>
+            </div>
+            {capacity <= 12 && (
+                <div className="flex items-center gap-1" aria-hidden>
+                    {Array.from({ length: capacity }).map((_, i) => (
+                        <span key={i} className={`h-1.5 flex-1 rounded-full ${i < used ? fillClass : 'bg-gray-700/50'}`} />
+                    ))}
+                </div>
+            )}
+            {atCapacity && (
+                <p className="text-[11px] text-amber-400/80">At capacity — turn a sensor off, or add capacity to add more.</p>
+            )}
+        </div>
+    );
+}

--- a/src/hooks/useCanClaimDevice.ts
+++ b/src/hooks/useCanClaimDevice.ts
@@ -39,7 +39,9 @@ export function useCanClaimDevice(): CanClaimDeviceResult {
                 SubscriptionService.getMySubscriptions().catch(() => []),
             ]);
             const activeSubs = subscriptions.filter(s => s.status === 'Active');
-            setOwnedSensorCount(sensors.length);
+            // Suspended (turned-off / over-capacity) sensors do not consume capacity — count only active ones,
+            // matching the backend's GetActiveOwnedSensorCountAsync.
+            setOwnedSensorCount(sensors.filter(s => !s.suspended).length);
             setPrimaryActive(activeSubs.some(s => s.productType === 'Primary'));
             setAddOnCapacity(
                 activeSubs

--- a/src/tests/components/CapacityMeter.test.tsx
+++ b/src/tests/components/CapacityMeter.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import CapacityMeter from '@/components/CapacityMeter'
+
+describe('CapacityMeter', () => {
+    it('shows used of capacity', () => {
+        render(<CapacityMeter used={3} capacity={6} primaryActive />)
+        expect(screen.getByText('3 of 6 used')).toBeInTheDocument()
+    })
+
+    it('shows the no-subscription state with a shop link when capacity is 0', () => {
+        render(<CapacityMeter used={0} capacity={0} primaryActive={false} />)
+        expect(screen.getByText(/no active subscription/i)).toBeInTheDocument()
+        expect(screen.getByRole('link', { name: /see plans/i })).toHaveAttribute('href', '/shop')
+    })
+
+    it('warns when at capacity', () => {
+        render(<CapacityMeter used={6} capacity={6} primaryActive />)
+        expect(screen.getByText('6 of 6 used')).toBeInTheDocument()
+        expect(screen.getByText(/at capacity/i)).toBeInTheDocument()
+    })
+
+    it('does not warn below capacity', () => {
+        render(<CapacityMeter used={2} capacity={6} primaryActive />)
+        expect(screen.queryByText(/at capacity/i)).not.toBeInTheDocument()
+    })
+
+    it('renders a loading skeleton', () => {
+        const { container } = render(<CapacityMeter used={0} capacity={0} primaryActive loading />)
+        expect(container.querySelector('.animate-pulse')).toBeTruthy()
+    })
+})


### PR DESCRIPTION
Adds a **CapacityMeter** to the profile **Devices** section: a segmented bar + "3 of 6 used", right next to the add-device box it gates.

- Reuses the existing `useCanClaimDevice` hook — **no backend change**.
- No-subscription state links to the shop; at-capacity turns amber with a hint.
- Also fixes the hook to exclude **suspended** sensors from the used count (they don't consume capacity), matching the backend's active-owned check.
- +5 component tests.
