### PR TITLE
feat: drive claim eligibility from the backend capacity endpoint

### DIFF
--- a/src/app/(protected)/profile/page.tsx
+++ b/src/app/(protected)/profile/page.tsx
@@ -58,7 +58,7 @@ const Profile: React.FC = () => {
     const [editPhone, setEditPhone] = useState('');
     const [profileSaving, setProfileSaving] = useState(false);
     const [editingField, setEditingField] = useState<'name' | 'phone' | null>(null);
-    const { canClaim, loading: eligibilityLoading, refresh: refreshEligibility, capacity, ownedSensorCount, primaryActive } = useCanClaimDevice();
+    const { canClaim, loading: eligibilityLoading, refresh: refreshEligibility, capacity, used, bypass } = useCanClaimDevice();
 
     useEffect(() => {
         if (!isAuthenticated) { router.push('/login'); return; }
@@ -490,7 +490,7 @@ const Profile: React.FC = () => {
 
                 <Section title="Devices">
                     <div className="space-y-4">
-                        <CapacityMeter used={ownedSensorCount} capacity={capacity} primaryActive={primaryActive} loading={eligibilityLoading} />
+                        <CapacityMeter used={used} capacity={capacity} bypass={bypass} loading={eligibilityLoading} />
                         <div>
                             <div className="flex gap-2 p-1 bg-gray-800/60 rounded-xl mb-3">
                                 <button

--- a/src/components/CapacityMeter.tsx
+++ b/src/components/CapacityMeter.tsx
@@ -3,23 +3,33 @@ import Link from 'next/link';
 interface CapacityMeterProps {
     /** Active (non-suspended) owned sensors consuming capacity. */
     used: number;
-    /** Sensors covered by the active subscription (1 Primary + add-on quantities). */
+    /** Sensors covered by the active subscription (1 Primary + add-on quantities); 0 without one. */
     capacity: number;
-    primaryActive: boolean;
+    /** Role-based access without a subscription (e.g. ComplimentaryUser) — no capacity limit. */
+    bypass?: boolean;
     loading?: boolean;
 }
 
 /**
  * Shows how much sensor capacity is in use ("3 of 6 used") with a segmented bar.
- * Capacity is additive (Primary covers 1 + each add-on adds quantity) — there is no
- * fixed plan tier, so this always reflects the current subscription.
+ * Capacity is additive (Primary covers 1 + each add-on adds quantity). Users with a
+ * subscription-bypass role have complimentary, unlimited access.
  */
-export default function CapacityMeter({ used, capacity, primaryActive, loading = false }: CapacityMeterProps) {
+export default function CapacityMeter({ used, capacity, bypass = false, loading = false }: CapacityMeterProps) {
     if (loading) {
         return <div className="h-12 rounded-xl bg-gray-800/40 animate-pulse" />;
     }
 
-    if (!primaryActive || capacity === 0) {
+    if (bypass) {
+        return (
+            <div className="flex items-center justify-between gap-3 rounded-xl bg-gray-900/50 border border-gray-700/40 px-3 py-2.5">
+                <span className="text-xs text-gray-400">Sensor capacity</span>
+                <span className="text-xs font-medium text-emerald-400">Complimentary access · {used} active</span>
+            </div>
+        );
+    }
+
+    if (capacity === 0) {
         return (
             <div className="flex items-center justify-between gap-3 rounded-xl bg-gray-900/50 border border-gray-700/40 px-3 py-2.5">
                 <p className="text-xs text-gray-400">No active subscription — no sensor capacity.</p>

--- a/src/hooks/useCanClaimDevice.ts
+++ b/src/hooks/useCanClaimDevice.ts
@@ -1,53 +1,33 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import SensorService from '@/services/sensorService';
-import SubscriptionService from '@/services/subscriptionService';
+import SensorService, { SensorCapacity } from '@/services/sensorService';
 
 export interface CanClaimDeviceResult {
     canClaim: boolean;
     loading: boolean;
-    ownedSensorCount: number;
+    used: number;
     capacity: number;
-    primaryActive: boolean;
+    /** True when a role grants service access without a subscription (e.g. ComplimentaryUser). */
+    bypass: boolean;
     refresh: () => Promise<void>;
 }
 
 /**
- * Mirrors the backend ActiveSubscriptionRequirement so the UI can hide the claim button
- * before submit. Capacity model:
- *
- *   - An active Primary subscription grants a base allowance of 1 owned sensor.
- *   - Each active AddOn subscription contributes its quantity to the allowance.
- *   - Without an active Primary the allowance is 0 — AddOns alone are not enough.
- *
- * A claim is allowed when ownedSensorCount < capacity. Shared sensors are tracked with
- * IsOwner=false on the backend and are not counted here either (the sensors endpoint
- * does not currently expose ownership and sharing is not implemented yet).
+ * Reads the caller's sensor capacity + claim eligibility from the backend
+ * (GET /sensors/capacity) — the single source of truth. The client does not
+ * re-derive capacity or duplicate the subscription-bypass role list.
  */
 export function useCanClaimDevice(): CanClaimDeviceResult {
-    const [ownedSensorCount, setOwnedSensorCount] = useState(0);
-    const [primaryActive, setPrimaryActive] = useState(false);
-    const [addOnCapacity, setAddOnCapacity] = useState(0);
+    const [data, setData] = useState<SensorCapacity>({ capacity: 0, used: 0, bypass: false, canClaim: false });
     const [loading, setLoading] = useState(true);
 
     const refresh = useCallback(async () => {
         setLoading(true);
         try {
-            const [sensors, subscriptions] = await Promise.all([
-                SensorService.getAllSensors().catch(() => []),
-                SubscriptionService.getMySubscriptions().catch(() => []),
-            ]);
-            const activeSubs = subscriptions.filter(s => s.status === 'Active');
-            // Suspended (turned-off / over-capacity) sensors do not consume capacity — count only active ones,
-            // matching the backend's GetActiveOwnedSensorCountAsync.
-            setOwnedSensorCount(sensors.filter(s => !s.suspended).length);
-            setPrimaryActive(activeSubs.some(s => s.productType === 'Primary'));
-            setAddOnCapacity(
-                activeSubs
-                    .filter(s => s.productType === 'AddOn')
-                    .reduce((sum, s) => sum + (s.quantity ?? 0), 0),
-            );
+            setData(await SensorService.getSensorCapacity());
+        } catch {
+            setData({ capacity: 0, used: 0, bypass: false, canClaim: false });
         } finally {
             setLoading(false);
         }
@@ -57,8 +37,12 @@ export function useCanClaimDevice(): CanClaimDeviceResult {
         refresh();
     }, [refresh]);
 
-    const capacity = primaryActive ? 1 + addOnCapacity : 0;
-    const canClaim = ownedSensorCount < capacity;
-
-    return { canClaim, loading, ownedSensorCount, capacity, primaryActive, refresh };
+    return {
+        canClaim: data.canClaim,
+        loading,
+        used: data.used,
+        capacity: data.capacity,
+        bypass: data.bypass,
+        refresh,
+    };
 }

--- a/src/services/sensorService.ts
+++ b/src/services/sensorService.ts
@@ -22,6 +22,15 @@ export interface SensorData {
     value: number;
 }
 
+/** The caller's sensor capacity and claim eligibility (GET /sensors/capacity). */
+export interface SensorCapacity {
+    capacity: number;
+    used: number;
+    /** Role-based access without a subscription (e.g. ComplimentaryUser) — no capacity limit. */
+    bypass: boolean;
+    canClaim: boolean;
+}
+
 export interface BatteryHealthData {
     id: number;
     sensorId: number;
@@ -148,6 +157,15 @@ const SensorService = {
                 return { totalCount: 0, pageNumber, pageSize, data: [] };
             }
             throw new Error(formatApiError(error, 'Failed to fetch multiple sensors data'));
+        }
+    },
+
+    async getSensorCapacity(): Promise<SensorCapacity> {
+        try {
+            const response = await axiosInstance.get<SensorCapacity>('/sensors/capacity');
+            return response.data;
+        } catch (error: unknown) {
+            throw new Error(formatApiError(error, 'Failed to fetch sensor capacity'));
         }
     },
 

--- a/src/tests/components/CapacityMeter.test.tsx
+++ b/src/tests/components/CapacityMeter.test.tsx
@@ -4,29 +4,35 @@ import CapacityMeter from '@/components/CapacityMeter'
 
 describe('CapacityMeter', () => {
     it('shows used of capacity', () => {
-        render(<CapacityMeter used={3} capacity={6} primaryActive />)
+        render(<CapacityMeter used={3} capacity={6} />)
         expect(screen.getByText('3 of 6 used')).toBeInTheDocument()
     })
 
     it('shows the no-subscription state with a shop link when capacity is 0', () => {
-        render(<CapacityMeter used={0} capacity={0} primaryActive={false} />)
+        render(<CapacityMeter used={0} capacity={0} />)
         expect(screen.getByText(/no active subscription/i)).toBeInTheDocument()
         expect(screen.getByRole('link', { name: /see plans/i })).toHaveAttribute('href', '/shop')
     })
 
+    it('shows complimentary access for a bypass role (no subscription needed)', () => {
+        render(<CapacityMeter used={2} capacity={0} bypass />)
+        expect(screen.getByText(/complimentary access/i)).toBeInTheDocument()
+        expect(screen.queryByText(/no active subscription/i)).not.toBeInTheDocument()
+    })
+
     it('warns when at capacity', () => {
-        render(<CapacityMeter used={6} capacity={6} primaryActive />)
+        render(<CapacityMeter used={6} capacity={6} />)
         expect(screen.getByText('6 of 6 used')).toBeInTheDocument()
         expect(screen.getByText(/at capacity/i)).toBeInTheDocument()
     })
 
     it('does not warn below capacity', () => {
-        render(<CapacityMeter used={2} capacity={6} primaryActive />)
+        render(<CapacityMeter used={2} capacity={6} />)
         expect(screen.queryByText(/at capacity/i)).not.toBeInTheDocument()
     })
 
     it('renders a loading skeleton', () => {
-        const { container } = render(<CapacityMeter used={0} capacity={0} primaryActive loading />)
+        const { container } = render(<CapacityMeter used={0} capacity={0} loading />)
         expect(container.querySelector('.animate-pulse')).toBeTruthy()
     })
 })

--- a/src/tests/hooks/useCanClaimDevice.test.tsx
+++ b/src/tests/hooks/useCanClaimDevice.test.tsx
@@ -2,98 +2,44 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
 import { useCanClaimDevice } from '@/hooks/useCanClaimDevice'
 
+// Capacity is computed server-side now (GET /sensors/capacity); the hook just surfaces it.
 vi.mock('@/services/sensorService', () => ({
-    default: {
-        getAllSensors: vi.fn(),
-    },
-}))
-
-vi.mock('@/services/subscriptionService', () => ({
-    default: {
-        getMySubscriptions: vi.fn(),
-    },
+    default: { getSensorCapacity: vi.fn() },
 }))
 
 import SensorService from '@/services/sensorService'
-import SubscriptionService from '@/services/subscriptionService'
 
-const mockedSensors = SensorService.getAllSensors as ReturnType<typeof vi.fn>
-const mockedSubs = SubscriptionService.getMySubscriptions as ReturnType<typeof vi.fn>
+const mockedCapacity = SensorService.getSensorCapacity as ReturnType<typeof vi.fn>
 
 beforeEach(() => {
-    mockedSensors.mockReset()
-    mockedSubs.mockReset()
+    mockedCapacity.mockReset()
 })
 
 describe('useCanClaimDevice', () => {
-    it('blocks claim when the user has no subscription at all', async () => {
-        mockedSensors.mockResolvedValue([])
-        mockedSubs.mockResolvedValue([])
-
-        const { result } = renderHook(() => useCanClaimDevice())
-        await waitFor(() => expect(result.current.loading).toBe(false))
-
-        expect(result.current.canClaim).toBe(false)
-        expect(result.current.capacity).toBe(0)
-        expect(result.current.primaryActive).toBe(false)
-    })
-
-    it('allows claim when an active Primary covers the first sensor', async () => {
-        mockedSensors.mockResolvedValue([])
-        mockedSubs.mockResolvedValue([{ id: 1, status: 'Active', productType: 'Primary', quantity: 1 }])
+    it('surfaces the backend capacity and claim eligibility', async () => {
+        mockedCapacity.mockResolvedValue({ capacity: 3, used: 1, bypass: false, canClaim: true })
 
         const { result } = renderHook(() => useCanClaimDevice())
         await waitFor(() => expect(result.current.loading).toBe(false))
 
         expect(result.current.canClaim).toBe(true)
-        expect(result.current.capacity).toBe(1)
-        expect(result.current.primaryActive).toBe(true)
-    })
-
-    it('blocks claim once owned sensors reach Primary capacity', async () => {
-        mockedSensors.mockResolvedValue([{ id: 1 }])
-        mockedSubs.mockResolvedValue([{ id: 1, status: 'Active', productType: 'Primary', quantity: 1 }])
-
-        const { result } = renderHook(() => useCanClaimDevice())
-        await waitFor(() => expect(result.current.loading).toBe(false))
-
-        expect(result.current.canClaim).toBe(false)
-        expect(result.current.capacity).toBe(1)
-    })
-
-    it('extends capacity by each active AddOn quantity', async () => {
-        mockedSensors.mockResolvedValue([{ id: 1 }, { id: 2 }])
-        mockedSubs.mockResolvedValue([
-            { id: 1, status: 'Active', productType: 'Primary', quantity: 1 },
-            { id: 2, status: 'Active', productType: 'AddOn',   quantity: 2 },
-        ])
-
-        const { result } = renderHook(() => useCanClaimDevice())
-        await waitFor(() => expect(result.current.loading).toBe(false))
-
         expect(result.current.capacity).toBe(3)
+        expect(result.current.used).toBe(1)
+        expect(result.current.bypass).toBe(false)
+    })
+
+    it('surfaces complimentary (bypass) access without a subscription', async () => {
+        mockedCapacity.mockResolvedValue({ capacity: 0, used: 2, bypass: true, canClaim: true })
+
+        const { result } = renderHook(() => useCanClaimDevice())
+        await waitFor(() => expect(result.current.loading).toBe(false))
+
+        expect(result.current.bypass).toBe(true)
         expect(result.current.canClaim).toBe(true)
     })
 
-    it('blocks claim when AddOn is active but Primary is not', async () => {
-        mockedSensors.mockResolvedValue([])
-        mockedSubs.mockResolvedValue([{ id: 1, status: 'Active', productType: 'AddOn', quantity: 5 }])
-
-        const { result } = renderHook(() => useCanClaimDevice())
-        await waitFor(() => expect(result.current.loading).toBe(false))
-
-        expect(result.current.canClaim).toBe(false)
-        expect(result.current.capacity).toBe(0)
-        expect(result.current.primaryActive).toBe(false)
-    })
-
-    it('ignores non-active subscriptions', async () => {
-        mockedSensors.mockResolvedValue([])
-        mockedSubs.mockResolvedValue([
-            { id: 1, status: 'Pending', productType: 'Primary', quantity: 1 },
-            { id: 2, status: 'Stopped', productType: 'AddOn',   quantity: 5 },
-            { id: 3, status: 'Expired', productType: 'Primary', quantity: 1 },
-        ])
+    it('treats a failed call as no capacity and blocks claim', async () => {
+        mockedCapacity.mockRejectedValue(new Error('boom'))
 
         const { result } = renderHook(() => useCanClaimDevice())
         await waitFor(() => expect(result.current.loading).toBe(false))
@@ -102,28 +48,14 @@ describe('useCanClaimDevice', () => {
         expect(result.current.capacity).toBe(0)
     })
 
-    it('treats failed service calls as empty lists and blocks claim', async () => {
-        mockedSensors.mockRejectedValue(new Error('boom'))
-        mockedSubs.mockRejectedValue(new Error('boom'))
-
-        const { result } = renderHook(() => useCanClaimDevice())
-        await waitFor(() => expect(result.current.loading).toBe(false))
-
-        expect(result.current.canClaim).toBe(false)
-        expect(result.current.capacity).toBe(0)
-    })
-
-    it('refresh re-runs the queries and updates state', async () => {
-        mockedSensors.mockResolvedValueOnce([])
-        mockedSubs.mockResolvedValueOnce([])
+    it('refresh re-fetches and updates state', async () => {
+        mockedCapacity.mockResolvedValueOnce({ capacity: 0, used: 0, bypass: false, canClaim: false })
 
         const { result } = renderHook(() => useCanClaimDevice())
         await waitFor(() => expect(result.current.loading).toBe(false))
         expect(result.current.canClaim).toBe(false)
 
-        mockedSensors.mockResolvedValueOnce([])
-        mockedSubs.mockResolvedValueOnce([{ id: 1, status: 'Active', productType: 'Primary', quantity: 1 }])
-
+        mockedCapacity.mockResolvedValueOnce({ capacity: 1, used: 0, bypass: false, canClaim: true })
         await act(async () => {
             await result.current.refresh()
         })


### PR DESCRIPTION
## Summary
Makes the claim button + capacity meter aware of complimentary (subscription-bypass) access, **without** duplicating the backend's role list in the frontend.

Previously `useCanClaimDevice` recomputed capacity client-side from subscriptions and would have needed a hardcoded copy of `RoleNames.SubscriptionBypassRoles` to know a `ComplimentaryUser` can claim. Instead it now reads the new backend endpoint **`GET /sensors/capacity`** (single source of truth): `{ capacity, used, bypass, canClaim }`.

- `useCanClaimDevice` fetches the endpoint — no client-side capacity math, no role list.
- `SensorService.getSensorCapacity` + `SensorCapacity` type.
- `CapacityMeter` gains a **"Complimentary access"** state for bypass roles and drops the `primaryActive` prop (the no-subscription state is simply `capacity === 0`).
- Profile passes `used`/`bypass`; hook + meter tests rewritten (capacity-math cases now live in the garge-api tests).

Requires the garge-api PR adding `GET /sensors/capacity` and exempting bypass roles from auto-suspend/purge.
