### PR TITLE
feat: device sharing UI (sensors + sockets, Read/Edit)

### DIFF
--- a/src/app/(protected)/profile/sensors/page.tsx
+++ b/src/app/(protected)/profile/sensors/page.tsx
@@ -15,6 +15,9 @@ const config: DevicePageConfig<Sensor> = {
     getDefaultName: (s) => s.defaultName ?? undefined,
     suspend: (id) => SensorService.suspendSensor(id),
     activate: (id) => SensorService.activateSensor(id),
+    listShares: (id) => SensorService.getSensorShares(id),
+    share: (id, email, permission) => SensorService.shareSensor(id, email, permission),
+    revokeShare: (id, userId) => SensorService.revokeSensorShare(id, userId),
 };
 
 export default function SensorsPage() {

--- a/src/app/(protected)/profile/sockets/page.tsx
+++ b/src/app/(protected)/profile/sockets/page.tsx
@@ -13,6 +13,9 @@ const config: DevicePageConfig<Switch> = {
     updateName: (id, name) => SwitchService.updateCustomName(id, name),
     getDisplayName: (sw) => sw.customName ?? sw.name,
     getDefaultName: (sw) => sw.name,
+    listShares: (id) => SwitchService.getSwitchShares(id),
+    share: (id, email, permission) => SwitchService.shareSwitch(id, email, permission),
+    revokeShare: (id, userId) => SwitchService.revokeSwitchShare(id, userId),
 };
 
 export default function SocketsPage() {

--- a/src/components/DeviceManagePage.tsx
+++ b/src/components/DeviceManagePage.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
-import { PencilIcon, CheckIcon, XMarkIcon, TrashIcon, ClipboardDocumentIcon, ArrowLeftIcon, PowerIcon } from '@heroicons/react/24/outline';
+import { PencilIcon, CheckIcon, XMarkIcon, TrashIcon, ClipboardDocumentIcon, ArrowLeftIcon, PowerIcon, ShareIcon } from '@heroicons/react/24/outline';
 import ConfirmModal from '@/components/ConfirmModal';
 import LoadingDots from '@/components/LoadingDots';
 import Section from '@/components/Section';
@@ -12,6 +12,8 @@ import Alert from '@/components/Alert';
 import { toast } from 'sonner';
 import Link from 'next/link';
 import { useCanClaimDevice } from '@/hooks/useCanClaimDevice';
+import ShareDeviceModal from '@/components/ShareDeviceModal';
+import { SensorAccess, SensorShare, SharePermission } from '@/services/sensorService';
 
 export interface DeviceItem {
     id: number;
@@ -20,6 +22,8 @@ export interface DeviceItem {
     registrationCode?: string | null;
     /** When true, the device is turned off / over-quota suspended: its data reads are blocked. */
     suspended?: boolean;
+    /** The caller's relationship to this device. Absent is treated as 'owner'. */
+    access?: SensorAccess;
 }
 
 export interface DevicePageConfig<T extends DeviceItem> {
@@ -36,6 +40,10 @@ export interface DevicePageConfig<T extends DeviceItem> {
     suspend?: (id: number) => Promise<unknown>;
     /** Optional: turn a device back on. Rejected by the API (and surfaced as a toast) if it would exceed the caller's capacity. */
     activate?: (id: number) => Promise<unknown>;
+    /** Optional sharing trio — when all present, owners get a Share action. */
+    listShares?: (id: number) => Promise<SensorShare[]>;
+    share?: (id: number, email: string, permission: SharePermission) => Promise<unknown>;
+    revokeShare?: (id: number, userId: string) => Promise<unknown>;
 }
 
 interface Props<T extends DeviceItem> {
@@ -60,10 +68,13 @@ export function DeviceManagePage<T extends DeviceItem>({ config }: Props<T>) {
     const [confirmDeleteId, setConfirmDeleteId] = useState<number | null>(null);
     const { canClaim, loading: eligibilityLoading, refresh: refreshEligibility } = useCanClaimDevice();
 
-    const { title, itemLabel, emoji, fetchAll, claim, unclaim, updateName, getDisplayName, getDefaultName, suspend, activate } = config;
+    const { title, itemLabel, emoji, fetchAll, claim, unclaim, updateName, getDisplayName, getDefaultName, suspend, activate, listShares, share, revokeShare } = config;
     const label = itemLabel;
     const Label = label.charAt(0).toUpperCase() + label.slice(1);
     const [togglingId, setTogglingId] = useState<number | null>(null);
+    const [shareTarget, setShareTarget] = useState<T | null>(null);
+    const sharingEnabled = Boolean(listShares && share && revokeShare);
+    const isOwner = (item: T) => (item.access ?? 'owner') === 'owner';
 
     const refresh = async () => {
         const all = await fetchAll();
@@ -156,16 +167,31 @@ export function DeviceManagePage<T extends DeviceItem>({ config }: Props<T>) {
     };
 
     const confirmItem = items.find(i => i.id === confirmDeleteId);
+    const confirmIsOwner = confirmItem ? isOwner(confirmItem) : true;
 
     return (
         <>
             {confirmDeleteId !== null && confirmItem && (
                 <ConfirmModal
-                    title={`Remove ${label}`}
-                    message={<>Are you sure you want to remove <span className="font-medium text-gray-100">{getDisplayName(confirmItem)}</span> from your account? You can re-add it later using the device code.</>}
-                    confirmLabel="Remove"
+                    title={confirmIsOwner ? `Remove ${label}` : `Leave ${label}`}
+                    message={confirmIsOwner
+                        ? <>Remove <span className="font-medium text-gray-100">{getDisplayName(confirmItem)}</span> from your account? Anyone you shared it with will lose access. You can re-add it later using the device code.</>
+                        : <>Stop viewing <span className="font-medium text-gray-100">{getDisplayName(confirmItem)}</span>? The owner can share it with you again.</>}
+                    confirmLabel={confirmIsOwner ? 'Remove' : 'Leave'}
                     onConfirm={handleUnclaim}
                     onCancel={() => setConfirmDeleteId(null)}
+                />
+            )}
+
+            {shareTarget && listShares && share && revokeShare && (
+                <ShareDeviceModal
+                    deviceLabel={label}
+                    deviceName={getDisplayName(shareTarget)}
+                    deviceId={shareTarget.id}
+                    listShares={listShares}
+                    share={share}
+                    revokeShare={revokeShare}
+                    onClose={() => setShareTarget(null)}
                 />
             )}
 
@@ -259,6 +285,11 @@ export function DeviceManagePage<T extends DeviceItem>({ config }: Props<T>) {
                                                                 Off
                                                             </span>
                                                         )}
+                                                        {!isOwner(item) && (
+                                                            <span className="flex-shrink-0 text-[10px] font-medium px-1.5 py-0.5 rounded-full bg-sky-500/15 text-sky-300 border border-sky-500/30">
+                                                                {item.access === 'edit' ? 'Shared · edit' : 'Shared · read'}
+                                                            </span>
+                                                        )}
                                                     </div>
                                                     <button onClick={() => startEditing(item)} className="p-1.5 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-gray-700/60 transition-all flex-shrink-0" title="Rename">
                                                         <PencilIcon className="h-3.5 w-3.5" />
@@ -284,7 +315,7 @@ export function DeviceManagePage<T extends DeviceItem>({ config }: Props<T>) {
                                                     )}
                                                 </div>
                                                 <div className="flex items-center gap-4">
-                                                    {suspend && activate && (
+                                                    {suspend && activate && isOwner(item) && (
                                                         <button
                                                             onClick={() => handleToggleActive(item)}
                                                             disabled={togglingId === item.id}
@@ -295,13 +326,23 @@ export function DeviceManagePage<T extends DeviceItem>({ config }: Props<T>) {
                                                             {togglingId === item.id ? '…' : item.suspended ? 'Turn on' : 'Turn off'}
                                                         </button>
                                                     )}
+                                                    {sharingEnabled && isOwner(item) && (
+                                                        <button
+                                                            onClick={() => setShareTarget(item)}
+                                                            className="flex items-center gap-1.5 text-xs text-gray-600 hover:text-sky-400 transition-colors"
+                                                            title={`Share ${label}`}
+                                                        >
+                                                            <ShareIcon className="h-3.5 w-3.5" />
+                                                            Share
+                                                        </button>
+                                                    )}
                                                     <button
                                                         onClick={() => setConfirmDeleteId(item.id)}
                                                         className="flex items-center gap-1.5 text-xs text-gray-600 hover:text-red-400 transition-colors"
-                                                        title="Remove from account"
+                                                        title={isOwner(item) ? 'Remove from account' : 'Leave'}
                                                     >
                                                         <TrashIcon className="h-3.5 w-3.5" />
-                                                        Remove from account
+                                                        {isOwner(item) ? 'Remove from account' : 'Leave'}
                                                     </button>
                                                 </div>
                                             </>

--- a/src/components/ShareDeviceModal.tsx
+++ b/src/components/ShareDeviceModal.tsx
@@ -1,0 +1,164 @@
+'use client';
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { XMarkIcon, UserPlusIcon } from '@heroicons/react/24/outline';
+import { toast } from 'sonner';
+import { inputClass } from '@/components/TextInput';
+import { useEscapeKey } from '@/lib/useEscapeKey';
+import { SensorShare, SharePermission } from '@/services/sensorService';
+
+interface ShareDeviceModalProps {
+    deviceLabel: string;
+    deviceName: string;
+    deviceId: number;
+    listShares: (id: number) => Promise<SensorShare[]>;
+    share: (id: number, email: string, permission: SharePermission) => Promise<unknown>;
+    revokeShare: (id: number, userId: string) => Promise<unknown>;
+    onClose: () => void;
+}
+
+const ShareDeviceModal: React.FC<ShareDeviceModalProps> = ({
+    deviceLabel, deviceName, deviceId, listShares, share, revokeShare, onClose,
+}) => {
+    const [shares, setShares] = useState<SensorShare[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [email, setEmail] = useState('');
+    const [permission, setPermission] = useState<SharePermission>('read');
+    const [submitting, setSubmitting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [revokingId, setRevokingId] = useState<string | null>(null);
+
+    useEscapeKey(!submitting, onClose);
+
+    const load = useCallback(async () => {
+        try {
+            setShares(await listShares(deviceId));
+        } catch (e) {
+            setError(e instanceof Error ? e.message : 'Failed to load shares');
+        } finally {
+            setLoading(false);
+        }
+    }, [deviceId, listShares]);
+
+    useEffect(() => { load(); }, [load]);
+
+    const handleShare = async () => {
+        const trimmed = email.trim();
+        if (!trimmed.includes('@')) { setError('Enter a valid email address.'); return; }
+        setSubmitting(true);
+        setError(null);
+        try {
+            await share(deviceId, trimmed, permission);
+            setEmail('');
+            toast.success(`Shared with ${trimmed}`);
+            await load();
+        } catch (e) {
+            const msg = e instanceof Error ? e.message : 'Failed to share';
+            setError(msg);
+            toast.error(msg);
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    const handleRevoke = async (userId: string, who: string) => {
+        setRevokingId(userId);
+        try {
+            await revokeShare(deviceId, userId);
+            toast.success(`Stopped sharing with ${who}`);
+            await load();
+        } catch (e) {
+            toast.error(e instanceof Error ? e.message : 'Failed to revoke');
+        } finally {
+            setRevokingId(null);
+        }
+    };
+
+    return (
+        <div role="dialog" aria-modal="true" aria-labelledby="share-modal-title" className="fixed inset-0 z-[200] flex items-center justify-center px-4">
+            <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={() => { if (!submitting) onClose(); }} />
+            <div className="relative bg-gray-800 border border-gray-700/60 rounded-2xl p-6 max-w-md w-full shadow-2xl">
+                <div className="flex items-start justify-between gap-3 mb-4">
+                    <div>
+                        <h3 id="share-modal-title" className="text-sm font-semibold text-gray-100">Share {deviceName}</h3>
+                        <p className="text-xs text-gray-400">Share this {deviceLabel} with another Garge user by their account email.</p>
+                    </div>
+                    <button onClick={onClose} className="p-1 rounded-lg text-gray-500 hover:text-gray-300 hover:bg-gray-700/60 transition-all" aria-label="Close">
+                        <XMarkIcon className="h-4 w-4" />
+                    </button>
+                </div>
+
+                <div className="flex flex-col gap-2 mb-2">
+                    <input
+                        type="email"
+                        value={email}
+                        onChange={e => setEmail(e.target.value)}
+                        onKeyDown={e => e.key === 'Enter' && !submitting && handleShare()}
+                        placeholder="person@example.com"
+                        className={inputClass}
+                        disabled={submitting}
+                    />
+                    <div className="flex gap-2">
+                        <select
+                            value={permission}
+                            onChange={e => setPermission(e.target.value as SharePermission)}
+                            disabled={submitting}
+                            className="flex-1 bg-gray-900/60 border border-gray-700/60 rounded-xl px-3 py-2.5 text-sm text-gray-100 focus:outline-none focus:border-sky-500/60"
+                        >
+                            <option value="read">Read — view data only</option>
+                            <option value="edit">Edit — also control & automate</option>
+                        </select>
+                        <button
+                            onClick={handleShare}
+                            disabled={submitting}
+                            className="flex items-center gap-1.5 px-4 py-2.5 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 text-white text-sm font-medium rounded-xl transition-all whitespace-nowrap"
+                        >
+                            <UserPlusIcon className="h-4 w-4" />
+                            {submitting ? 'Sharing…' : 'Share'}
+                        </button>
+                    </div>
+                    {error && <p className="text-xs text-red-400">{error}</p>}
+                </div>
+
+                <div className="mt-4 border-t border-gray-700/40 pt-3">
+                    <p className="text-xs font-medium text-gray-400 mb-2">Shared with</p>
+                    {loading ? (
+                        <p className="text-xs text-gray-500">Loading…</p>
+                    ) : shares.length === 0 ? (
+                        <p className="text-xs text-gray-500">Not shared with anyone yet.</p>
+                    ) : (
+                        <ul className="space-y-2">
+                            {shares.map(s => {
+                                const who = `${s.firstName} ${s.lastName}`.trim() || s.email;
+                                return (
+                                    <li key={s.userId} className="flex items-center justify-between gap-2 bg-gray-900/40 border border-gray-700/30 rounded-xl px-3 py-2">
+                                        <div className="min-w-0">
+                                            <p className="text-sm text-gray-200 truncate">{who}</p>
+                                            <p className="text-xs text-gray-500 truncate">{s.email}</p>
+                                        </div>
+                                        <div className="flex items-center gap-2 flex-shrink-0">
+                                            <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded-full border ${s.permission === 'edit' ? 'bg-sky-500/15 text-sky-300 border-sky-500/30' : 'bg-gray-600/20 text-gray-300 border-gray-600/40'}`}>
+                                                {s.permission === 'edit' ? 'Edit' : 'Read'}
+                                            </span>
+                                            <button
+                                                onClick={() => handleRevoke(s.userId, who)}
+                                                disabled={revokingId === s.userId}
+                                                className="p-1 rounded-lg text-gray-600 hover:text-red-400 hover:bg-gray-700/60 transition-all disabled:opacity-50"
+                                                aria-label={`Stop sharing with ${who}`}
+                                                title="Stop sharing"
+                                            >
+                                                <XMarkIcon className="h-3.5 w-3.5" />
+                                            </button>
+                                        </div>
+                                    </li>
+                                );
+                            })}
+                        </ul>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default ShareDeviceModal;

--- a/src/services/sensorService.ts
+++ b/src/services/sensorService.ts
@@ -13,7 +13,29 @@ export interface Sensor {
     parentName: string;
     /** True when the owner has turned this sensor off / it was auto-suspended for being over quota. Its data reads are blocked. */
     suspended?: boolean;
+    /** The caller's relationship to this sensor. Absent (older API) is treated as 'owner'. */
+    access?: SensorAccess;
 }
+
+/** What the caller may do with a sensor: full owner, editor, or read-only viewer. */
+export type SensorAccess = 'owner' | 'edit' | 'read';
+
+/** A share tier when sharing a sensor with another user. */
+export type SharePermission = 'read' | 'edit';
+
+/** A recipient of a shared sensor (GET /sensors/{id}/shares). */
+export interface SensorShare {
+    userId: string;
+    email: string;
+    firstName: string;
+    lastName: string;
+    permission: SharePermission;
+    sharedAt: string;
+}
+
+// The API serializes the SharePermission enum as an integer (Read=0, Edit=1).
+const permissionToApi = (p: SharePermission): number => (p === 'edit' ? 1 : 0);
+const permissionFromApi = (n: number): SharePermission => (n === 1 ? 'edit' : 'read');
 
 export interface SensorData {
     id: number;
@@ -193,6 +215,36 @@ const SensorService = {
             return response.data;
         } catch (error: unknown) {
             throw new Error(formatApiError(error, 'Failed to remove sensor'));
+        }
+    },
+
+    async getSensorShares(id: number): Promise<SensorShare[]> {
+        try {
+            const response = await axiosInstance.get<Array<Omit<SensorShare, 'permission'> & { permission: number }>>(`/sensors/${id}/shares`);
+            return response.data.map(s => ({ ...s, permission: permissionFromApi(s.permission) }));
+        } catch (error: unknown) {
+            throw new Error(formatApiError(error, 'Failed to load shares'));
+        }
+    },
+
+    async shareSensor(id: number, email: string, permission: SharePermission): Promise<{ message: string }> {
+        try {
+            const response = await axiosInstance.post<{ message: string }>(`/sensors/${id}/share`, {
+                email,
+                permission: permissionToApi(permission),
+            });
+            return response.data;
+        } catch (error: unknown) {
+            throw new Error(formatApiError(error, 'Failed to share sensor'));
+        }
+    },
+
+    async revokeSensorShare(id: number, userId: string): Promise<{ message: string }> {
+        try {
+            const response = await axiosInstance.delete<{ message: string }>(`/sensors/${id}/share/${userId}`);
+            return response.data;
+        } catch (error: unknown) {
+            throw new Error(formatApiError(error, 'Failed to revoke share'));
         }
     },
 

--- a/src/services/sensorService.ts
+++ b/src/services/sensorService.ts
@@ -33,9 +33,10 @@ export interface SensorShare {
     sharedAt: string;
 }
 
-// The API serializes the SharePermission enum as an integer (Read=0, Edit=1).
-const permissionToApi = (p: SharePermission): number => (p === 'edit' ? 1 : 0);
-const permissionFromApi = (n: number): SharePermission => (n === 1 ? 'edit' : 'read');
+// The API serializes the SharePermission enum as an integer (Read=0, Edit=1). Exported so switchService
+// reuses the same mapping (sockets share the device-sharing contract).
+export const permissionToApi = (p: SharePermission): number => (p === 'edit' ? 1 : 0);
+export const permissionFromApi = (n: number): SharePermission => (n === 1 ? 'edit' : 'read');
 
 export interface SensorData {
     id: number;

--- a/src/services/switchService.ts
+++ b/src/services/switchService.ts
@@ -1,5 +1,12 @@
 import axiosInstance from '@/services/axiosInstance';
 import { formatApiError } from '@/lib/errorMessages';
+import {
+    SensorAccess,
+    SensorShare,
+    SharePermission,
+    permissionFromApi,
+    permissionToApi,
+} from '@/services/sensorService';
 
 export interface Switch {
     id: number;
@@ -8,6 +15,8 @@ export interface Switch {
     role: string;
     customName?: string;
     registrationCode?: string;
+    /** The caller's relationship to this switch. Absent (older API) is treated as 'owner'. */
+    access?: SensorAccess;
 }
 
 export interface SwitchData {
@@ -103,6 +112,36 @@ const SwitchService = {
             await axiosInstance.delete(`/switches/${switchId}/claim`);
         } catch (error: unknown) {
             throw new Error(formatApiError(error, 'Failed to unclaim socket'));
+        }
+    },
+
+    async getSwitchShares(switchId: number): Promise<SensorShare[]> {
+        try {
+            const response = await axiosInstance.get<Array<Omit<SensorShare, 'permission'> & { permission: number }>>(`/switches/${switchId}/shares`);
+            return response.data.map(s => ({ ...s, permission: permissionFromApi(s.permission) }));
+        } catch (error: unknown) {
+            throw new Error(formatApiError(error, 'Failed to load shares'));
+        }
+    },
+
+    async shareSwitch(switchId: number, email: string, permission: SharePermission): Promise<{ message: string }> {
+        try {
+            const response = await axiosInstance.post<{ message: string }>(`/switches/${switchId}/share`, {
+                email,
+                permission: permissionToApi(permission),
+            });
+            return response.data;
+        } catch (error: unknown) {
+            throw new Error(formatApiError(error, 'Failed to share socket'));
+        }
+    },
+
+    async revokeSwitchShare(switchId: number, userId: string): Promise<{ message: string }> {
+        try {
+            const response = await axiosInstance.delete<{ message: string }>(`/switches/${switchId}/share/${userId}`);
+            return response.data;
+        } catch (error: unknown) {
+            throw new Error(formatApiError(error, 'Failed to revoke share'));
         }
     }
 };

--- a/src/tests/services/sensorService.test.ts
+++ b/src/tests/services/sensorService.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import SensorService from '@/services/sensorService'
+
+vi.mock('@/services/axiosInstance', () => ({
+    default: { get: vi.fn(), post: vi.fn(), delete: vi.fn() },
+}))
+
+import axiosInstance from '@/services/axiosInstance'
+
+const mockGet = axiosInstance.get as ReturnType<typeof vi.fn>
+const mockPost = axiosInstance.post as ReturnType<typeof vi.fn>
+const mockDelete = axiosInstance.delete as ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+    vi.clearAllMocks()
+})
+
+describe('SensorService sharing', () => {
+    it('maps the API integer permission to a string in getSensorShares', async () => {
+        mockGet.mockResolvedValueOnce({
+            data: [
+                { userId: 'u1', email: 'a@x', firstName: 'A', lastName: 'B', permission: 1, sharedAt: '2026-01-01' },
+                { userId: 'u2', email: 'c@x', firstName: 'C', lastName: 'D', permission: 0, sharedAt: '2026-01-02' },
+            ],
+        })
+
+        const shares = await SensorService.getSensorShares(5)
+
+        expect(mockGet).toHaveBeenCalledWith('/sensors/5/shares')
+        expect(shares[0].permission).toBe('edit')
+        expect(shares[1].permission).toBe('read')
+    })
+
+    it('sends the integer permission when sharing (edit=1)', async () => {
+        mockPost.mockResolvedValueOnce({ data: { message: 'ok' } })
+        await SensorService.shareSensor(5, 'a@x', 'edit')
+        expect(mockPost).toHaveBeenCalledWith('/sensors/5/share', { email: 'a@x', permission: 1 })
+    })
+
+    it('sends the integer permission when sharing (read=0)', async () => {
+        mockPost.mockResolvedValueOnce({ data: { message: 'ok' } })
+        await SensorService.shareSensor(5, 'a@x', 'read')
+        expect(mockPost).toHaveBeenCalledWith('/sensors/5/share', { email: 'a@x', permission: 0 })
+    })
+
+    it('revokeSensorShare deletes the share by user id', async () => {
+        mockDelete.mockResolvedValueOnce({ data: { message: 'ok' } })
+        await SensorService.revokeSensorShare(5, 'u1')
+        expect(mockDelete).toHaveBeenCalledWith('/sensors/5/share/u1')
+    })
+})

--- a/src/tests/services/switchService.test.ts
+++ b/src/tests/services/switchService.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import SwitchService from '@/services/switchService'
+
+vi.mock('@/services/axiosInstance', () => ({
+    default: { get: vi.fn(), post: vi.fn(), delete: vi.fn() },
+}))
+
+import axiosInstance from '@/services/axiosInstance'
+
+const mockGet = axiosInstance.get as ReturnType<typeof vi.fn>
+const mockPost = axiosInstance.post as ReturnType<typeof vi.fn>
+const mockDelete = axiosInstance.delete as ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+    vi.clearAllMocks()
+})
+
+describe('SwitchService sharing', () => {
+    it('maps the API integer permission to a string in getSwitchShares', async () => {
+        mockGet.mockResolvedValueOnce({
+            data: [
+                { userId: 'u1', email: 'a@x', firstName: 'A', lastName: 'B', permission: 1, sharedAt: '2026-01-01' },
+                { userId: 'u2', email: 'c@x', firstName: 'C', lastName: 'D', permission: 0, sharedAt: '2026-01-02' },
+            ],
+        })
+
+        const shares = await SwitchService.getSwitchShares(7)
+
+        expect(mockGet).toHaveBeenCalledWith('/switches/7/shares')
+        expect(shares[0].permission).toBe('edit')
+        expect(shares[1].permission).toBe('read')
+    })
+
+    it('sends the integer permission when sharing (edit=1)', async () => {
+        mockPost.mockResolvedValueOnce({ data: { message: 'ok' } })
+        await SwitchService.shareSwitch(7, 'a@x', 'edit')
+        expect(mockPost).toHaveBeenCalledWith('/switches/7/share', { email: 'a@x', permission: 1 })
+    })
+
+    it('sends the integer permission when sharing (read=0)', async () => {
+        mockPost.mockResolvedValueOnce({ data: { message: 'ok' } })
+        await SwitchService.shareSwitch(7, 'a@x', 'read')
+        expect(mockPost).toHaveBeenCalledWith('/switches/7/share', { email: 'a@x', permission: 0 })
+    })
+
+    it('revokeSwitchShare deletes the share by user id', async () => {
+        mockDelete.mockResolvedValueOnce({ data: { message: 'ok' } })
+        await SwitchService.revokeSwitchShare(7, 'u1')
+        expect(mockDelete).toHaveBeenCalledWith('/switches/7/share/u1')
+    })
+})


### PR DESCRIPTION
## Summary

Frontend for **device sharing** (sensors + sockets). Pairs with garge-api **#267** — needs that deployed for the `/sensors|switches/{id}/share[s]` endpoints and the `access` field on `SensorDto`/`SwitchDto`.

- Owners get a **Share** action on each sensor and socket → a modal to:
  - invite another Garge user by **email** at **Read** or **Edit**,
  - see who it's shared with, and **revoke**.
- Devices shared *with* the caller show a **"Shared · read/edit"** badge.
- Non-owners see only what they're allowed: read controls; their remove action is **"Leave"** (removes just themselves), not "Remove from account". Owner-only controls (turn on/off, share) are hidden on shared devices.
- Driven by `access` (`owner`/`edit`/`read`) and three optional config hooks on `DeviceManagePage`, shared by both the sensors and sockets pages.
- "Socket" wording kept in the UI (backend calls it "switch").

The share-tier enum is serialized by the API as an integer; the mapping (`'read'|'edit'` ↔ `0|1`) lives once in `sensorService` and is reused by `switchService`.

## Tests
- `sensorService.test.ts` / `switchService.test.ts`: `get*Shares` maps int→string permission; `share*` sends the integer (read=0, edit=1); `revoke*Share` deletes by user id.
- 167 unit tests pass; `tsc --noEmit` clean.

## Depends on
garge-api #267 (share endpoints + `access` fields).
