### PR TITLE
chore: dedup components, fix prop mutation, route HTTP through services

### DIFF
--- a/src/app/(protected)/admin/page.tsx
+++ b/src/app/(protected)/admin/page.tsx
@@ -417,14 +417,12 @@ export default function AdminPage() {
                                 {appSettings === null ? (
                                     <div className="w-10 h-6 bg-gray-700 rounded-full animate-pulse shrink-0" />
                                 ) : (
-                                    <button
-                                        onClick={() => handleToggleAppSetting('cookieBannerEnabled', !appSettings.cookieBannerEnabled)}
+                                    <ToggleSwitch
+                                        checked={appSettings.cookieBannerEnabled}
+                                        onChange={() => handleToggleAppSetting('cookieBannerEnabled', !appSettings.cookieBannerEnabled)}
                                         disabled={appSettingsLoading}
-                                        aria-label="Toggle cookie banner"
-                                        className={`relative shrink-0 w-10 h-6 rounded-full transition-colors disabled:opacity-50 ${appSettings.cookieBannerEnabled ? 'bg-sky-600' : 'bg-gray-600'}`}
-                                    >
-                                        <span className={`absolute top-1 left-0 w-4 h-4 bg-white rounded-full shadow transition-transform ${appSettings.cookieBannerEnabled ? 'translate-x-5' : 'translate-x-1'}`} />
-                                    </button>
+                                        ariaLabel="Toggle cookie banner"
+                                    />
                                 )}
                             </div>
                             <div className="flex items-center justify-between gap-4 bg-gray-900/50 border border-gray-700/40 rounded-xl p-4">
@@ -435,14 +433,12 @@ export default function AdminPage() {
                                 {appSettings === null ? (
                                     <div className="w-10 h-6 bg-gray-700 rounded-full animate-pulse shrink-0" />
                                 ) : (
-                                    <button
-                                        onClick={() => handleToggleAppSetting('vatEnabled', !appSettings.vatEnabled)}
+                                    <ToggleSwitch
+                                        checked={appSettings.vatEnabled}
+                                        onChange={() => handleToggleAppSetting('vatEnabled', !appSettings.vatEnabled)}
                                         disabled={appSettingsLoading}
-                                        aria-label="Toggle VAT"
-                                        className={`relative shrink-0 w-10 h-6 rounded-full transition-colors disabled:opacity-50 ${appSettings.vatEnabled ? 'bg-sky-600' : 'bg-gray-600'}`}
-                                    >
-                                        <span className={`absolute top-1 left-0 w-4 h-4 bg-white rounded-full shadow transition-transform ${appSettings.vatEnabled ? 'translate-x-5' : 'translate-x-1'}`} />
-                                    </button>
+                                        ariaLabel="Toggle VAT"
+                                    />
                                 )}
                             </div>
                             <div className="flex items-center justify-between gap-4 bg-gray-900/50 border border-amber-700/30 rounded-xl p-4">
@@ -453,14 +449,12 @@ export default function AdminPage() {
                                 {appSettings === null ? (
                                     <div className="w-10 h-6 bg-gray-700 rounded-full animate-pulse shrink-0" />
                                 ) : (
-                                    <button
-                                        onClick={() => handleToggleAppSetting('vippsTestMode', !appSettings.vippsTestMode)}
+                                    <ToggleSwitch
+                                        checked={appSettings.vippsTestMode}
+                                        onChange={() => handleToggleAppSetting('vippsTestMode', !appSettings.vippsTestMode)}
                                         disabled={appSettingsLoading}
-                                        aria-label="Toggle Vipps test mode"
-                                        className={`relative shrink-0 w-10 h-6 rounded-full transition-colors disabled:opacity-50 ${appSettings.vippsTestMode ? 'bg-amber-500' : 'bg-gray-600'}`}
-                                    >
-                                        <span className={`absolute top-1 left-0 w-4 h-4 bg-white rounded-full shadow transition-transform ${appSettings.vippsTestMode ? 'translate-x-5' : 'translate-x-1'}`} />
-                                    </button>
+                                        ariaLabel="Toggle Vipps test mode"
+                                    />
                                 )}
                             </div>
                         </div>

--- a/src/app/(protected)/automations/page.tsx
+++ b/src/app/(protected)/automations/page.tsx
@@ -11,8 +11,10 @@ import { UpdateAutomationRuleDto } from '@/dto/Automation/UpdateAutomationRuleDt
 import { unitForType } from '@/lib/typeUtils';
 import { formatDateTime } from '@/lib/dateUtils';
 import { sortAutomationRules } from '@/lib/automationSort';
-import { AxiosError } from 'axios';
+import { formatApiError } from '@/lib/errorMessages';
 import ConfirmModal from '@/components/ConfirmModal';
+import LoadingDots from '@/components/LoadingDots';
+import ToggleSwitch from '@/components/ToggleSwitch';
 import {
     PlusIcon,
     XMarkIcon,
@@ -110,27 +112,6 @@ const NumberInput: React.FC<React.InputHTMLAttributes<HTMLInputElement>> = ({ cl
     />
 );
 
-const LoadingDots = () => (
-    <div className="h-60 flex items-center justify-center">
-        <div className="flex gap-2">
-            <span className="w-2.5 h-2.5 rounded-full bg-sky-500 animate-bounce [animation-delay:0ms]" />
-            <span className="w-2.5 h-2.5 rounded-full bg-sky-500 animate-bounce [animation-delay:150ms]" />
-            <span className="w-2.5 h-2.5 rounded-full bg-sky-500 animate-bounce [animation-delay:300ms]" />
-        </div>
-    </div>
-);
-
-const Toggle: React.FC<{ enabled: boolean; onClick: () => void; title?: string }> = ({ enabled, onClick, title }) => (
-    <button
-        type="button"
-        title={title}
-        onClick={onClick}
-        className={`relative inline-flex h-7 w-12 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2 focus:ring-offset-gray-900 ${enabled ? 'bg-sky-600' : 'bg-gray-600'}`}
-    >
-        <span className={`pointer-events-none inline-block h-6 w-6 transform rounded-full bg-white shadow-lg ring-0 transition-transform duration-200 ease-in-out ${enabled ? 'translate-x-5' : 'translate-x-0'}`} />
-    </button>
-);
-
 // ── Electricity price sub-form ────────────────────────────────────────────────
 
 interface PriceConditionFields {
@@ -176,7 +157,11 @@ const PriceConditionForm: React.FC<PriceConditionFormProps> = ({ value, defaultA
                     <p className="text-sm font-medium text-gray-300">Electricity price condition</p>
                     <p className="text-xs text-gray-500 mt-0.5">Also check current electricity price</p>
                 </div>
-                <Toggle enabled={enabled} onClick={toggle} />
+                <ToggleSwitch
+                    checked={enabled}
+                    onChange={toggle}
+                    ariaLabel={enabled ? 'Disable electricity price condition' : 'Enable electricity price condition'}
+                />
             </div>
             {enabled && (
                 <div className="mt-3 p-3 bg-amber-500/5 border border-amber-500/20 rounded-lg space-y-3">
@@ -284,9 +269,7 @@ const AutomationsPage: React.FC = () => {
     };
 
     const handleError = (err: unknown, fallbackMsg?: string) => {
-        if (err instanceof AxiosError)  setError(err.response?.data?.message || fallbackMsg || 'A network error occurred');
-        else if (err instanceof Error)  setError(err.message);
-        else                            setError(fallbackMsg || 'An unknown error occurred');
+        setError(formatApiError(err, fallbackMsg || 'A network error occurred'));
     };
 
     const handleCreate = async (e: React.FormEvent) => {
@@ -438,9 +421,10 @@ const AutomationsPage: React.FC = () => {
                             <p className="text-sm font-medium text-gray-300">Auto-off timer</p>
                             <p className="text-xs text-gray-500 mt-0.5">Automatically turn off after a set duration</p>
                         </div>
-                        <Toggle
-                            enabled={!!form.timerDurationHours}
-                            onClick={() => setForm({ ...form, timerDurationHours: form.timerDurationHours ? undefined : 2 })}
+                        <ToggleSwitch
+                            checked={!!form.timerDurationHours}
+                            onChange={() => setForm({ ...form, timerDurationHours: form.timerDurationHours ? undefined : 2 })}
+                            ariaLabel={form.timerDurationHours ? 'Disable auto-off timer' : 'Enable auto-off timer'}
                         />
                     </div>
                     {form.timerDurationHours != null && (
@@ -529,9 +513,10 @@ const AutomationsPage: React.FC = () => {
                             <p className="text-sm font-medium text-gray-300">Auto-off timer</p>
                             <p className="text-xs text-gray-500 mt-0.5">Automatically turn off after a set duration</p>
                         </div>
-                        <Toggle
-                            enabled={!!editForm.timerDurationHours}
-                            onClick={() => setEditForm({ ...editForm, timerDurationHours: editForm.timerDurationHours ? undefined : 2 })}
+                        <ToggleSwitch
+                            checked={!!editForm.timerDurationHours}
+                            onChange={() => setEditForm({ ...editForm, timerDurationHours: editForm.timerDurationHours ? undefined : 2 })}
+                            ariaLabel={editForm.timerDurationHours ? 'Disable auto-off timer' : 'Enable auto-off timer'}
                         />
                     </div>
                     {editForm.timerDurationHours != null && (
@@ -645,10 +630,10 @@ const AutomationsPage: React.FC = () => {
                             {isOn ? 'Turn on rule' : 'Turn off rule'}
                         </span>
                     </div>
-                    <Toggle
-                        enabled={rule.isEnabled}
-                        onClick={() => handleToggleEnabled(rule)}
-                        title={rule.isEnabled ? 'Disable rule' : 'Enable rule'}
+                    <ToggleSwitch
+                        checked={rule.isEnabled}
+                        onChange={() => handleToggleEnabled(rule)}
+                        ariaLabel={rule.isEnabled ? 'Disable rule' : 'Enable rule'}
                     />
                 </div>
 
@@ -754,7 +739,7 @@ const AutomationsPage: React.FC = () => {
 
             {/* Content */}
             {loading ? (
-                <LoadingDots />
+                <LoadingDots height="h-60" />
             ) : rules.length === 0 ? (
                 emptyState
             ) : (

--- a/src/app/(protected)/profile/page.tsx
+++ b/src/app/(protected)/profile/page.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
 import { useSession, signOut } from 'next-auth/react';
 import UserService from '@/services/userService';
 import { UserDTO } from '@/dto/UserDTO';
@@ -23,8 +22,6 @@ import Link from 'next/link';
 
 const Profile: React.FC = () => {
     const { status } = useSession();
-    const router = useRouter();
-    const isAuthenticated = status === 'authenticated';
 
     const [user, setUser] = useState<UserDTO | null>(null);
     const [priceZone, setPriceZone] = useState<string>('NO2');
@@ -61,13 +58,14 @@ const Profile: React.FC = () => {
     const { canClaim, loading: eligibilityLoading, refresh: refreshEligibility, capacity, used, bypass } = useCanClaimDevice();
 
     useEffect(() => {
-        if (!isAuthenticated) { router.push('/login'); return; }
         UserService.getUserProfile().then(u => {
             setUser(u);
             setPriceZone(u.priceZone ?? 'NO2');
             setOfflineThreshold(u.offlineAlertThresholdHours > 0 ? u.offlineAlertThresholdHours : 4);
             if (u.id) UserService.getDataRetention(u.id).then(r => setRetentionKeep(!r.optOut)).catch(() => { });
-        }).catch(console.error).finally(() => setProfileLoading(false));
+        }).catch((err: unknown) => {
+            toast.error(err instanceof Error ? err.message : 'Failed to load your profile.');
+        }).finally(() => setProfileLoading(false));
         if (isPushSupported()) {
             setPushPermission(Notification.permission);
             isPushSubscribed()
@@ -76,8 +74,7 @@ const Profile: React.FC = () => {
         }
         SensorService.getAllSensors().then(s => setSensorCount(s.length)).catch(() => setSensorCount(0));
         SwitchService.getAllSwitches().then(s => setSocketCount(s.length)).catch(() => setSocketCount(0));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isAuthenticated, router]);
+    }, []);
 
     useEffect(() => {
         if (countdown <= 0) { setIsButtonDisabled(false); return; }
@@ -170,7 +167,9 @@ const Profile: React.FC = () => {
         setPriceZoneSaving(true);
         try {
             await UserService.updatePreferences(user.id, { priceZone: zone });
-        } catch { /* silent fail */ }
+        } catch (e: unknown) {
+            toast.error(e instanceof Error ? e.message : 'Failed to save price zone.');
+        }
         finally { setPriceZoneSaving(false); }
     };
 
@@ -221,7 +220,9 @@ const Profile: React.FC = () => {
         setThresholdSaving(true);
         try {
             await UserService.updatePreferences(user.id, { priceZone, offlineAlertThresholdHours: clamped });
-        } catch { /* silent */ }
+        } catch (e: unknown) {
+            toast.error(e instanceof Error ? e.message : 'Failed to save alert threshold.');
+        }
         finally { setThresholdSaving(false); }
     };
 

--- a/src/app/DeviceDashboard.tsx
+++ b/src/app/DeviceDashboard.tsx
@@ -3,7 +3,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { MagnifyingGlassIcon, ChevronDownIcon, PlusIcon, PencilIcon, TrashIcon, XMarkIcon, SignalIcon } from '@heroicons/react/24/outline';
 import { TYPE_CONFIG, DEFAULT_TYPE } from '@/lib/typeConfig';
-import { formatSensorValue } from '@/lib/typeUtils';
+import { formatSensorValue, typeEmoji } from '@/lib/typeUtils';
 import LoadingDots from '@/components/LoadingDots';
 import SensorService, { Sensor, BatteryHealthData } from '@/services/sensorService';
 import SwitchService, { Switch } from '@/services/switchService';
@@ -171,6 +171,8 @@ const DeviceDashboard: React.FC = () => {
     const [sort, setSort]             = useLocalStorage<SortKey>('device-sort', 'name-asc');
     const [typeFilter, setTypeFilter] = useLocalStorage<string>('device-type-filter', 'all');
     const [selected, setSelected]     = useState<UnifiedDevice | null>(null);
+    const selectedRef = useRef<UnifiedDevice | null>(null);
+    selectedRef.current = selected;
     const [wizardOpen, setWizardOpen]   = useState(false);
     const [wizardStep, setWizardStep]   = useState(0);
     const [wizardGroupId, setWizardGroupId] = useState<number | undefined>(undefined);
@@ -338,6 +340,19 @@ const DeviceDashboard: React.FC = () => {
             debouncedReload();
         },
     });
+
+    const handleRename = useCallback((id: number, name: string) => {
+        // The drawer only renames the currently selected device. Match the
+        // devices list on that device's kind + id to avoid colliding with a
+        // sensor and socket that happen to share the same numeric id.
+        const kind = selectedRef.current?.id === id ? selectedRef.current.kind : undefined;
+        setDevices(prev => prev.map(d =>
+            d.id === id && (kind === undefined || d.kind === kind)
+                ? { ...d, displayName: name }
+                : d
+        ));
+        setSelected(prev => (prev && prev.id === id ? { ...prev, displayName: name } : prev));
+    }, []);
 
     const filterPills = useMemo(() => {
         const types = [...new Set(devices.map(d => d.type))].sort();
@@ -517,12 +532,7 @@ const DeviceDashboard: React.FC = () => {
                                                         className="flex flex-col items-start bg-gray-900/50 border border-gray-700/30 rounded-xl px-2.5 py-2 hover:bg-gray-700/40 hover:border-gray-600/50 transition-all"
                                                     >
                                                         <div className="flex items-center gap-1 leading-tight">
-                                                            <span className="text-xs">{
-                                                                d.type === 'temperature' ? '🌡️' :
-                                                                d.type === 'humidity'    ? '💧' :
-                                                                d.type === 'voltage'     ? '⚡' :
-                                                                d.type === 'socket'      ? '🔌' : '📡'
-                                                            }</span>
+                                                            <span className="text-xs">{typeEmoji(d.type)}</span>
                                                             <span className="text-sm font-bold text-gray-100 tabular-nums">{formatValue(d)}</span>
                                                         </div>
                                                         <span className="text-[10px] text-gray-500 leading-tight mt-0.5 truncate max-w-[80px]">{d.displayName}</span>
@@ -638,7 +648,11 @@ const DeviceDashboard: React.FC = () => {
             </div>
 
             {selected && (
-                <DeviceDrawer device={selected} onClose={() => setSelected(null)} />
+                <DeviceDrawer
+                    device={selected}
+                    onClose={() => setSelected(null)}
+                    onRename={handleRename}
+                />
             )}
 
             {deleteGroup && (() => {

--- a/src/app/DeviceDrawer.tsx
+++ b/src/app/DeviceDrawer.tsx
@@ -22,6 +22,8 @@ const TimeSeriesChart = dynamic(() => import('@/components/TimeSeriesChart'), { 
 interface DeviceDrawerProps {
     device: UnifiedDevice;
     onClose: () => void;
+    /** Notifies the parent that the device was renamed so it can update its state. */
+    onRename: (id: number, name: string) => void;
 }
 
 function InfoLabel({ children, tooltip }: { children: React.ReactNode; tooltip: string }) {
@@ -139,7 +141,7 @@ const TimelineBar: React.FC<{ segments: Segment[]; rangeStart: number; rangeEnd:
 
 // ─────────────────────────────────────────────────────────────────────────────
 
-const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose }) => {
+const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose, onRename }) => {
     const [chartData, setChartData] = useState<{ x: number; y: number }[]>([]);
     const [loadingChart, setLoadingChart] = useState(false);
     const [activeRange, setActiveRange] = useState<RangeIndex>(0);
@@ -252,15 +254,16 @@ const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose }) => {
         ? [...switchEvents].sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())[0]
         : null;
     const handleSaveName = async () => {
-        if (!editName.trim()) return;
+        const trimmed = editName.trim();
+        if (!trimmed) return;
         setSavingName(true);
         try {
             if (device.kind === 'sensor') {
-                await SensorService.updateCustomName(device.id, editName.trim());
+                await SensorService.updateCustomName(device.id, trimmed);
             } else {
-                await SwitchService.updateCustomName(device.id, editName.trim());
+                await SwitchService.updateCustomName(device.id, trimmed);
             }
-            device.displayName = editName.trim();
+            onRename(device.id, trimmed);
             setEditingName(false);
             toast.success(device.kind === 'sensor' ? 'Sensor renamed' : 'Socket renamed');
         } catch {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -58,27 +58,6 @@ body {
     transform: translateY(0);
 }
 
-/* ── Buttons ────────────────────────────────────────────────────────────────── */
-.gargeBtnActive {
-    @apply bg-sky-600 hover:bg-sky-700 active:bg-sky-800 text-gray-200 px-4 py-2 rounded;
-}
-
-.gargeBtnDisabled {
-    @apply bg-gray-800 text-gray-700 px-4 py-2 rounded;
-}
-
-.gargeBtnWarning {
-    @apply bg-rose-600 hover:bg-rose-700 active:bg-rose-800 text-gray-200 px-4 py-2 rounded;
-}
-
-.gargeBtnSmall {
-    @apply px-2 py-1 text-sm;
-}
-
-.gargeDropdown {
-    @apply block w-full p-2 border rounded bg-gray-800 text-gray-200;
-}
-
 /* react-datepicker dark theme */
 .dark .react-datepicker {
     background-color: #1f2937;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,23 +1,13 @@
 "use client"
 
-import React from 'react';
 import { useSession } from 'next-auth/react';
 import DeviceDashboard from './DeviceDashboard';
 import MarketingPage from './MarketingPage';
-
-const LoadingDots: React.FC = () => (
-    <div className="h-64 flex items-center justify-center">
-        <div className="flex gap-1.5">
-            <span className="w-2 h-2 rounded-full bg-sky-500 animate-bounce [animation-delay:0ms]" />
-            <span className="w-2 h-2 rounded-full bg-sky-500 animate-bounce [animation-delay:150ms]" />
-            <span className="w-2 h-2 rounded-full bg-sky-500 animate-bounce [animation-delay:300ms]" />
-        </div>
-    </div>
-);
+import LoadingDots from '@/components/LoadingDots';
 
 export default function HomePage() {
     const { status } = useSession();
-    if (status === 'loading')       return <LoadingDots />;
+    if (status === 'loading')       return <LoadingDots height="h-64" />;
     if (status === 'authenticated') return <DeviceDashboard />;
     return <MarketingPage />;
 }

--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
+import { getPublicAppSettings } from '@/services/appSettingsService';
 
 const CONSENT_VERSION = 'v1';
 const STORAGE_KEY = 'cookie-consent';
@@ -13,15 +14,11 @@ export default function CookieBanner() {
 
     useEffect(() => {
         async function init() {
-            try {
-                const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/admin/settings`);
-                if (res.ok) {
-                    const settings = await res.json();
-                    if (!settings.cookieBannerEnabled) return;
-                }
-            } catch {
-                // Backend unreachable; proceed to the consent check.
-            }
+            // When the backend is reachable and the banner is disabled, skip it.
+            // If settings are null (backend unreachable), fall through to the
+            // consent check so the banner still shows.
+            const settings = await getPublicAppSettings();
+            if (settings && !settings.cookieBannerEnabled) return;
 
             try {
                 const raw = localStorage.getItem(STORAGE_KEY);

--- a/src/components/DeviceManagePage.tsx
+++ b/src/components/DeviceManagePage.tsx
@@ -1,8 +1,6 @@
 "use client"
 
 import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
-import { useSession } from 'next-auth/react';
 import { PencilIcon, CheckIcon, XMarkIcon, TrashIcon, ClipboardDocumentIcon, ArrowLeftIcon, PowerIcon, ShareIcon } from '@heroicons/react/24/outline';
 import ConfirmModal from '@/components/ConfirmModal';
 import LoadingDots from '@/components/LoadingDots';
@@ -51,10 +49,6 @@ interface Props<T extends DeviceItem> {
 }
 
 export function DeviceManagePage<T extends DeviceItem>({ config }: Props<T>) {
-    const { status } = useSession();
-    const router = useRouter();
-    const isAuthenticated = status === 'authenticated';
-
     const [items, setItems] = useState<T[]>([]);
     const [loading, setLoading] = useState(true);
     const [claimCode, setClaimCode] = useState('');
@@ -82,11 +76,12 @@ export function DeviceManagePage<T extends DeviceItem>({ config }: Props<T>) {
     };
 
     useEffect(() => {
-        if (!isAuthenticated) { router.push('/login'); return; }
         setLoading(true);
-        refresh().catch(console.error).finally(() => setLoading(false));
+        refresh()
+            .catch((err: unknown) => toast.error(err instanceof Error ? err.message : `Failed to load ${title.toLowerCase()}.`))
+            .finally(() => setLoading(false));
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [isAuthenticated, router]);
+    }, []);
 
     const handleClaim = async () => {
         if (!claimCode.trim()) { setClaimMessage('Please enter a device code.'); setClaimError(true); return; }

--- a/src/hooks/useDeviceStream.ts
+++ b/src/hooks/useDeviceStream.ts
@@ -27,7 +27,6 @@ interface Handlers {
     onSwitch?: (e: SwitchEvent) => void;
     onSensor?: (e: SensorEvent) => void;
     onDeviceCreated?: (e: DeviceCreatedEvent) => void;
-    onForceLogout?: () => void;
 }
 
 /**
@@ -85,9 +84,6 @@ export function useDeviceStream(handlers: Handlers): void {
             });
             connection.on('device-created', (payload: DeviceCreatedEvent) => {
                 handlersRef.current.onDeviceCreated?.(payload);
-            });
-            connection.on('forceLogout', () => {
-                handlersRef.current.onForceLogout?.();
             });
 
             try {

--- a/src/lib/company.ts
+++ b/src/lib/company.ts
@@ -1,3 +1,5 @@
+import { getPublicAppSettings } from '@/services/appSettingsService';
+
 export const COMPANY = {
     name: 'Garge',
     legalName: 'Sjølyst Innovations',
@@ -14,16 +16,8 @@ export const COMPANY = {
  * from the admin settings page.
  */
 export async function fetchVatEnabled(): Promise<boolean> {
-    try {
-        const base = process.env.NEXT_PUBLIC_API_URL;
-        if (!base) return false;
-        const res = await fetch(`${base}/admin/settings`, { cache: 'no-store' });
-        if (!res.ok) return false;
-        const data = await res.json();
-        return Boolean(data?.vatEnabled);
-    } catch {
-        return false;
-    }
+    const settings = await getPublicAppSettings();
+    return Boolean(settings?.vatEnabled);
 }
 
 export function formatOrgNumber(orgNumber: string, vatEnabled: boolean) {

--- a/src/lib/typeUtils.ts
+++ b/src/lib/typeUtils.ts
@@ -17,6 +17,7 @@ export function typeEmoji(type: string): string {
     if (type === 'temperature') return '🌡️';
     if (type === 'humidity')    return '💧';
     if (type === 'voltage')     return '⚡';
+    if (type === 'socket')      return '🔌';
     if (type === 'unknown')     return '🔒';
     return '📡';
 }

--- a/src/services/appSettingsService.ts
+++ b/src/services/appSettingsService.ts
@@ -1,0 +1,26 @@
+import { AppSettings } from '@/services/adminService';
+
+/**
+ * Fetches the public AppSettings from garge-api's `/admin/settings` endpoint.
+ *
+ * This read is intentionally unauthenticated: the settings drive public-facing
+ * behaviour (cookie banner visibility, VAT suffix on invoices) that must render
+ * before a user signs in. A plain `fetch` is used rather than `axiosInstance`
+ * because no JWT is required, but the call still lives in `services/` per the
+ * architecture rule that all HTTP belongs here.
+ *
+ * Returns `null` when the backend is unreachable or the URL is unconfigured so
+ * callers can apply their own defaults.
+ */
+export async function getPublicAppSettings(): Promise<AppSettings | null> {
+    const base = process.env.NEXT_PUBLIC_API_URL;
+    if (!base) return null;
+
+    try {
+        const res = await fetch(`${base}/admin/settings`, { cache: 'no-store' });
+        if (!res.ok) return null;
+        return (await res.json()) as AppSettings;
+    } catch {
+        return null;
+    }
+}

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -65,11 +65,7 @@ const UserService = {
         }
 
         try {
-            const response = await axiosInstance.get<UserDTO>(`/users/${sub}/profile`, {
-                headers: {
-                    Authorization: `Bearer ${session.accessToken}`,
-                },
-            });
+            const response = await axiosInstance.get<UserDTO>(`/users/${sub}/profile`);
             return { ...response.data, id: sub };
         } catch (error: unknown) {
             throw new Error(formatApiError(error, 'Failed to fetch user profile'));

--- a/src/tests/lib/typeUtils.test.ts
+++ b/src/tests/lib/typeUtils.test.ts
@@ -20,6 +20,7 @@ describe('typeEmoji', () => {
     it('returns thermometer for temperature', () => expect(typeEmoji('temperature')).toBe('🌡️'))
     it('returns droplet for humidity', () => expect(typeEmoji('humidity')).toBe('💧'))
     it('returns bolt for voltage', () => expect(typeEmoji('voltage')).toBe('⚡'))
+    it('returns plug for socket', () => expect(typeEmoji('socket')).toBe('🔌'))
     it('returns lock for unknown', () => expect(typeEmoji('unknown')).toBe('🔒'))
     it('returns antenna for anything else', () => expect(typeEmoji('foobar')).toBe('📡'))
 })

--- a/src/tests/services/appSettingsService.test.ts
+++ b/src/tests/services/appSettingsService.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { getPublicAppSettings } from '@/services/appSettingsService'
+import type { AppSettings } from '@/services/adminService'
+
+const SETTINGS: AppSettings = {
+    cookieBannerEnabled: true,
+    vatEnabled: false,
+    vippsTestMode: true,
+}
+
+describe('getPublicAppSettings', () => {
+    const originalUrl = process.env.NEXT_PUBLIC_API_URL
+
+    beforeEach(() => {
+        process.env.NEXT_PUBLIC_API_URL = 'https://api.example.test/api'
+    })
+
+    afterEach(() => {
+        process.env.NEXT_PUBLIC_API_URL = originalUrl
+        vi.restoreAllMocks()
+        vi.unstubAllGlobals()
+    })
+
+    it('fetches and returns the parsed settings on success', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({
+            ok: true,
+            json: () => Promise.resolve(SETTINGS),
+        })
+        vi.stubGlobal('fetch', fetchMock)
+
+        const result = await getPublicAppSettings()
+
+        expect(result).toEqual(SETTINGS)
+        expect(fetchMock).toHaveBeenCalledWith(
+            'https://api.example.test/api/admin/settings',
+            { cache: 'no-store' },
+        )
+    })
+
+    it('returns null when the URL is not configured', async () => {
+        delete process.env.NEXT_PUBLIC_API_URL
+        const fetchMock = vi.fn()
+        vi.stubGlobal('fetch', fetchMock)
+
+        const result = await getPublicAppSettings()
+
+        expect(result).toBeNull()
+        expect(fetchMock).not.toHaveBeenCalled()
+    })
+
+    it('returns null on a non-ok response', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }))
+
+        expect(await getPublicAppSettings()).toBeNull()
+    })
+
+    it('returns null when fetch rejects (backend unreachable)', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')))
+
+        expect(await getPublicAppSettings()).toBeNull()
+    })
+})


### PR DESCRIPTION
## Summary

Safe high-value cleanup pass on the frontend.

- Remove duplicate `LoadingDots` and local `Toggle`; use shared `components/LoadingDots` and `ToggleSwitch`
- Delete dead CSS button/dropdown classes and the unused `onForceLogout` stream handler
- **Bug fix:** `DeviceDrawer` mutated a prop on rename; rename now bubbles via an `onRename` callback and updates `DeviceDashboard` state
- Move the `/admin/settings` fetch into a new `appSettingsService` so no component fetches directly
- Drop the redundant manual Authorization header in `userService.getUserProfile` (axiosInstance attaches it)
- Remove duplicate in-page auth guards (the protected layout is the sole gate)
- Surface `toast.error` on failures that were previously silent or console-only
- Route automation errors through `formatApiError`; add a `socket` case to `typeEmoji`

Build passes; 174 tests pass (new tests for `appSettingsService` and the `typeEmoji` socket case).