### PR TITLE
refactor: extract shared UI primitives and dedup forms

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -5,14 +5,13 @@ import { useRouter } from 'next/navigation';
 import { signIn, getSession } from 'next-auth/react';
 import Image from 'next/image';
 import Link from 'next/link';
-import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/outline';
 import { inputClass } from '@/components/TextInput';
+import PasswordInput from '@/components/PasswordInput';
 import Alert from '@/components/Alert';
 
 const Login: React.FC = () => {
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
-    const [showPassword, setShowPassword] = useState(false);
     const [apiMessage, setApiMessage] = useState('');
     const [loading, setLoading] = useState(false);
     const router = useRouter();
@@ -72,25 +71,13 @@ const Login: React.FC = () => {
 
                         <div>
                             <label htmlFor="password" className="block text-xs font-medium text-gray-400 mb-1.5">Password</label>
-                            <div className="relative">
-                                <input
-                                    id="password"
-                                    className={`${inputClass} pr-10`}
-                                    type={showPassword ? 'text' : 'password'}
-                                    placeholder="••••••••"
-                                    required
-                                    value={password}
-                                    onChange={(e) => setPassword(e.target.value)}
-                                />
-                                <button
-                                    type="button"
-                                    onClick={() => setShowPassword(v => !v)}
-                                    className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-300 transition-colors"
-                                    tabIndex={-1}
-                                >
-                                    {showPassword ? <EyeSlashIcon className="h-4 w-4" /> : <EyeIcon className="h-4 w-4" />}
-                                </button>
-                            </div>
+                            <PasswordInput
+                                id="password"
+                                placeholder="••••••••"
+                                required
+                                value={password}
+                                onChange={(e) => setPassword(e.target.value)}
+                            />
                         </div>
 
                         {apiMessage && (

--- a/src/app/(auth)/register/page.tsx
+++ b/src/app/(auth)/register/page.tsx
@@ -6,9 +6,11 @@ import { signIn, getSession } from 'next-auth/react';
 import AuthService from '@/services/userService';
 import Image from 'next/image';
 import Link from 'next/link';
-import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/outline';
 import { inputClass } from '@/components/TextInput';
+import PasswordInput from '@/components/PasswordInput';
 import Alert from '@/components/Alert';
+import { FieldValidationError, type FieldErrors } from '@/lib/errors';
+import { registerSchema, zodIssuesToFieldErrors } from '@/lib/validation/registerSchema';
 
 const TERMS_VERSION = 'v1-2026-05';
 
@@ -18,10 +20,10 @@ const Register: React.FC = () => {
     const [lastName, setLastName] = useState('');
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
-    const [showPassword, setShowPassword] = useState(false);
     const [agreedToTerms, setAgreedToTerms] = useState(false);
     const [confirmAge16Plus, setConfirmAge16Plus] = useState(false);
-    const [errors, setErrors] = useState<{ userName?: string[]; firstName?: string[]; lastName?: string[]; email?: string[]; password?: string[] }>({});
+    const [errors, setErrors] = useState<FieldErrors>({});
+    const [touched, setTouched] = useState<Record<string, boolean>>({});
     const [apiMessage, setApiMessage] = useState('');
     const [loading, setLoading] = useState(false);
     const router = useRouter();
@@ -29,6 +31,35 @@ const Register: React.FC = () => {
     useEffect(() => {
         getSession().then(s => { if (s) router.push('/profile'); });
     }, [router]);
+
+    // Live client-side validation: re-check a field once the user has touched it,
+    // so password-rule feedback appears before the server round trip.
+    const validateField = (field: string, values: { userName: string; firstName: string; lastName: string; email: string; password: string }) => {
+        const result = registerSchema.safeParse(values);
+        setErrors(prev => {
+            const next = { ...prev };
+            if (result.success) {
+                delete next[field];
+            } else {
+                const fieldErrors = zodIssuesToFieldErrors(result.error.issues);
+                if (fieldErrors[field]) next[field] = fieldErrors[field];
+                else delete next[field];
+            }
+            return next;
+        });
+    };
+
+    const currentValues = () => ({ userName, firstName, lastName, email, password });
+
+    const handleFieldChange = (field: string, setter: (v: string) => void, value: string) => {
+        setter(value);
+        if (touched[field]) validateField(field, { ...currentValues(), [field]: value });
+    };
+
+    const handleFieldBlur = (field: string) => {
+        setTouched(prev => ({ ...prev, [field]: true }));
+        validateField(field, currentValues());
+    };
 
     const handleRegister = async (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
@@ -46,8 +77,10 @@ const Register: React.FC = () => {
             if (result?.error) { setApiMessage(result.error); setLoading(false); }
             else router.push('/profile');
         } catch (error: unknown) {
-            if (error instanceof Error) {
-                try { setErrors(JSON.parse(error.message)); } catch { setApiMessage(error.message); }
+            if (error instanceof FieldValidationError) {
+                setErrors(error.fieldErrors);
+            } else if (error instanceof Error) {
+                setApiMessage(error.message);
             } else {
                 setApiMessage('An unknown error occurred');
             }
@@ -72,48 +105,37 @@ const Register: React.FC = () => {
                     <form onSubmit={handleRegister} className="space-y-4">
                         <div>
                             <label className="block text-xs font-medium text-gray-400 mb-1.5">Username</label>
-                            <input className={inputClass} type="text" placeholder="username" value={userName} onChange={e => setUserName(e.target.value)} />
+                            <input className={inputClass} type="text" placeholder="username" value={userName} onChange={e => handleFieldChange('userName', setUserName, e.target.value)} onBlur={() => handleFieldBlur('userName')} />
                             {errors.userName?.map((err, i) => <p key={i} className="text-xs text-red-400 mt-1">{err}</p>)}
                         </div>
 
                         <div className="grid grid-cols-2 gap-3">
                             <div>
                                 <label className="block text-xs font-medium text-gray-400 mb-1.5">First name</label>
-                                <input className={inputClass} type="text" placeholder="First" value={firstName} onChange={e => setFirstName(e.target.value)} />
+                                <input className={inputClass} type="text" placeholder="First" value={firstName} onChange={e => handleFieldChange('firstName', setFirstName, e.target.value)} onBlur={() => handleFieldBlur('firstName')} />
                                 {errors.firstName?.map((err, i) => <p key={i} className="text-xs text-red-400 mt-1">{err}</p>)}
                             </div>
                             <div>
                                 <label className="block text-xs font-medium text-gray-400 mb-1.5">Last name</label>
-                                <input className={inputClass} type="text" placeholder="Last" value={lastName} onChange={e => setLastName(e.target.value)} />
+                                <input className={inputClass} type="text" placeholder="Last" value={lastName} onChange={e => handleFieldChange('lastName', setLastName, e.target.value)} onBlur={() => handleFieldBlur('lastName')} />
                                 {errors.lastName?.map((err, i) => <p key={i} className="text-xs text-red-400 mt-1">{err}</p>)}
                             </div>
                         </div>
 
                         <div>
                             <label className="block text-xs font-medium text-gray-400 mb-1.5">Email</label>
-                            <input className={inputClass} type="email" placeholder="you@example.com" value={email} onChange={e => setEmail(e.target.value)} />
+                            <input className={inputClass} type="email" placeholder="you@example.com" value={email} onChange={e => handleFieldChange('email', setEmail, e.target.value)} onBlur={() => handleFieldBlur('email')} />
                             {errors.email?.map((err, i) => <p key={i} className="text-xs text-red-400 mt-1">{err}</p>)}
                         </div>
 
                         <div>
                             <label className="block text-xs font-medium text-gray-400 mb-1.5">Password</label>
-                            <div className="relative">
-                                <input
-                                    className={`${inputClass} pr-10`}
-                                    type={showPassword ? 'text' : 'password'}
-                                    placeholder="••••••••"
-                                    value={password}
-                                    onChange={e => setPassword(e.target.value)}
-                                />
-                                <button
-                                    type="button"
-                                    onClick={() => setShowPassword(v => !v)}
-                                    className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-300 transition-colors"
-                                    tabIndex={-1}
-                                >
-                                    {showPassword ? <EyeSlashIcon className="h-4 w-4" /> : <EyeIcon className="h-4 w-4" />}
-                                </button>
-                            </div>
+                            <PasswordInput
+                                placeholder="••••••••"
+                                value={password}
+                                onChange={e => handleFieldChange('password', setPassword, e.target.value)}
+                                onBlur={() => handleFieldBlur('password')}
+                            />
                             {errors.password?.map((err, i) => <p key={i} className="text-xs text-red-400 mt-1">{err}</p>)}
                         </div>
 

--- a/src/app/(auth)/reset-password/page.tsx
+++ b/src/app/(auth)/reset-password/page.tsx
@@ -4,8 +4,8 @@ import { useState } from 'react';
 import AuthService from '@/services/userService';
 import Image from 'next/image';
 import Link from 'next/link';
-import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/outline';
 import { inputClass } from '@/components/TextInput';
+import PasswordInput from '@/components/PasswordInput';
 import Alert from '@/components/Alert';
 
 const ResetPassword: React.FC = () => {
@@ -13,7 +13,6 @@ const ResetPassword: React.FC = () => {
     const [email, setEmail] = useState('');
     const [code, setCode] = useState('');
     const [NewPassword, setNewPassword] = useState('');
-    const [showPassword, setShowPassword] = useState(false);
     const [apiMessage, setApiMessage] = useState('');
     const [successMessage, setSuccessMessage] = useState('');
     const [loading, setLoading] = useState(false);
@@ -89,18 +88,11 @@ const ResetPassword: React.FC = () => {
                             </div>
                             <div>
                                 <label className="block text-xs font-medium text-gray-400 mb-1.5">New password</label>
-                                <div className="relative">
-                                    <input
-                                        className={`${inputClass} pr-10`}
-                                        type={showPassword ? 'text' : 'password'}
-                                        placeholder="••••••••"
-                                        value={NewPassword}
-                                        onChange={e => setNewPassword(e.target.value)}
-                                    />
-                                    <button type="button" onClick={() => setShowPassword(v => !v)} className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-300 transition-colors" tabIndex={-1}>
-                                        {showPassword ? <EyeSlashIcon className="h-4 w-4" /> : <EyeIcon className="h-4 w-4" />}
-                                    </button>
-                                </div>
+                                <PasswordInput
+                                    placeholder="••••••••"
+                                    value={NewPassword}
+                                    onChange={e => setNewPassword(e.target.value)}
+                                />
                             </div>
                             {apiMessage && <Alert variant="error">{apiMessage}</Alert>}
                             <button className="w-full py-2.5 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 disabled:cursor-not-allowed text-white font-medium rounded-xl transition-all text-sm" type="submit" disabled={loading}>

--- a/src/app/(protected)/admin/page.tsx
+++ b/src/app/(protected)/admin/page.tsx
@@ -10,6 +10,7 @@ import Section from '@/components/Section';
 import LoadingDots from '@/components/LoadingDots';
 import ConfirmModal from '@/components/ConfirmModal';
 import ToggleSwitch from '@/components/ToggleSwitch';
+import { StatGrid } from '@/components/StatCard';
 import { toast } from 'sonner';
 
 const TimeSeriesChart = dynamic(() => import('@/components/TimeSeriesChart'), { ssr: false });
@@ -303,39 +304,25 @@ export default function AdminPage() {
 
                     {/* Orders */}
                     <Section title="Orders">
-                        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-                            {([
-                                { label: 'Today', value: stats?.orders?.today },
-                                { label: 'This week', value: stats?.orders?.thisWeek },
-                                { label: 'This month', value: stats?.orders?.thisMonth },
-                                { label: 'Pending capture', value: stats?.orders?.pendingCapture },
-                                { label: 'Failed / cancelled', value: stats?.orders?.failedOrCancelled },
-                                { label: 'Month revenue', value: stats?.orders ? formatNok(stats.orders.monthRevenueInOre) : undefined },
-                                { label: 'Total revenue', value: stats?.orders ? formatNok(stats.orders.totalRevenueInOre) : undefined },
-                            ]).map(({ label, value }) => (
-                                <div key={label} className="bg-gray-900/50 border border-gray-700/40 rounded-xl p-4">
-                                    <p className="text-2xl font-bold text-gray-100 tabular-nums">{value ?? '—'}</p>
-                                    <p className="text-xs text-gray-500 mt-1">{label}</p>
-                                </div>
-                            ))}
-                        </div>
+                        <StatGrid items={[
+                            { label: 'Today', value: stats?.orders?.today },
+                            { label: 'This week', value: stats?.orders?.thisWeek },
+                            { label: 'This month', value: stats?.orders?.thisMonth },
+                            { label: 'Pending capture', value: stats?.orders?.pendingCapture },
+                            { label: 'Failed / cancelled', value: stats?.orders?.failedOrCancelled },
+                            { label: 'Month revenue', value: stats?.orders ? formatNok(stats.orders.monthRevenueInOre) : undefined },
+                            { label: 'Total revenue', value: stats?.orders ? formatNok(stats.orders.totalRevenueInOre) : undefined },
+                        ]} />
                     </Section>
 
                     {/* Subscriptions */}
                     <Section title="Subscriptions">
-                        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-                            {([
-                                { label: 'Active', value: stats?.subscriptions?.active },
-                                { label: 'Pending confirm', value: stats?.subscriptions?.pendingConfirm },
-                                { label: 'Stopped this month', value: stats?.subscriptions?.stoppedThisMonth },
-                                { label: 'Monthly recurring revenue', value: stats?.subscriptions ? formatNok(stats.subscriptions.monthlyRecurringInOre) : undefined },
-                            ]).map(({ label, value }) => (
-                                <div key={label} className="bg-gray-900/50 border border-gray-700/40 rounded-xl p-4">
-                                    <p className="text-2xl font-bold text-gray-100 tabular-nums">{value ?? '—'}</p>
-                                    <p className="text-xs text-gray-500 mt-1">{label}</p>
-                                </div>
-                            ))}
-                        </div>
+                        <StatGrid items={[
+                            { label: 'Active', value: stats?.subscriptions?.active },
+                            { label: 'Pending confirm', value: stats?.subscriptions?.pendingConfirm },
+                            { label: 'Stopped this month', value: stats?.subscriptions?.stoppedThisMonth },
+                            { label: 'Monthly recurring revenue', value: stats?.subscriptions ? formatNok(stats.subscriptions.monthlyRecurringInOre) : undefined },
+                        ]} />
                     </Section>
 
                     {/* System Health */}
@@ -385,22 +372,15 @@ export default function AdminPage() {
                         {emailStatsLoading ? (
                             <LoadingDots height="h-16" />
                         ) : emailStats ? (
-                            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-                                {([
-                                    { label: 'Sent', value: emailStats.requests },
-                                    { label: 'Delivered', value: emailStats.delivered },
-                                    { label: 'Hard bounces', value: emailStats.hardBounces },
-                                    { label: 'Soft bounces', value: emailStats.softBounces },
-                                    { label: 'Blocked', value: emailStats.blocked },
-                                    { label: 'Spam reports', value: emailStats.spamReports },
-                                    { label: 'Invalid', value: emailStats.invalid },
-                                ]).map(({ label, value }) => (
-                                    <div key={label} className="bg-gray-900/50 border border-gray-700/40 rounded-xl p-4">
-                                        <p className="text-2xl font-bold tabular-nums text-gray-100">{value}</p>
-                                        <p className="text-xs text-gray-500 mt-1">{label}</p>
-                                    </div>
-                                ))}
-                            </div>
+                            <StatGrid items={[
+                                { label: 'Sent', value: emailStats.requests },
+                                { label: 'Delivered', value: emailStats.delivered },
+                                { label: 'Hard bounces', value: emailStats.hardBounces },
+                                { label: 'Soft bounces', value: emailStats.softBounces },
+                                { label: 'Blocked', value: emailStats.blocked },
+                                { label: 'Spam reports', value: emailStats.spamReports },
+                                { label: 'Invalid', value: emailStats.invalid },
+                            ]} />
                         ) : (
                             <p className="text-xs text-gray-500">No data.</p>
                         )}

--- a/src/app/(protected)/automations/AutomationRuleForm.tsx
+++ b/src/app/(protected)/automations/AutomationRuleForm.tsx
@@ -1,0 +1,294 @@
+"use client";
+
+import React, { useState } from 'react';
+import { TrashIcon, BoltIcon } from '@heroicons/react/24/outline';
+import ToggleSwitch from '@/components/ToggleSwitch';
+import { Switch } from '@/services/switchService';
+import { Sensor } from '@/services/sensorService';
+import { CreateAutomationRuleDto } from '@/dto/Automation/CreateAutomationRuleDto';
+import { unitForType } from '@/lib/typeUtils';
+
+const PRICE_AREAS = ['NO1', 'NO2', 'NO3', 'NO4', 'NO5'];
+
+export const conditionOptions = [
+    { label: 'Equals',                value: '==' },
+    { label: 'Less than',             value: '<'  },
+    { label: 'Greater than',          value: '>'  },
+    { label: 'Less than or equal',    value: '<=' },
+    { label: 'Greater than or equal', value: '>=' },
+];
+
+const actionOptions = [
+    { label: 'Turn On',  value: 'on'  },
+    { label: 'Turn Off', value: 'off' },
+];
+
+export const checkCondition = (value: number, condition: string, threshold: number): boolean => {
+    switch (condition) {
+        case '==': return value === threshold;
+        case '<':  return value < threshold;
+        case '>':  return value > threshold;
+        case '<=': return value <= threshold;
+        case '>=': return value >= threshold;
+        default:   return false;
+    }
+};
+
+// ── Shared field components ───────────────────────────────────────────────────
+
+const FieldLabel: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+    <label className="block text-xs font-semibold text-gray-400 mb-1.5 uppercase tracking-wider">
+        {children}
+    </label>
+);
+
+const Select: React.FC<React.SelectHTMLAttributes<HTMLSelectElement>> = ({ className = '', ...props }) => (
+    <select
+        className={`block w-full px-3 py-2.5 bg-gray-800 border border-gray-600/60 rounded-lg text-gray-200 text-sm focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/30 transition-all ${className}`}
+        {...props}
+    />
+);
+
+const NumberInput: React.FC<React.InputHTMLAttributes<HTMLInputElement>> = ({ className = '', onFocus, ...props }) => (
+    <input
+        type="number"
+        className={`block w-full px-3 py-2.5 bg-gray-800 border border-gray-600/60 rounded-lg text-gray-200 text-sm focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/30 transition-all ${className}`}
+        onFocus={e => { const el = e.currentTarget; setTimeout(() => el.select(), 0); onFocus?.(e); }}
+        {...props}
+    />
+);
+
+// ── Electricity price sub-form ────────────────────────────────────────────────
+
+interface PriceConditionFields {
+    electricityPriceCondition?: string;
+    electricityPriceThreshold?: number;
+    electricityPriceArea?: string;
+    electricityPriceOperator?: string;
+}
+
+interface PriceConditionFormProps {
+    value: PriceConditionFields;
+    defaultArea: string;
+    onChange: (v: PriceConditionFields) => void;
+}
+
+const PriceConditionForm: React.FC<PriceConditionFormProps> = ({ value, defaultArea, onChange }) => {
+    const [enabled, setEnabled] = useState(!!value.electricityPriceCondition);
+
+    const toggle = () => {
+        const next = !enabled;
+        setEnabled(next);
+        if (!next) {
+            onChange({
+                electricityPriceCondition: undefined,
+                electricityPriceThreshold: undefined,
+                electricityPriceArea: undefined,
+                electricityPriceOperator: undefined,
+            });
+        } else {
+            onChange({
+                electricityPriceCondition: '<',
+                electricityPriceThreshold: 0,
+                electricityPriceArea: value.electricityPriceArea || defaultArea,
+                electricityPriceOperator: 'AND',
+            });
+        }
+    };
+
+    return (
+        <div className="pt-4 border-t border-gray-700/60">
+            <div className="flex items-center justify-between mb-3">
+                <div>
+                    <p className="text-sm font-medium text-gray-300">Electricity price condition</p>
+                    <p className="text-xs text-gray-500 mt-0.5">Also check current electricity price</p>
+                </div>
+                <ToggleSwitch
+                    checked={enabled}
+                    onChange={toggle}
+                    ariaLabel={enabled ? 'Disable electricity price condition' : 'Enable electricity price condition'}
+                />
+            </div>
+            {enabled && (
+                <div className="mt-3 p-3 bg-amber-500/5 border border-amber-500/20 rounded-lg space-y-3">
+                    <div>
+                        <FieldLabel>Combine with sensor condition using</FieldLabel>
+                        <Select value={value.electricityPriceOperator ?? 'AND'} onChange={e => onChange({ ...value, electricityPriceOperator: e.target.value })}>
+                            <option value="AND">AND (both must be true)</option>
+                            <option value="OR">OR (either can be true)</option>
+                        </Select>
+                    </div>
+                    <div className="grid grid-cols-3 gap-2">
+                        <div>
+                            <FieldLabel>Condition</FieldLabel>
+                            <Select value={value.electricityPriceCondition ?? '<'} onChange={e => onChange({ ...value, electricityPriceCondition: e.target.value })}>
+                                {conditionOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+                            </Select>
+                        </div>
+                        <div>
+                            <FieldLabel>Price (kr/kWh)</FieldLabel>
+                            <NumberInput value={value.electricityPriceThreshold ?? 0} step="0.1" placeholder="0"
+                                onChange={e => onChange({ ...value, electricityPriceThreshold: Number(e.target.value) })} />
+                        </div>
+                        <div>
+                            <FieldLabel>Area</FieldLabel>
+                            <Select value={value.electricityPriceArea ?? defaultArea} onChange={e => onChange({ ...value, electricityPriceArea: e.target.value })}>
+                                {PRICE_AREAS.map(a => <option key={a} value={a}>{a}</option>)}
+                            </Select>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+};
+
+// ── AutomationRuleForm ────────────────────────────────────────────────────────
+
+export interface AutomationRuleFormProps {
+    /** Current form values. Shared shape for both create and edit. */
+    value: CreateAutomationRuleDto;
+    onChange: (next: CreateAutomationRuleDto) => void;
+    onSubmit: (e: React.FormEvent) => void;
+    onCancel: () => void;
+    submitting: boolean;
+    mode: 'create' | 'edit';
+    sortedSwitches: Switch[];
+    sortedSensors: Sensor[];
+    sensors: Sensor[];
+    /** Latest reading per sensor id, for the "would trigger now" preview. */
+    latestValueMap: Record<number, number>;
+    defaultPriceArea: string;
+    /** Stable key for the price sub-form so its local enabled state resets per rule. */
+    priceFormKey: React.Key;
+    /** Edit-mode delete action; required when mode === 'edit'. */
+    onDelete?: () => void;
+}
+
+const AutomationRuleForm: React.FC<AutomationRuleFormProps> = ({
+    value,
+    onChange,
+    onSubmit,
+    onCancel,
+    submitting,
+    mode,
+    sortedSwitches,
+    sortedSensors,
+    sensors,
+    latestValueMap,
+    defaultPriceArea,
+    priceFormKey,
+    onDelete,
+}) => {
+    const sensorObj = sensors.find(s => s.id === value.sensorId);
+    const unit = sensorObj ? unitForType(sensorObj.type) : '';
+
+    const handleTargetChange = (id: number) => {
+        onChange({ ...value, targetId: id, targetType: sortedSwitches.find(sw => sw.id === id)?.type || '' });
+    };
+    const handleSensorChange = (id: number) => {
+        onChange({ ...value, sensorId: id, sensorType: sensors.find(s => s.id === id)?.type || '' });
+    };
+
+    return (
+        <form onSubmit={onSubmit} className="space-y-5">
+            <div>
+                <FieldLabel>Target socket</FieldLabel>
+                <Select value={value.targetId} required onChange={e => handleTargetChange(Number(e.target.value))}>
+                    <option value={0}>Select a socket</option>
+                    {sortedSwitches.map(sw => <option key={sw.id} value={sw.id}>{sw.customName ?? sw.name}</option>)}
+                </Select>
+            </div>
+            <div>
+                <FieldLabel>Trigger sensor</FieldLabel>
+                <Select value={value.sensorId} required onChange={e => handleSensorChange(Number(e.target.value))}>
+                    <option value={0}>Select a sensor</option>
+                    {sortedSensors.map(s => <option key={s.id} value={s.id}>{s.customName ?? s.defaultName}</option>)}
+                </Select>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+                <div>
+                    <FieldLabel>Condition</FieldLabel>
+                    <Select value={value.condition} required onChange={e => onChange({ ...value, condition: e.target.value })}>
+                        {conditionOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+                    </Select>
+                </div>
+                <div>
+                    <FieldLabel>Threshold{unit ? ` (${unit})` : ''}</FieldLabel>
+                    <NumberInput value={value.threshold} step="0.1" placeholder="0" required
+                        onChange={e => onChange({ ...value, threshold: Number(e.target.value) })} />
+                </div>
+            </div>
+            {value.sensorId > 0 && latestValueMap[value.sensorId] !== undefined && (() => {
+                const current = latestValueMap[value.sensorId];
+                const met = checkCondition(current, value.condition, value.threshold);
+                return (
+                    <div className={`flex items-center gap-2 px-3 py-2 rounded-lg border text-xs font-medium ${met ? 'bg-amber-500/10 border-amber-500/20 text-amber-400' : 'bg-gray-800/50 border-gray-700/30 text-gray-500'}`}>
+                        <BoltIcon className="h-3.5 w-3.5 flex-shrink-0" />
+                        {met ? `Would trigger now — current value: ${current}${unit ? ` ${unit}` : ''}` : `Would not trigger — current value: ${current}${unit ? ` ${unit}` : ''}`}
+                    </div>
+                );
+            })()}
+            <div>
+                <FieldLabel>Action</FieldLabel>
+                <Select value={value.action} required onChange={e => onChange({ ...value, action: e.target.value })}>
+                    {actionOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+                </Select>
+            </div>
+            {value.action === 'on' && (
+                <div className="pt-4 border-t border-gray-700/60">
+                    <div className="flex items-center justify-between mb-3">
+                        <div>
+                            <p className="text-sm font-medium text-gray-300">Auto-off timer</p>
+                            <p className="text-xs text-gray-500 mt-0.5">Automatically turn off after a set duration</p>
+                        </div>
+                        <ToggleSwitch
+                            checked={!!value.timerDurationHours}
+                            onChange={() => onChange({ ...value, timerDurationHours: value.timerDurationHours ? undefined : 2 })}
+                            ariaLabel={value.timerDurationHours ? 'Disable auto-off timer' : 'Enable auto-off timer'}
+                        />
+                    </div>
+                    {value.timerDurationHours != null && (
+                        <div>
+                            <FieldLabel>Duration (hours)</FieldLabel>
+                            <NumberInput value={value.timerDurationHours} step="0.5" min="0.5" placeholder="2"
+                                onChange={e => onChange({ ...value, timerDurationHours: Number(e.target.value) })} />
+                        </div>
+                    )}
+                </div>
+            )}
+            <PriceConditionForm
+                key={priceFormKey}
+                value={value}
+                defaultArea={defaultPriceArea}
+                onChange={fields => onChange({ ...value, ...fields })}
+            />
+            <div className="flex gap-3 pt-2">
+                <button type="submit" disabled={submitting}
+                    className="flex-1 px-4 py-2.5 bg-sky-600 hover:bg-sky-500 active:bg-sky-700 disabled:opacity-50 text-white text-sm font-semibold rounded-lg transition-all">
+                    {mode === 'create'
+                        ? (submitting ? 'Creating…' : 'Create Rule')
+                        : (submitting ? 'Saving…' : 'Save Changes')}
+                </button>
+                <button type="button" onClick={onCancel}
+                    className="px-4 py-2.5 bg-gray-700 hover:bg-gray-600 text-gray-300 text-sm font-medium rounded-lg transition-all">
+                    Cancel
+                </button>
+            </div>
+            {mode === 'edit' && (
+                <div className="pt-4 border-t border-gray-700/60">
+                    <button
+                        type="button"
+                        onClick={onDelete}
+                        className="w-full px-4 py-2.5 bg-rose-600/10 hover:bg-rose-600/20 border border-rose-600/30 text-rose-400 text-sm font-medium rounded-lg transition-all flex items-center justify-center gap-2"
+                    >
+                        <TrashIcon className="h-4 w-4" />
+                        Delete Rule
+                    </button>
+                </div>
+            )}
+        </form>
+    );
+};
+
+export default AutomationRuleForm;

--- a/src/app/(protected)/automations/page.tsx
+++ b/src/app/(protected)/automations/page.tsx
@@ -15,17 +15,15 @@ import { formatApiError } from '@/lib/errorMessages';
 import ConfirmModal from '@/components/ConfirmModal';
 import LoadingDots from '@/components/LoadingDots';
 import ToggleSwitch from '@/components/ToggleSwitch';
+import AutomationRuleForm from './AutomationRuleForm';
 import {
     PlusIcon,
     XMarkIcon,
     ClockIcon,
     PencilSquareIcon,
-    TrashIcon,
     BoltIcon,
 } from '@heroicons/react/24/outline';
 import { toast } from 'sonner';
-
-const PRICE_AREAS = ['NO1', 'NO2', 'NO3', 'NO4', 'NO5'];
 
 const initialForm: CreateAutomationRuleDto = {
     targetType: '',
@@ -37,14 +35,6 @@ const initialForm: CreateAutomationRuleDto = {
     action: 'on',
     isEnabled: true,
 };
-
-const conditionOptions = [
-    { label: 'Equals',                value: '==' },
-    { label: 'Less than',             value: '<'  },
-    { label: 'Greater than',          value: '>'  },
-    { label: 'Less than or equal',    value: '<=' },
-    { label: 'Greater than or equal', value: '>=' },
-];
 
 const conditionSymbol: Record<string, string> = {
     '==': '=', '<': '<', '>': '>', '<=': '≤', '>=': '≥',
@@ -58,11 +48,6 @@ const conditionVerb: Record<string, string> = {
     '>=': 'reaches',
 };
 
-const actionOptions = [
-    { label: 'Turn On',  value: 'on'  },
-    { label: 'Turn Off', value: 'off' },
-];
-
 const formatTriggered = (iso: string | null): string | null => {
     if (!iso) return null;
     return formatDateTime(iso);
@@ -75,126 +60,6 @@ const formatTimerRemaining = (activatedAt: string, durationHours: number): strin
     const h = Math.floor(remainingMs / 3600000);
     const m = Math.floor((remainingMs % 3600000) / 60000);
     return h > 0 ? `${h}h ${m}m remaining` : `${m}m remaining`;
-};
-
-const checkCondition = (value: number, condition: string, threshold: number): boolean => {
-    switch (condition) {
-        case '==': return value === threshold;
-        case '<':  return value < threshold;
-        case '>':  return value > threshold;
-        case '<=': return value <= threshold;
-        case '>=': return value >= threshold;
-        default:   return false;
-    }
-};
-
-// ── Shared field components ───────────────────────────────────────────────────
-
-const FieldLabel: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-    <label className="block text-xs font-semibold text-gray-400 mb-1.5 uppercase tracking-wider">
-        {children}
-    </label>
-);
-
-const Select: React.FC<React.SelectHTMLAttributes<HTMLSelectElement>> = ({ className = '', ...props }) => (
-    <select
-        className={`block w-full px-3 py-2.5 bg-gray-800 border border-gray-600/60 rounded-lg text-gray-200 text-sm focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/30 transition-all ${className}`}
-        {...props}
-    />
-);
-
-const NumberInput: React.FC<React.InputHTMLAttributes<HTMLInputElement>> = ({ className = '', onFocus, ...props }) => (
-    <input
-        type="number"
-        className={`block w-full px-3 py-2.5 bg-gray-800 border border-gray-600/60 rounded-lg text-gray-200 text-sm focus:outline-none focus:border-sky-500 focus:ring-1 focus:ring-sky-500/30 transition-all ${className}`}
-        onFocus={e => { const el = e.currentTarget; setTimeout(() => el.select(), 0); onFocus?.(e); }}
-        {...props}
-    />
-);
-
-// ── Electricity price sub-form ────────────────────────────────────────────────
-
-interface PriceConditionFields {
-    electricityPriceCondition?: string;
-    electricityPriceThreshold?: number;
-    electricityPriceArea?: string;
-    electricityPriceOperator?: string;
-}
-
-interface PriceConditionFormProps {
-    value: PriceConditionFields;
-    defaultArea: string;
-    onChange: (v: PriceConditionFields) => void;
-}
-
-const PriceConditionForm: React.FC<PriceConditionFormProps> = ({ value, defaultArea, onChange }) => {
-    const [enabled, setEnabled] = useState(!!value.electricityPriceCondition);
-
-    const toggle = () => {
-        const next = !enabled;
-        setEnabled(next);
-        if (!next) {
-            onChange({
-                electricityPriceCondition: undefined,
-                electricityPriceThreshold: undefined,
-                electricityPriceArea: undefined,
-                electricityPriceOperator: undefined,
-            });
-        } else {
-            onChange({
-                electricityPriceCondition: '<',
-                electricityPriceThreshold: 0,
-                electricityPriceArea: value.electricityPriceArea || defaultArea,
-                electricityPriceOperator: 'AND',
-            });
-        }
-    };
-
-    return (
-        <div className="pt-4 border-t border-gray-700/60">
-            <div className="flex items-center justify-between mb-3">
-                <div>
-                    <p className="text-sm font-medium text-gray-300">Electricity price condition</p>
-                    <p className="text-xs text-gray-500 mt-0.5">Also check current electricity price</p>
-                </div>
-                <ToggleSwitch
-                    checked={enabled}
-                    onChange={toggle}
-                    ariaLabel={enabled ? 'Disable electricity price condition' : 'Enable electricity price condition'}
-                />
-            </div>
-            {enabled && (
-                <div className="mt-3 p-3 bg-amber-500/5 border border-amber-500/20 rounded-lg space-y-3">
-                    <div>
-                        <FieldLabel>Combine with sensor condition using</FieldLabel>
-                        <Select value={value.electricityPriceOperator ?? 'AND'} onChange={e => onChange({ ...value, electricityPriceOperator: e.target.value })}>
-                            <option value="AND">AND (both must be true)</option>
-                            <option value="OR">OR (either can be true)</option>
-                        </Select>
-                    </div>
-                    <div className="grid grid-cols-3 gap-2">
-                        <div>
-                            <FieldLabel>Condition</FieldLabel>
-                            <Select value={value.electricityPriceCondition ?? '<'} onChange={e => onChange({ ...value, electricityPriceCondition: e.target.value })}>
-                                {conditionOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-                            </Select>
-                        </div>
-                        <div>
-                            <FieldLabel>Price (kr/kWh)</FieldLabel>
-                            <NumberInput value={value.electricityPriceThreshold ?? 0} step="0.1" placeholder="0"
-                                onChange={e => onChange({ ...value, electricityPriceThreshold: Number(e.target.value) })} />
-                        </div>
-                        <div>
-                            <FieldLabel>Area</FieldLabel>
-                            <Select value={value.electricityPriceArea ?? defaultArea} onChange={e => onChange({ ...value, electricityPriceArea: e.target.value })}>
-                                {PRICE_AREAS.map(a => <option key={a} value={a}>{a}</option>)}
-                            </Select>
-                        </div>
-                    </div>
-                </div>
-            )}
-        </div>
-    );
 };
 
 // ── AutomationsPage ───────────────────────────────────────────────────────────
@@ -348,21 +213,8 @@ const AutomationsPage: React.FC = () => {
         finally { setSubmitting(false); }
     };
 
-    const handleTargetChange = (id: number) => {
-        const selected = switches.find(sw => sw.id === id);
-        setForm({ ...form, targetId: id, targetType: selected?.type || '' });
-    };
-    const handleSensorChange = (id: number) => {
-        const selected = sensors.find(s => s.id === id);
-        setForm({ ...form, sensorId: id, sensorType: selected?.type || '' });
-    };
-
     // ── Derived values ─────────────────────────────────────────────────────────
     const isEditMode     = editingId !== null && editForm !== null;
-    const editSensorObj  = sensors.find(s => s.id === editForm?.sensorId);
-    const editUnit       = editSensorObj ? unitForType(editSensorObj.type) : '';
-    const createSensorObj = sensors.find(s => s.id === form.sensorId);
-    const createUnit      = createSensorObj ? unitForType(createSensorObj.type) : '';
 
     const openCreateDrawer = () => { setEditingId(null); setEditForm(null); setFormOpen(true); };
     const closeDrawer      = () => { setFormOpen(false); setEditingId(null); setEditForm(null); };
@@ -370,191 +222,38 @@ const AutomationsPage: React.FC = () => {
     // ── Form contents (shared between drawer modes) ────────────────────────────
 
     const createFormContent = (
-        <form onSubmit={handleCreate} className="space-y-5">
-            <div>
-                <FieldLabel>Target socket</FieldLabel>
-                <Select value={form.targetId} required onChange={e => handleTargetChange(Number(e.target.value))}>
-                    <option value={0}>Select a socket</option>
-                    {sortedSwitches.map(sw => <option key={sw.id} value={sw.id}>{sw.customName ?? sw.name}</option>)}
-                </Select>
-            </div>
-            <div>
-                <FieldLabel>Trigger sensor</FieldLabel>
-                <Select value={form.sensorId} required onChange={e => handleSensorChange(Number(e.target.value))}>
-                    <option value={0}>Select a sensor</option>
-                    {sortedSensors.map(s => <option key={s.id} value={s.id}>{s.customName ?? s.defaultName}</option>)}
-                </Select>
-            </div>
-            <div className="grid grid-cols-2 gap-3">
-                <div>
-                    <FieldLabel>Condition</FieldLabel>
-                    <Select value={form.condition} required onChange={e => setForm({ ...form, condition: e.target.value })}>
-                        {conditionOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-                    </Select>
-                </div>
-                <div>
-                    <FieldLabel>Threshold{createUnit ? ` (${createUnit})` : ''}</FieldLabel>
-                    <NumberInput value={form.threshold} step="0.1" placeholder="0" required
-                        onChange={e => setForm({ ...form, threshold: Number(e.target.value) })} />
-                </div>
-            </div>
-            {form.sensorId > 0 && latestValueMap[form.sensorId] !== undefined && (() => {
-                const current = latestValueMap[form.sensorId];
-                const met = checkCondition(current, form.condition, form.threshold);
-                return (
-                    <div className={`flex items-center gap-2 px-3 py-2 rounded-lg border text-xs font-medium ${met ? 'bg-amber-500/10 border-amber-500/20 text-amber-400' : 'bg-gray-800/50 border-gray-700/30 text-gray-500'}`}>
-                        <BoltIcon className="h-3.5 w-3.5 flex-shrink-0" />
-                        {met ? `Would trigger now — current value: ${current}${createUnit ? ` ${createUnit}` : ''}` : `Would not trigger — current value: ${current}${createUnit ? ` ${createUnit}` : ''}`}
-                    </div>
-                );
-            })()}
-            <div>
-                <FieldLabel>Action</FieldLabel>
-                <Select value={form.action} required onChange={e => setForm({ ...form, action: e.target.value })}>
-                    {actionOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-                </Select>
-            </div>
-            {form.action === 'on' && (
-                <div className="pt-4 border-t border-gray-700/60">
-                    <div className="flex items-center justify-between mb-3">
-                        <div>
-                            <p className="text-sm font-medium text-gray-300">Auto-off timer</p>
-                            <p className="text-xs text-gray-500 mt-0.5">Automatically turn off after a set duration</p>
-                        </div>
-                        <ToggleSwitch
-                            checked={!!form.timerDurationHours}
-                            onChange={() => setForm({ ...form, timerDurationHours: form.timerDurationHours ? undefined : 2 })}
-                            ariaLabel={form.timerDurationHours ? 'Disable auto-off timer' : 'Enable auto-off timer'}
-                        />
-                    </div>
-                    {form.timerDurationHours != null && (
-                        <div>
-                            <FieldLabel>Duration (hours)</FieldLabel>
-                            <NumberInput value={form.timerDurationHours} step="0.5" min="0.5" placeholder="2"
-                                onChange={e => setForm({ ...form, timerDurationHours: Number(e.target.value) })} />
-                        </div>
-                    )}
-                </div>
-            )}
-            <PriceConditionForm
-                key="create"
-                value={form}
-                defaultArea={defaultPriceArea}
-                onChange={fields => setForm({ ...form, ...fields })}
-            />
-            <div className="flex gap-3 pt-2">
-                <button type="submit" disabled={submitting}
-                    className="flex-1 px-4 py-2.5 bg-sky-600 hover:bg-sky-500 active:bg-sky-700 disabled:opacity-50 text-white text-sm font-semibold rounded-lg transition-all">
-                    {submitting ? 'Creating…' : 'Create Rule'}
-                </button>
-                <button type="button" onClick={closeDrawer}
-                    className="px-4 py-2.5 bg-gray-700 hover:bg-gray-600 text-gray-300 text-sm font-medium rounded-lg transition-all">
-                    Cancel
-                </button>
-            </div>
-        </form>
+        <AutomationRuleForm
+            mode="create"
+            value={form}
+            onChange={setForm}
+            onSubmit={handleCreate}
+            onCancel={closeDrawer}
+            submitting={submitting}
+            sortedSwitches={sortedSwitches}
+            sortedSensors={sortedSensors}
+            sensors={sensors}
+            latestValueMap={latestValueMap}
+            defaultPriceArea={defaultPriceArea}
+            priceFormKey="create"
+        />
     );
 
     const editFormContent = editForm && (
-        <form onSubmit={handleUpdate} className="space-y-5">
-            <div>
-                <FieldLabel>Target socket</FieldLabel>
-                <Select value={editForm.targetId} required onChange={e => {
-                    const id = Number(e.target.value);
-                    setEditForm({ ...editForm, targetId: id, targetType: switches.find(sw => sw.id === id)?.type || '' });
-                }}>
-                    <option value={0}>Select a socket</option>
-                    {sortedSwitches.map(sw => <option key={sw.id} value={sw.id}>{sw.customName ?? sw.name}</option>)}
-                </Select>
-            </div>
-            <div>
-                <FieldLabel>Trigger sensor</FieldLabel>
-                <Select value={editForm.sensorId} required onChange={e => {
-                    const id = Number(e.target.value);
-                    setEditForm({ ...editForm, sensorId: id, sensorType: sensors.find(s => s.id === id)?.type || '' });
-                }}>
-                    <option value={0}>Select a sensor</option>
-                    {sortedSensors.map(s => <option key={s.id} value={s.id}>{s.customName ?? s.defaultName}</option>)}
-                </Select>
-            </div>
-            <div className="grid grid-cols-2 gap-3">
-                <div>
-                    <FieldLabel>Condition</FieldLabel>
-                    <Select value={editForm.condition} required onChange={e => setEditForm({ ...editForm, condition: e.target.value })}>
-                        {conditionOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-                    </Select>
-                </div>
-                <div>
-                    <FieldLabel>Threshold{editUnit ? ` (${editUnit})` : ''}</FieldLabel>
-                    <NumberInput value={editForm.threshold} step="0.1" required
-                        onChange={e => setEditForm({ ...editForm, threshold: Number(e.target.value) })} />
-                </div>
-            </div>
-            {editForm.sensorId > 0 && latestValueMap[editForm.sensorId] !== undefined && (() => {
-                const current = latestValueMap[editForm.sensorId];
-                const met = checkCondition(current, editForm.condition, editForm.threshold);
-                return (
-                    <div className={`flex items-center gap-2 px-3 py-2 rounded-lg border text-xs font-medium ${met ? 'bg-amber-500/10 border-amber-500/20 text-amber-400' : 'bg-gray-800/50 border-gray-700/30 text-gray-500'}`}>
-                        <BoltIcon className="h-3.5 w-3.5 flex-shrink-0" />
-                        {met ? `Would trigger now — current value: ${current}${editUnit ? ` ${editUnit}` : ''}` : `Would not trigger — current value: ${current}${editUnit ? ` ${editUnit}` : ''}`}
-                    </div>
-                );
-            })()}
-            <div>
-                <FieldLabel>Action</FieldLabel>
-                <Select value={editForm.action} required onChange={e => setEditForm({ ...editForm, action: e.target.value })}>
-                    {actionOptions.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
-                </Select>
-            </div>
-            {editForm.action === 'on' && (
-                <div className="pt-4 border-t border-gray-700/60">
-                    <div className="flex items-center justify-between mb-3">
-                        <div>
-                            <p className="text-sm font-medium text-gray-300">Auto-off timer</p>
-                            <p className="text-xs text-gray-500 mt-0.5">Automatically turn off after a set duration</p>
-                        </div>
-                        <ToggleSwitch
-                            checked={!!editForm.timerDurationHours}
-                            onChange={() => setEditForm({ ...editForm, timerDurationHours: editForm.timerDurationHours ? undefined : 2 })}
-                            ariaLabel={editForm.timerDurationHours ? 'Disable auto-off timer' : 'Enable auto-off timer'}
-                        />
-                    </div>
-                    {editForm.timerDurationHours != null && (
-                        <div>
-                            <FieldLabel>Duration (hours)</FieldLabel>
-                            <NumberInput value={editForm.timerDurationHours} step="0.5" min="0.5" placeholder="2"
-                                onChange={e => setEditForm({ ...editForm, timerDurationHours: Number(e.target.value) })} />
-                        </div>
-                    )}
-                </div>
-            )}
-            <PriceConditionForm
-                key={editingId ?? 'edit'}
-                value={editForm}
-                defaultArea={defaultPriceArea}
-                onChange={fields => setEditForm({ ...editForm, ...fields })}
-            />
-            <div className="flex gap-3 pt-2">
-                <button type="submit" disabled={submitting}
-                    className="flex-1 px-4 py-2.5 bg-sky-600 hover:bg-sky-500 active:bg-sky-700 disabled:opacity-50 text-white text-sm font-semibold rounded-lg transition-all">
-                    {submitting ? 'Saving…' : 'Save Changes'}
-                </button>
-                <button type="button" onClick={closeDrawer}
-                    className="px-4 py-2.5 bg-gray-700 hover:bg-gray-600 text-gray-300 text-sm font-medium rounded-lg transition-all">
-                    Cancel
-                </button>
-            </div>
-            <div className="pt-4 border-t border-gray-700/60">
-                <button
-                    type="button"
-                    onClick={() => editingId && setDeleteTargetId(editingId)}
-                    className="w-full px-4 py-2.5 bg-rose-600/10 hover:bg-rose-600/20 border border-rose-600/30 text-rose-400 text-sm font-medium rounded-lg transition-all flex items-center justify-center gap-2"
-                >
-                    <TrashIcon className="h-4 w-4" />
-                    Delete Rule
-                </button>
-            </div>
-        </form>
+        <AutomationRuleForm
+            mode="edit"
+            value={editForm}
+            onChange={setEditForm}
+            onSubmit={handleUpdate}
+            onCancel={closeDrawer}
+            submitting={submitting}
+            sortedSwitches={sortedSwitches}
+            sortedSensors={sortedSensors}
+            sensors={sensors}
+            latestValueMap={latestValueMap}
+            defaultPriceArea={defaultPriceArea}
+            priceFormKey={editingId ?? 'edit'}
+            onDelete={() => editingId && setDeleteTargetId(editingId)}
+        />
     );
 
     // ── Empty state ────────────────────────────────────────────────────────────

--- a/src/app/(protected)/profile/page.tsx
+++ b/src/app/(protected)/profile/page.tsx
@@ -16,6 +16,7 @@ import Section from '@/components/Section';
 import CapacityMeter from '@/components/CapacityMeter';
 import ToggleSwitch from '@/components/ToggleSwitch';
 import { inputClass } from '@/components/TextInput';
+import InlineEditField from '@/components/InlineEditField';
 import Alert from '@/components/Alert';
 import { toast } from 'sonner';
 import Link from 'next/link';
@@ -395,30 +396,19 @@ const Profile: React.FC = () => {
                                 {editingField === 'phone' ? (
                                     <div className="space-y-2">
                                         <span className="text-sm text-gray-400">Phone</span>
-                                        <input
-                                            type="tel"
+                                        <InlineEditField
+                                            value={editPhone}
+                                            onChange={setEditPhone}
+                                            onSave={handleSavePhone}
+                                            onCancel={cancelEdit}
+                                            saving={profileSaving}
+                                            inputType="tel"
                                             inputMode="tel"
                                             autoComplete="tel"
-                                            value={editPhone}
-                                            onChange={e => setEditPhone(e.target.value)}
                                             placeholder="91 23 45 67"
-                                            className={inputClass}
+                                            error={editPhone.trim() && normalizeNoPhone(editPhone) === null ? 'Enter a valid phone number.' : null}
                                             autoFocus
-                                            disabled={profileSaving}
                                         />
-                                        {editPhone.trim() && normalizeNoPhone(editPhone) === null && (
-                                            <p className="text-[11px] text-red-400">Enter a valid phone number.</p>
-                                        )}
-                                        <div className="flex gap-2">
-                                            <button onClick={handleSavePhone} disabled={profileSaving} className="flex items-center gap-1.5 px-3 py-1.5 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 text-white text-xs font-medium rounded-lg transition-all">
-                                                <CheckIcon className="h-3.5 w-3.5" />
-                                                {profileSaving ? 'Saving…' : 'Save'}
-                                            </button>
-                                            <button onClick={cancelEdit} disabled={profileSaving} className="flex items-center gap-1.5 px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-300 text-xs font-medium rounded-lg transition-all">
-                                                <XMarkIcon className="h-3.5 w-3.5" />
-                                                Cancel
-                                            </button>
-                                        </div>
                                     </div>
                                 ) : (
                                     <div className="flex items-center justify-between">

--- a/src/app/DeviceDashboard.tsx
+++ b/src/app/DeviceDashboard.tsx
@@ -15,6 +15,7 @@ import { groupEmoji } from '@/lib/groupIcons';
 import { useLocalStorage } from '@/lib/useLocalStorage';
 import CollapsibleSection from '@/components/CollapsibleSection';
 import { useDeviceStream } from '@/hooks/useDeviceStream';
+import { useOutsideClick } from '@/hooks/useOutsideClick';
 
 // ── Type sort order for group cards ───────────────────────────────────────────
 const TYPE_ORDER: Record<string, number> = { voltage: 0, temperature: 1, humidity: 2, socket: 3 };
@@ -39,13 +40,7 @@ const CustomSelect: React.FC<CustomSelectProps> = ({ value, options, onChange })
     const ref = useRef<HTMLDivElement>(null);
     const selected = options.find(o => o.value === value);
 
-    useEffect(() => {
-        const handler = (e: MouseEvent) => {
-            if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
-        };
-        document.addEventListener('mousedown', handler);
-        return () => document.removeEventListener('mousedown', handler);
-    }, []);
+    useOutsideClick(ref, () => setOpen(false), open);
 
     return (
         <div ref={ref} className="relative">

--- a/src/app/DeviceDrawer.tsx
+++ b/src/app/DeviceDrawer.tsx
@@ -2,7 +2,9 @@
 
 import React, { useCallback, useEffect, useState } from 'react';
 import dynamic from 'next/dynamic';
-import { XMarkIcon, PencilIcon, CheckIcon, InformationCircleIcon } from '@heroicons/react/24/outline';
+import { XMarkIcon, PencilIcon, InformationCircleIcon } from '@heroicons/react/24/outline';
+import { useOutsideClick } from '@/hooks/useOutsideClick';
+import InlineEditField from '@/components/InlineEditField';
 import { TYPE_CONFIG as typeConfig, DEFAULT_TYPE as defaultType, BATTERY_STATUS_CONFIG as statusConfig } from '@/lib/typeConfig';
 import { unitForType, typeLabel } from '@/lib/typeUtils';
 import { RANGE_OPTIONS, type RangeIndex } from '@/lib/constants';
@@ -30,18 +32,7 @@ function InfoLabel({ children, tooltip }: { children: React.ReactNode; tooltip: 
     const [open, setOpen] = useState(false);
     const ref = React.useRef<HTMLSpanElement>(null);
 
-    useEffect(() => {
-        if (!open) return;
-        const handler = (e: MouseEvent | TouchEvent) => {
-            if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
-        };
-        document.addEventListener('mousedown', handler);
-        document.addEventListener('touchstart', handler);
-        return () => {
-            document.removeEventListener('mousedown', handler);
-            document.removeEventListener('touchstart', handler);
-        };
-    }, [open]);
+    useOutsideClick(ref, () => setOpen(false), open);
 
     return (
         <span ref={ref} className="relative text-gray-500 inline-flex items-center gap-1">
@@ -296,31 +287,16 @@ const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose, onRename }
                     </div>
                     <div className="flex-1 min-w-0">
                         {(device.kind === 'socket' || device.kind === 'sensor') && editingName ? (
-                            <div className="flex items-center gap-2">
-                                <div className="relative flex-1 min-w-0">
-                                    <input
-                                        autoFocus
-                                        type="text"
-                                        value={editName}
-                                        onChange={e => setEditName(e.target.value)}
-                                        onKeyDown={e => {
-                                            if (e.key === 'Enter') handleSaveName();
-                                            if (e.key === 'Escape') setEditingName(false);
-                                        }}
-                                        maxLength={50}
-                                        className="w-full bg-gray-800/80 border border-gray-600/50 rounded-lg px-2 py-1 pr-10 text-sm text-gray-100 focus:outline-none focus:border-sky-500/60"
-                                    />
-                                    <span className={`absolute right-2 top-1/2 -translate-y-1/2 text-[10px] tabular-nums pointer-events-none ${editName.length >= 45 ? 'text-amber-400' : 'text-gray-600'}`}>{editName.length}/50</span>
-                                </div>
-                                <button
-                                    onClick={handleSaveName}
-                                    disabled={savingName}
-                                    aria-label="Save name"
-                                    className="p-1 rounded-lg text-sky-400 hover:text-sky-300 hover:bg-sky-500/10 transition-colors flex-shrink-0"
-                                >
-                                    <CheckIcon className="h-4 w-4" />
-                                </button>
-                            </div>
+                            <InlineEditField
+                                compact
+                                value={editName}
+                                onChange={setEditName}
+                                onSave={handleSaveName}
+                                onCancel={() => setEditingName(false)}
+                                saving={savingName}
+                                maxLength={50}
+                                autoFocus
+                            />
                         ) : (
                             <div className="flex items-center gap-1.5 min-w-0">
                                 <h2 className="font-semibold text-gray-100 truncate">{device.displayName}</h2>

--- a/src/app/SetupWizard.tsx
+++ b/src/app/SetupWizard.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { XMarkIcon, ChevronRightIcon, CheckIcon } from '@heroicons/react/24/outline';
+import Modal from '@/components/Modal';
 import SensorService, { Sensor } from '@/services/sensorService';
 import SwitchService, { Switch } from '@/services/switchService';
 import GroupService, { Group } from '@/services/groupService';
@@ -96,17 +97,9 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
     );
     const [selectedSwitchIds, setSelectedSwitchIds] = useState<Set<number>>(new Set());
 
-    const overlayRef = useRef<HTMLDivElement>(null);
     const { canClaim, loading: eligibilityLoading, refresh: refreshEligibility } = useCanClaimDevice();
 
     const TOTAL_STEPS = 4; // 0: claim, 1: name, 2: group, 3: done
-
-    // Close on Escape
-    useEffect(() => {
-        const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
-        window.addEventListener('keydown', handler);
-        return () => window.removeEventListener('keydown', handler);
-    }, [onClose]);
 
     // Load groups + all sensors + all switches when reaching step 2
     useEffect(() => {
@@ -613,14 +606,12 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
     };
 
     return (
-        <div
-            ref={overlayRef}
-            role="dialog"
-            aria-modal="true"
-            className="fixed inset-0 z-[100] flex items-end sm:items-center justify-center p-0 sm:p-6 bg-black/60 backdrop-blur-sm"
-            onClick={e => { if (e.target === overlayRef.current) onClose(); }}
+        <Modal
+            open
+            onClose={onClose}
+            containerClassName="fixed inset-0 z-[100] flex items-end sm:items-center justify-center p-0 sm:p-6 bg-black/60 backdrop-blur-sm"
+            panelClassName="relative w-full sm:max-w-md max-h-[90dvh] sm:max-h-[85vh] flex flex-col bg-gray-900 border border-gray-700/50 rounded-t-3xl sm:rounded-3xl shadow-2xl overflow-hidden"
         >
-            <div className="relative w-full sm:max-w-md max-h-[90dvh] sm:max-h-[85vh] flex flex-col bg-gray-900 border border-gray-700/50 rounded-t-3xl sm:rounded-3xl shadow-2xl overflow-hidden">
                 {/* Drag handle — mobile only */}
                 <div className="sm:hidden flex justify-center pt-3 pb-1 flex-shrink-0">
                     <div className="w-10 h-1 rounded-full bg-gray-700" />
@@ -641,8 +632,7 @@ const SetupWizard: React.FC<WizardProps> = ({ onClose, prefillSensor, initialSte
 
                     {renderStep()}
                 </div>
-            </div>
-        </div>
+        </Modal>
     );
 };
 

--- a/src/components/CartDrawer.tsx
+++ b/src/components/CartDrawer.tsx
@@ -8,7 +8,7 @@ import { ShopItem } from '@/services/shopService';
 import { effectivePriceInOre, vatLabel } from '@/lib/pricing';
 import { formatNok } from '@/lib/formatUtils';
 import { normalizeNoPhone } from '@/lib/phone';
-import { useEscapeKey } from '@/lib/useEscapeKey';
+import Drawer from '@/components/Drawer';
 
 export interface CartDrawerProps {
     open: boolean;
@@ -45,8 +45,6 @@ export default function CartDrawer({
         if (open) setPhone(initialPhone);
     }, [open, initialPhone]);
 
-    useEscapeKey(open && !submitting, onClose);
-
     if (!open) return null;
 
     const resolved: ResolvedLine[] = cart.map(line => ({
@@ -74,18 +72,15 @@ export default function CartDrawer({
     }
 
     return (
-        <div
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="cart-drawer-title"
-            className="fixed inset-0 z-50"
+        <Drawer
+            open={open}
+            onClose={onClose}
+            closable={!submitting}
+            labelledBy="cart-drawer-title"
+            containerClassName="fixed inset-0 z-50"
+            backdropClassName="absolute inset-0 bg-black/60 backdrop-blur-sm"
+            panelClassName="absolute inset-y-0 right-0 w-full max-w-md bg-gray-900 border-l border-gray-700/60 shadow-2xl flex flex-col"
         >
-            <div
-                className="absolute inset-0 bg-black/60 backdrop-blur-sm"
-                aria-hidden
-                onClick={() => { if (!submitting) onClose(); }}
-            />
-            <div className="absolute inset-y-0 right-0 w-full max-w-md bg-gray-900 border-l border-gray-700/60 shadow-2xl flex flex-col">
                 <div className="flex items-center justify-between p-4 border-b border-gray-700/60">
                     <h2 id="cart-drawer-title" className="text-base font-semibold text-gray-100">Cart</h2>
                     <button
@@ -231,7 +226,6 @@ export default function CartDrawer({
                         </p>
                     </div>
                 )}
-            </div>
-        </div>
+        </Drawer>
     );
 }

--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState } from 'react';
 import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
-import { useEscapeKey } from '@/lib/useEscapeKey';
+import Modal from '@/components/Modal';
 
 interface ConfirmModalProps {
     title: string;
@@ -25,8 +25,6 @@ const ConfirmModal: React.FC<ConfirmModalProps> = ({
 }) => {
     const [loading, setLoading] = useState(false);
 
-    useEscapeKey(!loading, onCancel);
-
     const handleConfirm = async () => {
         setLoading(true);
         try {
@@ -37,14 +35,17 @@ const ConfirmModal: React.FC<ConfirmModalProps> = ({
     };
 
     return (
-        <div
+        <Modal
+            open
+            onClose={onCancel}
+            closable={!loading}
             role="alertdialog"
-            aria-modal="true"
-            aria-labelledby="confirm-modal-title"
-            className="fixed inset-0 z-[200] flex items-center justify-center px-4"
+            labelledBy="confirm-modal-title"
+            containerClassName="fixed inset-0 z-[200] flex items-center justify-center px-4"
+            withBackdropElement
+            backdropClassName="absolute inset-0 bg-black/60 backdrop-blur-sm"
+            panelClassName="relative bg-gray-800 border border-gray-700/60 rounded-2xl p-6 max-w-sm w-full shadow-2xl"
         >
-            <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={() => { if (!loading) onCancel(); }} />
-            <div className="relative bg-gray-800 border border-gray-700/60 rounded-2xl p-6 max-w-sm w-full shadow-2xl">
                 <div className="flex items-center gap-3 mb-4">
                     <div className="w-10 h-10 rounded-xl bg-red-500/15 flex items-center justify-center flex-shrink-0">
                         <ExclamationTriangleIcon className="h-5 w-5 text-red-400" aria-hidden />
@@ -76,8 +77,7 @@ const ConfirmModal: React.FC<ConfirmModalProps> = ({
                         {confirmLabel}
                     </button>
                 </div>
-            </div>
-        </div>
+        </Modal>
     );
 };
 

--- a/src/components/DeviceManagePage.tsx
+++ b/src/components/DeviceManagePage.tsx
@@ -1,11 +1,12 @@
 "use client"
 
 import { useEffect, useState } from 'react';
-import { PencilIcon, CheckIcon, XMarkIcon, TrashIcon, ClipboardDocumentIcon, ArrowLeftIcon, PowerIcon, ShareIcon } from '@heroicons/react/24/outline';
+import { PencilIcon, TrashIcon, ClipboardDocumentIcon, ArrowLeftIcon, PowerIcon, ShareIcon } from '@heroicons/react/24/outline';
 import ConfirmModal from '@/components/ConfirmModal';
 import LoadingDots from '@/components/LoadingDots';
 import Section from '@/components/Section';
 import { inputClass } from '@/components/TextInput';
+import InlineEditField from '@/components/InlineEditField';
 import Alert from '@/components/Alert';
 import { toast } from 'sonner';
 import Link from 'next/link';
@@ -245,31 +246,16 @@ export function DeviceManagePage<T extends DeviceItem>({ config }: Props<T>) {
                                 return (
                                     <div key={item.id} className="bg-gray-900/50 border border-gray-700/40 rounded-xl p-4">
                                         {editingId === item.id ? (
-                                            <div className="space-y-2">
-                                                <div className="relative">
-                                                    <input
-                                                        type="text"
-                                                        value={editName}
-                                                        onChange={e => setEditName(e.target.value)}
-                                                        className={inputClass}
-                                                        maxLength={50}
-                                                        disabled={editLoading}
-                                                        autoFocus
-                                                    />
-                                                    <span className={`absolute right-2 top-1/2 -translate-y-1/2 text-[10px] tabular-nums pointer-events-none ${editName.length >= 45 ? 'text-amber-400' : 'text-gray-600'}`}>{editName.length}/50</span>
-                                                </div>
-                                                {editError && <p className="text-xs text-red-400">{editError}</p>}
-                                                <div className="flex gap-2">
-                                                    <button onClick={() => handleSaveName(item.id)} disabled={editLoading} className="flex items-center gap-1.5 px-3 py-1.5 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 text-white text-xs font-medium rounded-lg transition-all">
-                                                        <CheckIcon className="h-3.5 w-3.5" />
-                                                        {editLoading ? 'Saving…' : 'Save'}
-                                                    </button>
-                                                    <button onClick={cancelEditing} disabled={editLoading} className="flex items-center gap-1.5 px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-300 text-xs font-medium rounded-lg transition-all">
-                                                        <XMarkIcon className="h-3.5 w-3.5" />
-                                                        Cancel
-                                                    </button>
-                                                </div>
-                                            </div>
+                                            <InlineEditField
+                                                value={editName}
+                                                onChange={setEditName}
+                                                onSave={() => handleSaveName(item.id)}
+                                                onCancel={cancelEditing}
+                                                saving={editLoading}
+                                                maxLength={50}
+                                                error={editError}
+                                                autoFocus
+                                            />
                                         ) : (
                                             <>
                                                 <div className="flex items-start justify-between gap-2 mb-2">

--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import React from 'react';
+import { useEscapeKey } from '@/lib/useEscapeKey';
+import { useBodyScrollLock } from '@/hooks/useBodyScrollLock';
+
+export interface DrawerProps {
+    /** Whether the drawer is mounted. When false, nothing is rendered. */
+    open: boolean;
+    /** Called on backdrop click and Escape (unless `closable` is false). */
+    onClose: () => void;
+    children: React.ReactNode;
+    /** Guards backdrop-click and Escape — e.g. set to false while submitting. Defaults to true. */
+    closable?: boolean;
+    /** Maps to aria-labelledby on the dialog. */
+    labelledBy?: string;
+    /** Tailwind classes for the outer fixed container. */
+    containerClassName?: string;
+    /** Tailwind classes for the backdrop element. */
+    backdropClassName?: string;
+    /** Tailwind classes for the sliding panel that holds `children`. */
+    panelClassName?: string;
+}
+
+/**
+ * Slide-in panel shell. Handles the fixed backdrop, close-on-backdrop-click,
+ * Escape-to-close, dialog ARIA attributes, and body scroll lock while open.
+ *
+ * Positioning and slide direction are driven by `panelClassName` so each call
+ * site keeps its exact look; this component only owns the shared behavior. For
+ * drawers with bespoke enter/exit transitions, manage the panel transform
+ * classes yourself and keep `open` mounted across the animation.
+ */
+const Drawer: React.FC<DrawerProps> = ({
+    open,
+    onClose,
+    children,
+    closable = true,
+    labelledBy,
+    containerClassName = 'fixed inset-0 z-50',
+    backdropClassName = 'absolute inset-0 bg-black/60 backdrop-blur-sm',
+    panelClassName = '',
+}) => {
+    useEscapeKey(open && closable, onClose);
+    useBodyScrollLock(open);
+
+    if (!open) return null;
+
+    const handleBackdrop = () => { if (closable) onClose(); };
+
+    return (
+        <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby={labelledBy}
+            className={containerClassName}
+        >
+            <div className={backdropClassName} aria-hidden onClick={handleBackdrop} />
+            <div className={panelClassName}>
+                {children}
+            </div>
+        </div>
+    );
+};
+
+export default Drawer;

--- a/src/components/InlineEditField.tsx
+++ b/src/components/InlineEditField.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import React from 'react';
+import { CheckIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import { inputClass } from '@/components/TextInput';
+
+export interface InlineEditFieldProps {
+    value: string;
+    onChange: (value: string) => void;
+    onSave: () => void;
+    onCancel: () => void;
+    /** Disables inputs/buttons and shows the saving label while a save is in flight. */
+    saving?: boolean;
+    /** Enables a live "x/max" character counter and caps input length. */
+    maxLength?: number;
+    /** Validation/error message rendered under the input (default layout only). */
+    error?: string | null;
+    placeholder?: string;
+    inputType?: React.HTMLInputTypeAttribute;
+    inputMode?: React.HTMLAttributes<HTMLInputElement>['inputMode'];
+    autoComplete?: string;
+    autoFocus?: boolean;
+    /**
+     * Compact mode: a single inline Save (check) button, no Cancel button, sized
+     * to sit inside a header row. Enter saves and Escape cancels via the keyboard.
+     * Used by the device drawer's header rename control.
+     */
+    compact?: boolean;
+}
+
+/**
+ * Inline text editor: an input with an optional character counter and Save/Cancel
+ * controls. The default layout renders Save/Cancel buttons (and an error line);
+ * `compact` renders a single inline Save check button for header rename controls.
+ */
+const InlineEditField: React.FC<InlineEditFieldProps> = ({
+    value,
+    onChange,
+    onSave,
+    onCancel,
+    saving = false,
+    maxLength,
+    error,
+    placeholder,
+    inputType = 'text',
+    inputMode,
+    autoComplete,
+    autoFocus,
+    compact = false,
+}) => {
+    const counter = maxLength != null && (
+        <span className={`absolute right-2 top-1/2 -translate-y-1/2 text-[10px] tabular-nums pointer-events-none ${value.length >= maxLength - 5 ? 'text-amber-400' : 'text-gray-600'}`}>
+            {value.length}/{maxLength}
+        </span>
+    );
+
+    if (compact) {
+        return (
+            <div className="flex items-center gap-2">
+                <div className="relative flex-1 min-w-0">
+                    <input
+                        autoFocus={autoFocus}
+                        type={inputType}
+                        value={value}
+                        onChange={e => onChange(e.target.value)}
+                        onKeyDown={e => {
+                            if (e.key === 'Enter') onSave();
+                            if (e.key === 'Escape') onCancel();
+                        }}
+                        maxLength={maxLength}
+                        className="w-full bg-gray-800/80 border border-gray-600/50 rounded-lg px-2 py-1 pr-10 text-sm text-gray-100 focus:outline-none focus:border-sky-500/60"
+                    />
+                    {counter}
+                </div>
+                <button
+                    onClick={onSave}
+                    disabled={saving}
+                    aria-label="Save name"
+                    className="p-1 rounded-lg text-sky-400 hover:text-sky-300 hover:bg-sky-500/10 transition-colors flex-shrink-0"
+                >
+                    <CheckIcon className="h-4 w-4" />
+                </button>
+            </div>
+        );
+    }
+
+    return (
+        <div className="space-y-2">
+            <div className="relative">
+                <input
+                    type={inputType}
+                    inputMode={inputMode}
+                    autoComplete={autoComplete}
+                    value={value}
+                    onChange={e => onChange(e.target.value)}
+                    className={inputClass}
+                    maxLength={maxLength}
+                    placeholder={placeholder}
+                    disabled={saving}
+                    autoFocus={autoFocus}
+                />
+                {counter}
+            </div>
+            {error && <p className="text-xs text-red-400">{error}</p>}
+            <div className="flex gap-2">
+                <button onClick={onSave} disabled={saving} className="flex items-center gap-1.5 px-3 py-1.5 bg-sky-600 hover:bg-sky-500 disabled:opacity-50 text-white text-xs font-medium rounded-lg transition-all">
+                    <CheckIcon className="h-3.5 w-3.5" />
+                    {saving ? 'Saving…' : 'Save'}
+                </button>
+                <button onClick={onCancel} disabled={saving} className="flex items-center gap-1.5 px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-gray-300 text-xs font-medium rounded-lg transition-all">
+                    <XMarkIcon className="h-3.5 w-3.5" />
+                    Cancel
+                </button>
+            </div>
+        </div>
+    );
+};
+
+export default InlineEditField;

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import React from 'react';
+import { useEscapeKey } from '@/lib/useEscapeKey';
+import { useBodyScrollLock } from '@/hooks/useBodyScrollLock';
+
+export interface ModalProps {
+    /** Whether the modal is rendered. When false, nothing is mounted. */
+    open: boolean;
+    /** Called on backdrop click and Escape (unless `closable` is false). */
+    onClose: () => void;
+    children: React.ReactNode;
+    /** Guards backdrop-click and Escape — e.g. set to false while submitting. Defaults to true. */
+    closable?: boolean;
+    /** Dialog role. Defaults to "dialog"; ConfirmModal uses "alertdialog". */
+    role?: 'dialog' | 'alertdialog';
+    /** Maps to aria-labelledby on the dialog. */
+    labelledBy?: string;
+    /** Tailwind classes for the outer fixed positioning/backdrop container. */
+    containerClassName?: string;
+    /** Tailwind classes for the panel that holds `children`. */
+    panelClassName?: string;
+    /**
+     * When true, a separate absolute backdrop element is rendered behind the panel
+     * (used by call sites that blur the backdrop independently of the container).
+     * When false, the container itself carries the backdrop styling.
+     */
+    withBackdropElement?: boolean;
+    /** Extra classes for the standalone backdrop element (only when withBackdropElement). */
+    backdropClassName?: string;
+}
+
+/**
+ * Centered dialog shell. Handles the fixed backdrop, close-on-backdrop-click,
+ * Escape-to-close, dialog ARIA attributes, and body scroll lock while open.
+ *
+ * Layout is intentionally driven by `containerClassName`/`panelClassName` so each
+ * call site keeps its exact look; this component only owns the shared behavior.
+ */
+const Modal: React.FC<ModalProps> = ({
+    open,
+    onClose,
+    children,
+    closable = true,
+    role = 'dialog',
+    labelledBy,
+    containerClassName = '',
+    panelClassName = '',
+    withBackdropElement = false,
+    backdropClassName = '',
+}) => {
+    useEscapeKey(open && closable, onClose);
+    useBodyScrollLock(open);
+
+    if (!open) return null;
+
+    const handleBackdrop = () => { if (closable) onClose(); };
+
+    return (
+        <div
+            role={role}
+            aria-modal="true"
+            aria-labelledby={labelledBy}
+            className={containerClassName}
+        >
+            {withBackdropElement ? (
+                <div className={backdropClassName} aria-hidden onClick={handleBackdrop} />
+            ) : (
+                <div className="absolute inset-0" aria-hidden onClick={handleBackdrop} />
+            )}
+            <div className={panelClassName}>
+                {children}
+            </div>
+        </div>
+    );
+};
+
+export default Modal;

--- a/src/components/PasswordInput.tsx
+++ b/src/components/PasswordInput.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import React, { useState } from 'react';
+import { EyeIcon, EyeSlashIcon } from '@heroicons/react/24/outline';
+import { inputClass } from '@/components/TextInput';
+
+type Props = Omit<React.InputHTMLAttributes<HTMLInputElement>, 'type'>;
+
+/**
+ * Password input with a show/hide eye toggle. Mirrors the styling used across the
+ * auth pages: the shared `inputClass` plus `pr-10` to leave room for the toggle.
+ * Any extra className is appended after that base.
+ */
+const PasswordInput: React.FC<Props> = ({ className, ...props }) => {
+    const [show, setShow] = useState(false);
+
+    return (
+        <div className="relative">
+            <input
+                {...props}
+                type={show ? 'text' : 'password'}
+                className={`${inputClass} pr-10${className ? ` ${className}` : ''}`}
+            />
+            <button
+                type="button"
+                onClick={() => setShow(v => !v)}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-300 transition-colors"
+                tabIndex={-1}
+            >
+                {show ? <EyeSlashIcon className="h-4 w-4" /> : <EyeIcon className="h-4 w-4" />}
+            </button>
+        </div>
+    );
+};
+
+export default PasswordInput;

--- a/src/components/PaymentPhoneModal.tsx
+++ b/src/components/PaymentPhoneModal.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 import { useEffect, useRef, useState } from 'react';
 import { CheckIcon } from '@heroicons/react/24/outline';
 import { normalizeNoPhone } from '@/lib/phone';
-import { useEscapeKey } from '@/lib/useEscapeKey';
+import Modal from '@/components/Modal';
 
 export interface PaymentPhoneModalProps {
     title: string;
@@ -31,8 +31,6 @@ export default function PaymentPhoneModal({
     const [agreed, setAgreed] = useState(false);
     const phoneRef = useRef<HTMLInputElement>(null);
 
-    useEscapeKey(!submitting, onCancel);
-
     useEffect(() => {
         phoneRef.current?.focus();
     }, []);
@@ -50,14 +48,14 @@ export default function PaymentPhoneModal({
     }
 
     return (
-        <div
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="payment-modal-title"
-            className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+        <Modal
+            open
+            onClose={onCancel}
+            closable={!submitting}
+            labelledBy="payment-modal-title"
+            containerClassName="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+            panelClassName="relative bg-gray-900 border border-gray-700/60 rounded-2xl p-5 w-full max-w-sm space-y-4 shadow-2xl"
         >
-            <div className="absolute inset-0" aria-hidden onClick={() => { if (!submitting) onCancel(); }} />
-            <div className="relative bg-gray-900 border border-gray-700/60 rounded-2xl p-5 w-full max-w-sm space-y-4 shadow-2xl">
                 <p id="payment-modal-title" className="text-sm font-semibold text-gray-100">{title}</p>
                 <div className="text-xs text-gray-500">{summary}</div>
 
@@ -132,7 +130,6 @@ export default function PaymentPhoneModal({
                         Cancel
                     </button>
                 </div>
-            </div>
-        </div>
+        </Modal>
     );
 }

--- a/src/components/QuantityChangeModal.tsx
+++ b/src/components/QuantityChangeModal.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import { MinusIcon, PlusIcon } from '@heroicons/react/24/outline';
-import { useEscapeKey } from '@/lib/useEscapeKey';
+import Modal from '@/components/Modal';
 import { effectivePriceInOre, vatLabel } from '@/lib/pricing';
 import { formatNok } from '@/lib/formatUtils';
 import type { Subscription } from '@/services/subscriptionService';
@@ -24,8 +24,6 @@ export default function QuantityChangeModal({
 }: QuantityChangeModalProps) {
     const [qty, setQty] = useState(subscription.quantity);
 
-    useEscapeKey(!submitting, onCancel);
-
     const unitPrice = effectivePriceInOre(subscription.priceInOre, vatEnabled);
     const newTotal = unitPrice * qty;
     const intervalLabel = subscription.interval === 'Monthly' ? 'month' : 'year';
@@ -36,14 +34,14 @@ export default function QuantityChangeModal({
     }
 
     return (
-        <div
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="qty-change-title"
-            className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+        <Modal
+            open
+            onClose={onCancel}
+            closable={!submitting}
+            labelledBy="qty-change-title"
+            containerClassName="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4"
+            panelClassName="relative bg-gray-900 border border-gray-700/60 rounded-2xl p-5 w-full max-w-sm space-y-4 shadow-2xl"
         >
-            <div className="absolute inset-0" aria-hidden onClick={() => { if (!submitting) onCancel(); }} />
-            <div className="relative bg-gray-900 border border-gray-700/60 rounded-2xl p-5 w-full max-w-sm space-y-4 shadow-2xl">
                 <div>
                     <p id="qty-change-title" className="text-sm font-semibold text-gray-100">Change quantity</p>
                     <p className="text-xs text-gray-500 mt-1">{subscription.productName} — currently × {subscription.quantity}</p>
@@ -103,7 +101,6 @@ export default function QuantityChangeModal({
                         Cancel
                     </button>
                 </div>
-            </div>
-        </div>
+        </Modal>
     );
 }

--- a/src/components/ShareDeviceModal.tsx
+++ b/src/components/ShareDeviceModal.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { XMarkIcon, UserPlusIcon } from '@heroicons/react/24/outline';
 import { toast } from 'sonner';
 import { inputClass } from '@/components/TextInput';
-import { useEscapeKey } from '@/lib/useEscapeKey';
+import Modal from '@/components/Modal';
 import { SensorShare, SharePermission } from '@/services/sensorService';
 
 interface ShareDeviceModalProps {
@@ -27,8 +27,6 @@ const ShareDeviceModal: React.FC<ShareDeviceModalProps> = ({
     const [submitting, setSubmitting] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [revokingId, setRevokingId] = useState<string | null>(null);
-
-    useEscapeKey(!submitting, onClose);
 
     const load = useCallback(async () => {
         try {
@@ -75,9 +73,16 @@ const ShareDeviceModal: React.FC<ShareDeviceModalProps> = ({
     };
 
     return (
-        <div role="dialog" aria-modal="true" aria-labelledby="share-modal-title" className="fixed inset-0 z-[200] flex items-center justify-center px-4">
-            <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={() => { if (!submitting) onClose(); }} />
-            <div className="relative bg-gray-800 border border-gray-700/60 rounded-2xl p-6 max-w-md w-full shadow-2xl">
+        <Modal
+            open
+            onClose={onClose}
+            closable={!submitting}
+            labelledBy="share-modal-title"
+            containerClassName="fixed inset-0 z-[200] flex items-center justify-center px-4"
+            withBackdropElement
+            backdropClassName="absolute inset-0 bg-black/60 backdrop-blur-sm"
+            panelClassName="relative bg-gray-800 border border-gray-700/60 rounded-2xl p-6 max-w-md w-full shadow-2xl"
+        >
                 <div className="flex items-start justify-between gap-3 mb-4">
                     <div>
                         <h3 id="share-modal-title" className="text-sm font-semibold text-gray-100">Share {deviceName}</h3>
@@ -156,8 +161,7 @@ const ShareDeviceModal: React.FC<ShareDeviceModalProps> = ({
                         </ul>
                     )}
                 </div>
-            </div>
-        </div>
+        </Modal>
     );
 };
 

--- a/src/components/StatCard.tsx
+++ b/src/components/StatCard.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import React from 'react';
+
+export interface StatItem {
+    label: string;
+    value: React.ReactNode;
+}
+
+interface StatCardProps extends StatItem {
+    /** Renders an em dash when the value is null/undefined. Defaults to true. */
+    placeholderWhenEmpty?: boolean;
+}
+
+/**
+ * Stat tile used across the admin dashboard: a large value over a small label,
+ * in the shared `bg-gray-900/50` rounded card.
+ */
+export const StatCard: React.FC<StatCardProps> = ({ label, value, placeholderWhenEmpty = true }) => {
+    const display = placeholderWhenEmpty ? (value ?? '—') : value;
+    return (
+        <div className="bg-gray-900/50 border border-gray-700/40 rounded-xl p-4">
+            <p className="text-2xl font-bold text-gray-100 tabular-nums">{display}</p>
+            <p className="text-xs text-gray-500 mt-1">{label}</p>
+        </div>
+    );
+};
+
+interface StatGridProps {
+    items: StatItem[];
+    /** Tailwind classes for the grid wrapper; defaults to a 2/4-column responsive grid. */
+    className?: string;
+    placeholderWhenEmpty?: boolean;
+}
+
+/** Renders a grid of {@link StatCard}s from an items array. */
+export const StatGrid: React.FC<StatGridProps> = ({
+    items,
+    className = 'grid grid-cols-2 sm:grid-cols-4 gap-3',
+    placeholderWhenEmpty = true,
+}) => (
+    <div className={className}>
+        {items.map(item => (
+            <StatCard key={item.label} label={item.label} value={item.value} placeholderWhenEmpty={placeholderWhenEmpty} />
+        ))}
+    </div>
+);
+
+export default StatCard;

--- a/src/hooks/useBodyScrollLock.ts
+++ b/src/hooks/useBodyScrollLock.ts
@@ -1,0 +1,28 @@
+'use client';
+
+import { useEffect } from 'react';
+
+/**
+ * Prevents the document body from scrolling while a modal or drawer is open.
+ * Restores the previous overflow value on close or unmount, and is safe to
+ * nest: it only restores once no lock is active.
+ */
+let lockCount = 0;
+let previousOverflow = '';
+
+export function useBodyScrollLock(enabled: boolean) {
+    useEffect(() => {
+        if (!enabled) return;
+        if (lockCount === 0) {
+            previousOverflow = document.body.style.overflow;
+            document.body.style.overflow = 'hidden';
+        }
+        lockCount++;
+        return () => {
+            lockCount--;
+            if (lockCount === 0) {
+                document.body.style.overflow = previousOverflow;
+            }
+        };
+    }, [enabled]);
+}

--- a/src/hooks/useOutsideClick.ts
+++ b/src/hooks/useOutsideClick.ts
@@ -1,0 +1,30 @@
+'use client';
+
+import { RefObject, useEffect } from 'react';
+
+/**
+ * Dismisses something when a pointer interaction lands outside the referenced element.
+ * Listens for both mousedown and touchstart so it works on touch devices too.
+ *
+ * @param ref      Element to treat as "inside". Clicks within it are ignored.
+ * @param onOutside Called when a click/tap occurs outside the element.
+ * @param enabled  When false, no listeners are attached (defaults to true).
+ */
+export function useOutsideClick<T extends HTMLElement>(
+    ref: RefObject<T | null>,
+    onOutside: () => void,
+    enabled: boolean = true,
+) {
+    useEffect(() => {
+        if (!enabled) return;
+        const handler = (e: MouseEvent | TouchEvent) => {
+            if (ref.current && !ref.current.contains(e.target as Node)) onOutside();
+        };
+        document.addEventListener('mousedown', handler);
+        document.addEventListener('touchstart', handler);
+        return () => {
+            document.removeEventListener('mousedown', handler);
+            document.removeEventListener('touchstart', handler);
+        };
+    }, [ref, onOutside, enabled]);
+}

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,19 @@
+/** Per-field validation messages, keyed by field name. */
+export type FieldErrors = Record<string, string[]>;
+
+/**
+ * Carries structured per-field validation errors so callers can map them onto
+ * form fields without serializing through `Error.message`. Use `instanceof
+ * FieldValidationError` at the call site to read `fieldErrors`.
+ */
+export class FieldValidationError extends Error {
+    readonly fieldErrors: FieldErrors;
+
+    constructor(fieldErrors: FieldErrors, message = 'Validation failed') {
+        super(message);
+        this.name = 'FieldValidationError';
+        this.fieldErrors = fieldErrors;
+        // Restore the prototype chain for instanceof to work after transpilation.
+        Object.setPrototypeOf(this, FieldValidationError.prototype);
+    }
+}

--- a/src/lib/validation/registerSchema.ts
+++ b/src/lib/validation/registerSchema.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+import type { FieldErrors } from '@/lib/errors';
+
+/**
+ * Validation rules for the registration form. Shared between the user service
+ * (server-bound submit) and the register page (live client-side feedback) so
+ * the password rules stay in one place.
+ */
+export const registerSchema = z.object({
+    firstName: z
+        .string()
+        .min(2, { message: 'First Name must be at least 2 characters long.' })
+        .trim(),
+    lastName: z
+        .string()
+        .min(2, { message: 'Last Name must be at least 2 characters long.' })
+        .trim(),
+    userName: z
+        .string()
+        .min(2, { message: 'Username must be at least 2 characters long.' })
+        .trim(),
+    email: z.string().email({ message: 'Please enter a valid email.' }).trim(),
+    password: z
+        .string()
+        .min(8, { message: 'Be at least 8 characters long.' })
+        .max(128, { message: 'Be at most 128 characters long.' })
+        .regex(/[a-zA-Z]/, { message: 'Contain at least one letter.' })
+        .regex(/[0-9]/, { message: 'Contain at least one number.' })
+        .regex(/[A-Z]/, { message: 'Contain at least one uppercase letter.' })
+        .regex(/[^a-zA-Z0-9]/, {
+            message: 'Contain at least one special character.',
+        })
+        .trim(),
+});
+
+export type RegisterInput = z.infer<typeof registerSchema>;
+
+/** Groups Zod issues into per-field message arrays keyed by the first path segment. */
+export function zodIssuesToFieldErrors(issues: z.ZodIssue[]): FieldErrors {
+    return issues.reduce((acc, issue) => {
+        const path = issue.path[0] as string;
+        if (!acc[path]) acc[path] = [];
+        acc[path].push(issue.message);
+        return acc;
+    }, {} as FieldErrors);
+}

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -2,9 +2,10 @@ import axiosInstance from '@/services/axiosInstance';
 import { UserDTO } from '@/dto/UserDTO';
 import { AxiosError } from 'axios';
 import { getSession } from 'next-auth/react';
-import { z } from 'zod';
 import { formatApiError } from '@/lib/errorMessages';
 import { parseValidationErrors } from '@/lib/apiErrors';
+import { FieldValidationError } from '@/lib/errors';
+import { registerSchema, zodIssuesToFieldErrors } from '@/lib/validation/registerSchema';
 
 interface RegisterData extends LoginData {
     firstName: string;
@@ -24,33 +25,6 @@ export interface DataRetention {
     optOut: boolean;
     optedOutAt: string | null;
 }
-
-const registerSchema = z.object({
-    firstName: z
-        .string()
-        .min(2, { message: 'First Name must be at least 2 characters long.' })
-        .trim(),
-    lastName: z
-        .string()
-        .min(2, { message: 'Last Name must be at least 2 characters long.' })
-        .trim(),
-    userName: z
-        .string()
-        .min(2, { message: 'Username must be at least 2 characters long.' })
-        .trim(),
-    email: z.string().email({ message: 'Please enter a valid email.' }).trim(),
-    password: z
-        .string()
-        .min(8, { message: 'Be at least 8 characters long.' })
-        .max(128, { message: 'Be at most 128 characters long.' })
-        .regex(/[a-zA-Z]/, { message: 'Contain at least one letter.' })
-        .regex(/[0-9]/, { message: 'Contain at least one number.' })
-        .regex(/[A-Z]/, { message: 'Contain at least one uppercase letter.' })
-        .regex(/[^a-zA-Z0-9]/, {
-            message: 'Contain at least one special character.',
-        })
-        .trim(),
-});
 
 const UserService = {
     async getUserProfile(): Promise<UserDTO> {
@@ -85,15 +59,7 @@ const UserService = {
         const result = registerSchema.safeParse(data);
 
         if (!result.success) {
-            const errors = result.error.issues.reduce((acc, error) => {
-                const path = error.path[0] as string;
-                if (!acc[path]) {
-                    acc[path] = [];
-                }
-                acc[path].push(error.message);
-                return acc;
-            }, {} as Record<string, string[]>);
-            throw new Error(JSON.stringify(errors));
+            throw new FieldValidationError(zodIssuesToFieldErrors(result.error.issues));
         }
 
         try {
@@ -102,7 +68,7 @@ const UserService = {
         } catch (error: unknown) {
             if (error instanceof AxiosError) {
                 const fieldErrors = parseValidationErrors(error.response?.data);
-                if (fieldErrors) throw new Error(JSON.stringify(fieldErrors));
+                if (fieldErrors) throw new FieldValidationError(fieldErrors);
             }
             throw new Error(formatApiError(error, 'Failed to register'));
         }

--- a/src/tests/components/Drawer.test.tsx
+++ b/src/tests/components/Drawer.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import Drawer from '@/components/Drawer'
+
+afterEach(() => {
+    document.body.style.overflow = ''
+})
+
+describe('Drawer', () => {
+    it('renders nothing when closed', () => {
+        const { container } = render(
+            <Drawer open={false} onClose={() => {}}><p>Panel</p></Drawer>
+        )
+        expect(container).toBeEmptyDOMElement()
+    })
+
+    it('exposes the dialog role with aria-modal', () => {
+        render(<Drawer open onClose={() => {}} labelledBy="t"><p>Panel</p></Drawer>)
+        const dialog = screen.getByRole('dialog')
+        expect(dialog).toHaveAttribute('aria-modal', 'true')
+        expect(dialog).toHaveAttribute('aria-labelledby', 't')
+    })
+
+    it('closes on Escape and backdrop click, and respects closable=false', () => {
+        const onClose = vi.fn()
+        const { rerender } = render(<Drawer open onClose={onClose}><p>Panel</p></Drawer>)
+        fireEvent.keyDown(window, { key: 'Escape' })
+        const backdrop = document.querySelector('[aria-hidden]') as HTMLElement
+        fireEvent.click(backdrop)
+        expect(onClose).toHaveBeenCalledTimes(2)
+
+        onClose.mockClear()
+        rerender(<Drawer open onClose={onClose} closable={false}><p>Panel</p></Drawer>)
+        fireEvent.keyDown(window, { key: 'Escape' })
+        fireEvent.click(document.querySelector('[aria-hidden]') as HTMLElement)
+        expect(onClose).not.toHaveBeenCalled()
+    })
+
+    it('locks body scroll while open and restores it on close', () => {
+        const { rerender } = render(<Drawer open onClose={() => {}}><p>Panel</p></Drawer>)
+        expect(document.body.style.overflow).toBe('hidden')
+        rerender(<Drawer open={false} onClose={() => {}}><p>Panel</p></Drawer>)
+        expect(document.body.style.overflow).toBe('')
+    })
+})

--- a/src/tests/components/InlineEditField.test.tsx
+++ b/src/tests/components/InlineEditField.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import InlineEditField from '@/components/InlineEditField'
+
+describe('InlineEditField (default layout)', () => {
+    it('calls onSave when Save is clicked and onCancel when Cancel is clicked', () => {
+        const onSave = vi.fn()
+        const onCancel = vi.fn()
+        render(
+            <InlineEditField value="Garage" onChange={() => {}} onSave={onSave} onCancel={onCancel} />
+        )
+        fireEvent.click(screen.getByText('Save'))
+        expect(onSave).toHaveBeenCalledOnce()
+        fireEvent.click(screen.getByText('Cancel'))
+        expect(onCancel).toHaveBeenCalledOnce()
+    })
+
+    it('forwards typing through onChange', () => {
+        const onChange = vi.fn()
+        render(<InlineEditField value="Garage" onChange={onChange} onSave={() => {}} onCancel={() => {}} />)
+        fireEvent.change(screen.getByDisplayValue('Garage'), { target: { value: 'Garages' } })
+        expect(onChange).toHaveBeenCalledWith('Garages')
+    })
+
+    it('shows the character counter and caps length when maxLength is set', () => {
+        render(<InlineEditField value="abc" onChange={() => {}} onSave={() => {}} onCancel={() => {}} maxLength={50} />)
+        expect(screen.getByText('3/50')).toBeInTheDocument()
+        expect(screen.getByDisplayValue('abc')).toHaveAttribute('maxlength', '50')
+    })
+
+    it('turns the counter amber within 5 of the limit', () => {
+        const { rerender } = render(
+            <InlineEditField value={'x'.repeat(44)} onChange={() => {}} onSave={() => {}} onCancel={() => {}} maxLength={50} />
+        )
+        expect(screen.getByText('44/50').className).toContain('text-gray-600')
+
+        rerender(
+            <InlineEditField value={'x'.repeat(45)} onChange={() => {}} onSave={() => {}} onCancel={() => {}} maxLength={50} />
+        )
+        expect(screen.getByText('45/50').className).toContain('text-amber-400')
+    })
+
+    it('renders no counter when maxLength is omitted', () => {
+        render(<InlineEditField value="abc" onChange={() => {}} onSave={() => {}} onCancel={() => {}} />)
+        expect(screen.queryByText(/\/\d+$/)).not.toBeInTheDocument()
+    })
+
+    it('shows an error message and disables controls while saving', () => {
+        render(
+            <InlineEditField value="abc" onChange={() => {}} onSave={() => {}} onCancel={() => {}} error="Required" saving />
+        )
+        expect(screen.getByText('Required')).toBeInTheDocument()
+        expect(screen.getByText('Saving…')).toBeInTheDocument()
+        expect(screen.getByDisplayValue('abc')).toBeDisabled()
+    })
+})
+
+describe('InlineEditField (compact)', () => {
+    it('saves on Enter and cancels on Escape', () => {
+        const onSave = vi.fn()
+        const onCancel = vi.fn()
+        render(
+            <InlineEditField compact value="Garage" onChange={() => {}} onSave={onSave} onCancel={onCancel} maxLength={50} />
+        )
+        const input = screen.getByDisplayValue('Garage')
+        fireEvent.keyDown(input, { key: 'Enter' })
+        expect(onSave).toHaveBeenCalledOnce()
+        fireEvent.keyDown(input, { key: 'Escape' })
+        expect(onCancel).toHaveBeenCalledOnce()
+    })
+
+    it('renders only a single save button (no Cancel) and the counter', () => {
+        render(
+            <InlineEditField compact value="abc" onChange={() => {}} onSave={() => {}} onCancel={() => {}} maxLength={50} />
+        )
+        expect(screen.getByText('3/50')).toBeInTheDocument()
+        expect(screen.queryByText('Cancel')).not.toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Save name' })).toBeInTheDocument()
+    })
+})

--- a/src/tests/components/Modal.test.tsx
+++ b/src/tests/components/Modal.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import Modal from '@/components/Modal'
+
+afterEach(() => {
+    document.body.style.overflow = ''
+})
+
+describe('Modal', () => {
+    it('renders nothing when closed', () => {
+        const { container } = render(
+            <Modal open={false} onClose={() => {}}><p>Body</p></Modal>
+        )
+        expect(container).toBeEmptyDOMElement()
+    })
+
+    it('exposes the dialog role with aria-modal and labelledby', () => {
+        render(
+            <Modal open onClose={() => {}} labelledBy="title"><h2 id="title">Hi</h2></Modal>
+        )
+        const dialog = screen.getByRole('dialog')
+        expect(dialog).toHaveAttribute('aria-modal', 'true')
+        expect(dialog).toHaveAttribute('aria-labelledby', 'title')
+    })
+
+    it('supports the alertdialog role', () => {
+        render(<Modal open onClose={() => {}} role="alertdialog"><p>!</p></Modal>)
+        expect(screen.getByRole('alertdialog')).toBeInTheDocument()
+    })
+
+    it('closes on Escape and on backdrop click', () => {
+        const onClose = vi.fn()
+        render(<Modal open onClose={onClose}><p>Body</p></Modal>)
+        fireEvent.keyDown(window, { key: 'Escape' })
+        expect(onClose).toHaveBeenCalledTimes(1)
+        // The backdrop is the aria-hidden element behind the panel.
+        const backdrop = document.querySelector('[aria-hidden]') as HTMLElement
+        fireEvent.click(backdrop)
+        expect(onClose).toHaveBeenCalledTimes(2)
+    })
+
+    it('does not close when closable is false', () => {
+        const onClose = vi.fn()
+        render(<Modal open onClose={onClose} closable={false}><p>Body</p></Modal>)
+        fireEvent.keyDown(window, { key: 'Escape' })
+        const backdrop = document.querySelector('[aria-hidden]') as HTMLElement
+        fireEvent.click(backdrop)
+        expect(onClose).not.toHaveBeenCalled()
+    })
+
+    it('locks body scroll while open and restores it on close', () => {
+        const { rerender } = render(<Modal open onClose={() => {}}><p>Body</p></Modal>)
+        expect(document.body.style.overflow).toBe('hidden')
+        rerender(<Modal open={false} onClose={() => {}}><p>Body</p></Modal>)
+        expect(document.body.style.overflow).toBe('')
+    })
+})

--- a/src/tests/components/PasswordInput.test.tsx
+++ b/src/tests/components/PasswordInput.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import PasswordInput from '@/components/PasswordInput'
+
+describe('PasswordInput', () => {
+    it('renders as a password field by default', () => {
+        render(<PasswordInput placeholder="pw" />)
+        const input = screen.getByPlaceholderText('pw')
+        expect(input).toHaveAttribute('type', 'password')
+    })
+
+    it('toggles between password and text when the eye button is clicked', () => {
+        render(<PasswordInput placeholder="pw" />)
+        const input = screen.getByPlaceholderText('pw')
+        const toggle = screen.getByRole('button')
+
+        expect(input).toHaveAttribute('type', 'password')
+        fireEvent.click(toggle)
+        expect(input).toHaveAttribute('type', 'text')
+        fireEvent.click(toggle)
+        expect(input).toHaveAttribute('type', 'password')
+    })
+
+    it('keeps the pr-10 spacing and forwards extra className', () => {
+        render(<PasswordInput placeholder="pw" className="extra-class" />)
+        const input = screen.getByPlaceholderText('pw')
+        expect(input.className).toContain('pr-10')
+        expect(input.className).toContain('extra-class')
+    })
+
+    it('forwards value and onChange', () => {
+        const onChange = vi.fn()
+        render(<PasswordInput placeholder="pw" value="secret" onChange={onChange} />)
+        const input = screen.getByPlaceholderText('pw') as HTMLInputElement
+        expect(input.value).toBe('secret')
+        fireEvent.change(input, { target: { value: 'next' } })
+        expect(onChange).toHaveBeenCalledOnce()
+    })
+
+    it('the toggle is excluded from tab order', () => {
+        render(<PasswordInput placeholder="pw" />)
+        expect(screen.getByRole('button')).toHaveAttribute('tabindex', '-1')
+    })
+})

--- a/src/tests/components/StatCard.test.tsx
+++ b/src/tests/components/StatCard.test.tsx
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import StatCard, { StatGrid } from '@/components/StatCard'
+
+describe('StatCard', () => {
+    it('renders value and label', () => {
+        render(<StatCard label="Users" value={42} />)
+        expect(screen.getByText('42')).toBeInTheDocument()
+        expect(screen.getByText('Users')).toBeInTheDocument()
+    })
+
+    it('shows an em dash for nullish values by default', () => {
+        render(<StatCard label="Users" value={undefined} />)
+        expect(screen.getByText('—')).toBeInTheDocument()
+    })
+
+    it('renders an empty value verbatim when placeholderWhenEmpty is false', () => {
+        const { container } = render(<StatCard label="Users" value={0} placeholderWhenEmpty={false} />)
+        expect(container.querySelector('p')?.textContent).toBe('0')
+    })
+})
+
+describe('StatGrid', () => {
+    it('renders one card per item', () => {
+        render(
+            <StatGrid items={[
+                { label: 'A', value: 1 },
+                { label: 'B', value: 2 },
+                { label: 'C', value: undefined },
+            ]} />
+        )
+        expect(screen.getByText('1')).toBeInTheDocument()
+        expect(screen.getByText('2')).toBeInTheDocument()
+        expect(screen.getByText('—')).toBeInTheDocument()
+        expect(screen.getByText('A')).toBeInTheDocument()
+    })
+})

--- a/src/tests/hooks/useOutsideClick.test.tsx
+++ b/src/tests/hooks/useOutsideClick.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { useRef } from 'react'
+import { useOutsideClick } from '@/hooks/useOutsideClick'
+
+function Probe({ onOutside, enabled = true }: { onOutside: () => void; enabled?: boolean }) {
+    const ref = useRef<HTMLDivElement>(null)
+    useOutsideClick(ref, onOutside, enabled)
+    return (
+        <div>
+            <div ref={ref} data-testid="inside">inside</div>
+            <div data-testid="outside">outside</div>
+        </div>
+    )
+}
+
+afterEach(() => {
+    while (document.body.firstChild) document.body.removeChild(document.body.firstChild)
+})
+
+describe('useOutsideClick', () => {
+    it('fires when a mousedown lands outside the ref element', () => {
+        const onOutside = vi.fn()
+        render(<Probe onOutside={onOutside} />)
+        fireEvent.mouseDown(screen.getByTestId('outside'))
+        expect(onOutside).toHaveBeenCalledOnce()
+    })
+
+    it('does not fire when the click is inside the ref element', () => {
+        const onOutside = vi.fn()
+        render(<Probe onOutside={onOutside} />)
+        fireEvent.mouseDown(screen.getByTestId('inside'))
+        expect(onOutside).not.toHaveBeenCalled()
+    })
+
+    it('also fires on touchstart outside', () => {
+        const onOutside = vi.fn()
+        render(<Probe onOutside={onOutside} />)
+        fireEvent.touchStart(screen.getByTestId('outside'))
+        expect(onOutside).toHaveBeenCalledOnce()
+    })
+
+    it('does nothing when disabled', () => {
+        const onOutside = vi.fn()
+        render(<Probe onOutside={onOutside} enabled={false} />)
+        fireEvent.mouseDown(screen.getByTestId('outside'))
+        expect(onOutside).not.toHaveBeenCalled()
+    })
+
+    it('detaches its listeners on unmount', () => {
+        const onOutside = vi.fn()
+        const { unmount } = render(<Probe onOutside={onOutside} />)
+        unmount()
+        fireEvent.mouseDown(document.body)
+        expect(onOutside).not.toHaveBeenCalled()
+    })
+})

--- a/src/tests/lib/errors.test.ts
+++ b/src/tests/lib/errors.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { FieldValidationError } from '@/lib/errors'
+
+describe('FieldValidationError', () => {
+    it('is an Error and carries the field errors', () => {
+        const err = new FieldValidationError({ email: ['Please enter a valid email.'] })
+        expect(err).toBeInstanceOf(Error)
+        expect(err).toBeInstanceOf(FieldValidationError)
+        expect(err.fieldErrors).toEqual({ email: ['Please enter a valid email.'] })
+        expect(err.name).toBe('FieldValidationError')
+    })
+
+    it('uses a default message and allows an override', () => {
+        expect(new FieldValidationError({}).message).toBe('Validation failed')
+        expect(new FieldValidationError({}, 'Bad input').message).toBe('Bad input')
+    })
+
+    it('survives an instanceof check after being thrown and caught', () => {
+        let caught: unknown
+        try {
+            throw new FieldValidationError({ password: ['too short'] })
+        } catch (e) {
+            caught = e
+        }
+        expect(caught instanceof FieldValidationError).toBe(true)
+        if (caught instanceof FieldValidationError) {
+            expect(caught.fieldErrors.password).toEqual(['too short'])
+        }
+    })
+})

--- a/src/tests/lib/registerSchema.test.ts
+++ b/src/tests/lib/registerSchema.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { registerSchema, zodIssuesToFieldErrors } from '@/lib/validation/registerSchema'
+
+const valid = {
+    firstName: 'Ada',
+    lastName: 'Lovelace',
+    userName: 'ada',
+    email: 'ada@example.com',
+    password: 'Sup3r!secret',
+}
+
+describe('registerSchema', () => {
+    it('accepts a fully valid registration', () => {
+        expect(registerSchema.safeParse(valid).success).toBe(true)
+    })
+
+    it('rejects names shorter than 2 characters', () => {
+        const result = registerSchema.safeParse({ ...valid, firstName: 'A', lastName: 'B', userName: 'c' })
+        expect(result.success).toBe(false)
+        if (!result.success) {
+            const fields = zodIssuesToFieldErrors(result.error.issues)
+            expect(fields.firstName).toContain('First Name must be at least 2 characters long.')
+            expect(fields.lastName).toContain('Last Name must be at least 2 characters long.')
+            expect(fields.userName).toContain('Username must be at least 2 characters long.')
+        }
+    })
+
+    it('rejects an invalid email', () => {
+        const result = registerSchema.safeParse({ ...valid, email: 'not-an-email' })
+        expect(result.success).toBe(false)
+        if (!result.success) {
+            expect(zodIssuesToFieldErrors(result.error.issues).email).toContain('Please enter a valid email.')
+        }
+    })
+
+    it('enforces every password rule', () => {
+        const cases: Array<[string, string]> = [
+            ['Sh1!aaa', 'Be at least 8 characters long.'],
+            ['nouppercase1!', 'Contain at least one uppercase letter.'],
+            ['NoNumber!!', 'Contain at least one number.'],
+            ['NoSpecial123', 'Contain at least one special character.'],
+            ['12345678!', 'Contain at least one letter.'],
+        ]
+        for (const [password, message] of cases) {
+            const result = registerSchema.safeParse({ ...valid, password })
+            expect(result.success, `expected "${password}" to fail`).toBe(false)
+            if (!result.success) {
+                expect(zodIssuesToFieldErrors(result.error.issues).password).toContain(message)
+            }
+        }
+    })
+
+    it('groups multiple issues per field', () => {
+        const result = registerSchema.safeParse({ ...valid, password: 'a' })
+        expect(result.success).toBe(false)
+        if (!result.success) {
+            const fields = zodIssuesToFieldErrors(result.error.issues)
+            expect(fields.password.length).toBeGreaterThan(1)
+        }
+    })
+})

--- a/src/tests/services/userService.test.ts
+++ b/src/tests/services/userService.test.ts
@@ -12,12 +12,70 @@ vi.mock('next-auth/react', () => ({ getSession: vi.fn() }))
 
 import UserService from '@/services/userService'
 import axiosInstance from '@/services/axiosInstance'
+import { FieldValidationError } from '@/lib/errors'
+import { AxiosError } from 'axios'
 
 const mockGet = axiosInstance.get as ReturnType<typeof vi.fn>
 const mockPut = axiosInstance.put as ReturnType<typeof vi.fn>
+const mockPost = axiosInstance.post as ReturnType<typeof vi.fn>
+
+const validRegistration = {
+    firstName: 'Ada',
+    lastName: 'Lovelace',
+    userName: 'ada',
+    email: 'ada@example.com',
+    password: 'Sup3r!secret',
+    confirmAge16Plus: true,
+    acceptTerms: true,
+    termsVersion: 'v1',
+}
 
 beforeEach(() => {
     vi.clearAllMocks()
+})
+
+describe('UserService.register', () => {
+    it('throws a FieldValidationError with per-field messages on client-side validation failure', async () => {
+        const promise = UserService.register({ ...validRegistration, email: 'bad', password: 'weak' })
+        await expect(promise).rejects.toBeInstanceOf(FieldValidationError)
+        try {
+            await UserService.register({ ...validRegistration, email: 'bad' })
+        } catch (e) {
+            expect(e).toBeInstanceOf(FieldValidationError)
+            if (e instanceof FieldValidationError) {
+                expect(e.fieldErrors.email).toContain('Please enter a valid email.')
+            }
+        }
+        expect(mockPost).not.toHaveBeenCalled()
+    })
+
+    it('posts to /auth/register when validation passes', async () => {
+        mockPost.mockResolvedValueOnce({ data: { message: 'ok' } })
+        const result = await UserService.register(validRegistration)
+        expect(mockPost).toHaveBeenCalledWith('/auth/register', validRegistration)
+        expect(result).toEqual({ message: 'ok' })
+    })
+
+    it('maps server-side validation errors into a FieldValidationError', async () => {
+        const axiosErr = new AxiosError('Bad Request')
+        axiosErr.response = {
+            data: { errors: { Email: ['Email already taken.'] } },
+            status: 400,
+            statusText: 'Bad Request',
+            headers: {},
+            config: { headers: {} } as never,
+        }
+        mockPost.mockRejectedValueOnce(axiosErr)
+        try {
+            await UserService.register(validRegistration)
+            throw new Error('should have thrown')
+        } catch (e) {
+            expect(e).toBeInstanceOf(FieldValidationError)
+            if (e instanceof FieldValidationError) {
+                expect(e.fieldErrors.email).toContain('Email already taken.')
+            }
+        }
+    })
 })
 
 describe('UserService.getDataRetention', () => {


### PR DESCRIPTION
## Summary

Deferred structural refactors: extract reusable UI primitives, dedup forms. Behavior/visuals preserved; this is extraction, not a redesign.

- New shells `Modal` + `Drawer` (backdrop, escape via `useEscapeKey`, dialog ARIA, body scroll lock) adopted in `ConfirmModal`, `ShareDeviceModal`, `QuantityChangeModal`, `PaymentPhoneModal`, `SetupWizard` (Modal) and `CartDrawer` (Drawer)
- `AutomationRuleForm` shared by create + edit (removes ~170 duplicated lines)
- New `PasswordInput`, `InlineEditField`, `StatCard`/`StatGrid`, `useOutsideClick`, `useBodyScrollLock`
- Replace brittle `JSON.stringify(error)`/`JSON.parse` round-trip with a typed `FieldValidationError`
- Move `registerSchema` to a shared module; add client-side live validation on the register page

Build passes; 217 tests pass (174 prior + 43 new).

**Left un-refactored (intentional):** the `DeviceDrawer` + automations drawer keep their bespoke slide animations (mount-toggle `Drawer` doesn't fit them; inner content still deduped); the profile dual first/last name editor and the interactive admin Overview tiles are structurally different from the single-field/static primitives.

**Minor behavior deltas:** converted modals/drawers now lock body scroll while open; `useOutsideClick` also closes on touch-outside (CustomSelect previously mousedown-only); one phone-error font size 11px to 12px to share `InlineEditField` styling. Lint not run (Next16/ESLint10 env bug); TS build clean.