### PR TITLE
test: cover AutomationRuleForm, device rename regression, register validation

### DIFF
--- a/src/tests/components/AutomationRuleForm.test.tsx
+++ b/src/tests/components/AutomationRuleForm.test.tsx
@@ -1,0 +1,230 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import React, { useState } from 'react'
+import AutomationRuleForm from '@/app/(protected)/automations/AutomationRuleForm'
+import type { CreateAutomationRuleDto } from '@/dto/Automation/CreateAutomationRuleDto'
+import type { Switch } from '@/services/switchService'
+import type { Sensor } from '@/services/sensorService'
+
+const sortedSwitches = [
+    { id: 10, name: 'Garage socket', customName: 'Garage socket', type: 'relay' },
+] as unknown as Switch[]
+
+const sortedSensors = [
+    { id: 20, name: 'volt-1', defaultName: 'Battery voltage', customName: null, type: 'voltage' },
+] as unknown as Sensor[]
+
+const sensors = sortedSensors
+
+const emptyRule = (): CreateAutomationRuleDto => ({
+    targetType: '',
+    targetId: 0,
+    sensorType: '',
+    sensorId: 0,
+    condition: '<',
+    threshold: 0,
+    action: 'off',
+    isEnabled: true,
+})
+
+/**
+ * Wraps the form so its `value` is real React state, mirroring how the
+ * automations page drives it: every onChange replaces the whole DTO and the
+ * latest snapshot is captured for assertions after submit.
+ */
+const Harness: React.FC<{
+    initial: CreateAutomationRuleDto
+    mode: 'create' | 'edit'
+    onSubmitCapture: (v: CreateAutomationRuleDto) => void
+    onDelete?: () => void
+}> = ({ initial, mode, onSubmitCapture, onDelete }) => {
+    const [value, setValue] = useState<CreateAutomationRuleDto>(initial)
+    return (
+        <AutomationRuleForm
+            value={value}
+            onChange={setValue}
+            onSubmit={e => { e.preventDefault(); onSubmitCapture(value) }}
+            onCancel={() => {}}
+            submitting={false}
+            mode={mode}
+            sortedSwitches={sortedSwitches}
+            sortedSensors={sortedSensors}
+            sensors={sensors}
+            latestValueMap={{ 20: 12.6 }}
+            defaultPriceArea="NO1"
+            priceFormKey={mode}
+            onDelete={onDelete}
+        />
+    )
+}
+
+describe('AutomationRuleForm — create', () => {
+    it('renders create-mode labels and the empty option placeholders', () => {
+        render(<Harness initial={emptyRule()} mode="create" onSubmitCapture={() => {}} />)
+        expect(screen.getByRole('button', { name: 'Create Rule' })).toBeInTheDocument()
+        expect(screen.getByRole('option', { name: 'Select a socket' })).toBeInTheDocument()
+        expect(screen.getByRole('option', { name: 'Select a sensor' })).toBeInTheDocument()
+        // No delete button in create mode.
+        expect(screen.queryByRole('button', { name: /Delete Rule/ })).not.toBeInTheDocument()
+    })
+
+    it('captures the filled condition, threshold, target and sensor on submit', () => {
+        const onSubmit = vi.fn()
+        render(<Harness initial={emptyRule()} mode="create" onSubmitCapture={onSubmit} />)
+
+        // Pick target socket — also sets targetType from the matched switch.
+        fireEvent.change(screen.getByDisplayValue('Select a socket'), { target: { value: '10' } })
+        // Pick trigger sensor — also sets sensorType from the matched sensor.
+        fireEvent.change(screen.getByDisplayValue('Select a sensor'), { target: { value: '20' } })
+        // Condition: greater than or equal.
+        fireEvent.change(screen.getByDisplayValue('Less than'), { target: { value: '>=' } })
+        // Threshold.
+        const threshold = screen.getByPlaceholderText('0')
+        fireEvent.change(threshold, { target: { value: '12.8' } })
+
+        fireEvent.click(screen.getByRole('button', { name: 'Create Rule' }))
+
+        expect(onSubmit).toHaveBeenCalledTimes(1)
+        expect(onSubmit.mock.calls[0][0]).toMatchObject({
+            targetId: 10,
+            targetType: 'relay',
+            sensorId: 20,
+            sensorType: 'voltage',
+            condition: '>=',
+            threshold: 12.8,
+            action: 'off',
+        })
+    })
+
+    it('shows the threshold unit from the chosen sensor type', () => {
+        render(<Harness initial={emptyRule()} mode="create" onSubmitCapture={() => {}} />)
+        fireEvent.change(screen.getByDisplayValue('Select a sensor'), { target: { value: '20' } })
+        // voltage → unit V appears in the threshold label.
+        expect(screen.getByText(/Threshold \(V\)/)).toBeInTheDocument()
+    })
+
+    it('renders the auto-off timer block only for the "on" action and emits a default duration', () => {
+        const onSubmit = vi.fn()
+        render(<Harness initial={emptyRule()} mode="create" onSubmitCapture={onSubmit} />)
+
+        // No timer block while action is "off".
+        expect(screen.queryByText('Auto-off timer')).not.toBeInTheDocument()
+
+        // Switch action to "on" — the timer block appears.
+        fireEvent.change(screen.getByDisplayValue('Turn Off'), { target: { value: 'on' } })
+        expect(screen.getByText('Auto-off timer')).toBeInTheDocument()
+
+        // Enable the timer toggle → default 2 hours, then bump it.
+        fireEvent.click(screen.getByRole('switch', { name: 'Enable auto-off timer' }))
+        const duration = screen.getByDisplayValue('2')
+        fireEvent.change(duration, { target: { value: '5' } })
+
+        fireEvent.click(screen.getByRole('button', { name: 'Create Rule' }))
+        expect(onSubmit.mock.calls[0][0]).toMatchObject({ action: 'on', timerDurationHours: 5 })
+    })
+
+    it('captures the electricity price sub-form when enabled', () => {
+        const onSubmit = vi.fn()
+        render(<Harness initial={emptyRule()} mode="create" onSubmitCapture={onSubmit} />)
+
+        // Price fields hidden until the toggle is on.
+        expect(screen.queryByText('Price (kr/kWh)')).not.toBeInTheDocument()
+
+        fireEvent.click(screen.getByRole('switch', { name: 'Enable electricity price condition' }))
+        const priceLabel = screen.getByText('Price (kr/kWh)')
+        expect(priceLabel).toBeInTheDocument()
+
+        // Set the price threshold — scope to the input next to the "Price (kr/kWh)"
+        // label, since the sensor threshold field also has a placeholder of "0".
+        const priceInput = priceLabel.parentElement!.querySelector('input') as HTMLInputElement
+        fireEvent.change(priceInput, { target: { value: '1.5' } })
+        // Choose OR as the combine operator.
+        fireEvent.change(screen.getByDisplayValue('AND (both must be true)'), { target: { value: 'OR' } })
+
+        fireEvent.click(screen.getByRole('button', { name: 'Create Rule' }))
+        expect(onSubmit.mock.calls[0][0]).toMatchObject({
+            electricityPriceCondition: '<',
+            electricityPriceThreshold: 1.5,
+            electricityPriceArea: 'NO1',
+            electricityPriceOperator: 'OR',
+        })
+    })
+
+    it('shows a "would trigger now" preview based on the latest reading', () => {
+        // current 12.6 < threshold 13 → would trigger.
+        const initial = { ...emptyRule(), sensorId: 20, sensorType: 'voltage', condition: '<', threshold: 13 }
+        render(<Harness initial={initial} mode="create" onSubmitCapture={() => {}} />)
+        expect(screen.getByText(/Would trigger now/)).toBeInTheDocument()
+    })
+})
+
+describe('AutomationRuleForm — edit', () => {
+    const existingRule: CreateAutomationRuleDto = {
+        targetType: 'relay',
+        targetId: 10,
+        sensorType: 'voltage',
+        sensorId: 20,
+        condition: '>',
+        threshold: 14.4,
+        action: 'on',
+        isEnabled: true,
+        timerDurationHours: 3,
+        electricityPriceCondition: '<',
+        electricityPriceThreshold: 0.8,
+        electricityPriceArea: 'NO2',
+        electricityPriceOperator: 'AND',
+    }
+
+    it('pre-fills every field from the existing rule value', () => {
+        render(<Harness initial={existingRule} mode="edit" onSubmitCapture={() => {}} onDelete={() => {}} />)
+
+        expect(screen.getByRole('button', { name: 'Save Changes' })).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: /Delete Rule/ })).toBeInTheDocument()
+
+        // Selects reflect the existing values.
+        expect((screen.getByDisplayValue('Garage socket') as HTMLSelectElement).value).toBe('10')
+        expect((screen.getByDisplayValue('Battery voltage') as HTMLSelectElement).value).toBe('20')
+        expect((screen.getByDisplayValue('Greater than') as HTMLSelectElement).value).toBe('>')
+        expect(screen.getByDisplayValue('14.4')).toBeInTheDocument()
+        expect((screen.getByDisplayValue('Turn On') as HTMLSelectElement).value).toBe('on')
+
+        // Timer pre-filled and enabled.
+        expect(screen.getByText('Auto-off timer')).toBeInTheDocument()
+        expect(screen.getByDisplayValue('3')).toBeInTheDocument()
+
+        // Price sub-form pre-filled and enabled.
+        expect(screen.getByText('Price (kr/kWh)')).toBeInTheDocument()
+        expect(screen.getByDisplayValue('0.8')).toBeInTheDocument()
+        expect((screen.getByDisplayValue('NO2') as HTMLSelectElement).value).toBe('NO2')
+    })
+
+    it('emits the edited values on save', () => {
+        const onSubmit = vi.fn()
+        render(<Harness initial={existingRule} mode="edit" onSubmitCapture={onSubmit} onDelete={() => {}} />)
+
+        // Change condition and threshold.
+        fireEvent.change(screen.getByDisplayValue('Greater than'), { target: { value: '<=' } })
+        fireEvent.change(screen.getByDisplayValue('14.4'), { target: { value: '15.0' } })
+
+        fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }))
+
+        expect(onSubmit).toHaveBeenCalledTimes(1)
+        expect(onSubmit.mock.calls[0][0]).toMatchObject({
+            targetId: 10,
+            sensorId: 20,
+            condition: '<=',
+            threshold: 15,
+            action: 'on',
+            timerDurationHours: 3,
+            electricityPriceThreshold: 0.8,
+            electricityPriceOperator: 'AND',
+        })
+    })
+
+    it('invokes onDelete when the delete button is clicked', () => {
+        const onDelete = vi.fn()
+        render(<Harness initial={existingRule} mode="edit" onSubmitCapture={() => {}} onDelete={onDelete} />)
+        fireEvent.click(screen.getByRole('button', { name: /Delete Rule/ }))
+        expect(onDelete).toHaveBeenCalledOnce()
+    })
+})

--- a/src/tests/components/DeviceDashboard.test.tsx
+++ b/src/tests/components/DeviceDashboard.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+// Mock the data services so the dashboard mounts with a single socket and no
+// real network. The rename path under test only needs SwitchService.
+const { updateSwitchName } = vi.hoisted(() => ({
+    updateSwitchName: vi.fn(() => Promise.resolve({})),
+}))
+
+vi.mock('@/services/sensorService', () => ({
+    default: {
+        getAllSensors: vi.fn(() => Promise.resolve([])),
+        getMultipleSensorsData: vi.fn(() => Promise.resolve({ data: [], totalCount: 0 })),
+        getBatteryHealthLatest: vi.fn(() => Promise.resolve(null)),
+        updateCustomName: vi.fn(() => Promise.resolve({})),
+    },
+}))
+vi.mock('@/services/switchService', () => ({
+    default: {
+        getAllSwitches: vi.fn(() => Promise.resolve([
+            { id: 7, name: 'socket-7', type: 'relay', role: 'owner', customName: 'Garage socket' },
+        ])),
+        getSwitchState: vi.fn(() => Promise.resolve('ON')),
+        getSwitchData: vi.fn(() => Promise.resolve([])),
+        updateCustomName: updateSwitchName,
+    },
+}))
+vi.mock('@/services/groupService', () => ({
+    default: { getAllGroups: vi.fn(() => Promise.resolve([])) },
+}))
+vi.mock('@/services/sensorPhotoService', () => ({
+    default: { get: vi.fn(() => Promise.resolve(null)) },
+}))
+
+// The realtime stream is irrelevant to the rename flow; stub it to a no-op.
+vi.mock('@/hooks/useDeviceStream', () => ({ useDeviceStream: vi.fn() }))
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }))
+vi.mock('next/dynamic', () => ({ default: () => () => null }))
+
+import DeviceDashboard from '@/app/DeviceDashboard'
+
+beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+})
+
+describe('DeviceDashboard.handleRename', () => {
+    it('updates the rendered device name after the drawer renames it', async () => {
+        render(<DeviceDashboard />)
+
+        // Wait for the socket card to appear (loadData resolves).
+        await waitFor(() => expect(screen.getByText('Garage socket')).toBeInTheDocument())
+
+        // Open the drawer for the socket.
+        fireEvent.click(screen.getByText('Garage socket'))
+
+        // Enter edit mode (drawer becomes visible after a rAF).
+        fireEvent.click(await screen.findByRole('button', { name: 'Rename' }))
+
+        // Rename and save.
+        const input = screen.getByDisplayValue('Garage socket')
+        fireEvent.change(input, { target: { value: 'Workbench socket' } })
+        fireEvent.click(screen.getByRole('button', { name: 'Save name' }))
+
+        // The dashboard's devices state updated immutably, so the card now shows
+        // the new name. (The drawer header also reflects it.)
+        await waitFor(() =>
+            expect(screen.getAllByText('Workbench socket').length).toBeGreaterThan(0)
+        )
+        expect(screen.queryByText('Garage socket')).not.toBeInTheDocument()
+        expect(updateSwitchName).toHaveBeenCalledWith(7, 'Workbench socket')
+    })
+})

--- a/src/tests/components/DeviceDrawer.test.tsx
+++ b/src/tests/components/DeviceDrawer.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+// Mock the services the drawer imports so no real HTTP happens. The socket
+// device exercised below only touches SwitchService; the others are stubbed to
+// keep the module graph happy. Mock fns are declared with vi.hoisted so the
+// hoisted vi.mock factories can reference them.
+const { updateSwitchName, getSwitchData, toastSuccess, toastError } = vi.hoisted(() => ({
+    updateSwitchName: vi.fn(() => Promise.resolve({})),
+    getSwitchData: vi.fn(() => Promise.resolve([])),
+    toastSuccess: vi.fn(),
+    toastError: vi.fn(),
+}))
+
+vi.mock('@/services/switchService', () => ({
+    default: {
+        getSwitchData,
+        updateCustomName: updateSwitchName,
+    },
+}))
+vi.mock('@/services/sensorService', () => ({
+    default: {
+        getMultipleSensorsData: vi.fn(() => Promise.resolve({ data: [], totalCount: 0 })),
+        updateCustomName: vi.fn(() => Promise.resolve({})),
+    },
+}))
+vi.mock('@/services/sensorPhotoService', () => ({
+    default: { get: vi.fn(() => Promise.resolve(null)) },
+}))
+
+vi.mock('sonner', () => ({ toast: { success: toastSuccess, error: toastError } }))
+
+// Avoid pulling ApexCharts into jsdom; sockets don't render it anyway.
+vi.mock('next/dynamic', () => ({ default: () => () => null }))
+
+import DeviceDrawer from '@/app/DeviceDrawer'
+import type { UnifiedDevice } from '@/app/DeviceDashboard'
+
+function makeSocket(overrides: Partial<UnifiedDevice> = {}): UnifiedDevice {
+    return {
+        kind: 'socket',
+        id: 7,
+        displayName: 'Garage socket',
+        type: 'socket',
+        latestState: 'ON',
+        isActive: true,
+        ...overrides,
+    }
+}
+
+beforeEach(() => {
+    vi.clearAllMocks()
+})
+
+describe('DeviceDrawer rename', () => {
+    it('calls onRename(id, trimmedName) and does NOT mutate the device prop', async () => {
+        const device = makeSocket()
+        const onRename = vi.fn()
+        render(<DeviceDrawer device={device} onClose={() => {}} onRename={onRename} />)
+
+        // The drawer mounts with aria-hidden until a requestAnimationFrame flips
+        // it visible; findByRole retries until the accessibility tree exposes it.
+        fireEvent.click(await screen.findByRole('button', { name: 'Rename' }))
+
+        // Type a new name with surrounding whitespace to verify trimming.
+        const input = screen.getByDisplayValue('Garage socket')
+        fireEvent.change(input, { target: { value: '  New Socket Name  ' } })
+
+        // Save via the compact check button.
+        fireEvent.click(screen.getByRole('button', { name: 'Save name' }))
+
+        await waitFor(() => expect(onRename).toHaveBeenCalledTimes(1))
+        expect(onRename).toHaveBeenCalledWith(7, 'New Socket Name')
+
+        // The persisted name must flow through the callback, not by mutating the
+        // prop object. The passed-in device's displayName stays untouched.
+        expect(device.displayName).toBe('Garage socket')
+
+        // Service was asked to persist the trimmed name, and a success toast fired.
+        expect(updateSwitchName).toHaveBeenCalledWith(7, 'New Socket Name')
+        await waitFor(() => expect(toastSuccess).toHaveBeenCalledWith('Socket renamed'))
+    })
+
+    it('does not call onRename for an empty/whitespace-only name', async () => {
+        const device = makeSocket()
+        const onRename = vi.fn()
+        render(<DeviceDrawer device={device} onClose={() => {}} onRename={onRename} />)
+
+        fireEvent.click(await screen.findByRole('button', { name: 'Rename' }))
+        fireEvent.change(screen.getByDisplayValue('Garage socket'), { target: { value: '   ' } })
+        fireEvent.click(screen.getByRole('button', { name: 'Save name' }))
+
+        // Whitespace-only is rejected before any persistence.
+        expect(onRename).not.toHaveBeenCalled()
+        expect(updateSwitchName).not.toHaveBeenCalled()
+    })
+
+    it('surfaces a failure toast and leaves the device prop unchanged when the service throws', async () => {
+        updateSwitchName.mockRejectedValueOnce(new Error('boom'))
+        const device = makeSocket()
+        const onRename = vi.fn()
+        render(<DeviceDrawer device={device} onClose={() => {}} onRename={onRename} />)
+
+        fireEvent.click(await screen.findByRole('button', { name: 'Rename' }))
+        fireEvent.change(screen.getByDisplayValue('Garage socket'), { target: { value: 'Other' } })
+        fireEvent.click(screen.getByRole('button', { name: 'Save name' }))
+
+        await waitFor(() => expect(toastError).toHaveBeenCalledWith('Failed to rename'))
+        expect(onRename).not.toHaveBeenCalled()
+        expect(device.displayName).toBe('Garage socket')
+    })
+})

--- a/src/tests/components/RegisterPage.test.tsx
+++ b/src/tests/components/RegisterPage.test.tsx
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { FieldValidationError } from '@/lib/errors'
+
+const { push, register, signIn, getSession } = vi.hoisted(() => ({
+    push: vi.fn(),
+    register: vi.fn(),
+    signIn: vi.fn(),
+    getSession: vi.fn(() => Promise.resolve(null)),
+}))
+
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push }) }))
+vi.mock('next-auth/react', () => ({ signIn, getSession }))
+vi.mock('@/services/userService', () => ({ default: { register } }))
+
+// next/image and next/link render fine in jsdom but mock them lean to avoid
+// optimization/runtime noise.
+vi.mock('next/image', () => ({ default: (props: Record<string, unknown>) => <img alt={String(props.alt ?? '')} /> }))
+vi.mock('next/link', () => ({ default: ({ children, href }: { children: React.ReactNode; href: string }) => <a href={href}>{children}</a> }))
+
+import Register from '@/app/(auth)/register/page'
+
+beforeEach(() => {
+    vi.clearAllMocks()
+    getSession.mockResolvedValue(null)
+})
+
+describe('Register — live client-side validation', () => {
+    it('shows a password-rule error on blur before any submit', async () => {
+        render(<Register />)
+        const password = screen.getByPlaceholderText('••••••••')
+
+        fireEvent.change(password, { target: { value: 'short' } })
+        fireEvent.blur(password)
+
+        // Validation feedback from the shared registerSchema appears live.
+        await waitFor(() =>
+            expect(screen.getByText('Be at least 8 characters long.')).toBeInTheDocument()
+        )
+        // It surfaces every failing rule, not just the first.
+        expect(screen.getByText('Contain at least one number.')).toBeInTheDocument()
+        expect(screen.getByText('Contain at least one uppercase letter.')).toBeInTheDocument()
+
+        // No network call yet — this is pure client-side feedback.
+        expect(register).not.toHaveBeenCalled()
+    })
+
+    it('clears the error as the user types a value that satisfies the rules', async () => {
+        render(<Register />)
+        const password = screen.getByPlaceholderText('••••••••')
+
+        fireEvent.change(password, { target: { value: 'short' } })
+        fireEvent.blur(password)
+        await waitFor(() =>
+            expect(screen.getByText('Be at least 8 characters long.')).toBeInTheDocument()
+        )
+
+        // Once touched, onChange re-validates live.
+        fireEvent.change(password, { target: { value: 'Sup3r!secret' } })
+        await waitFor(() =>
+            expect(screen.queryByText('Be at least 8 characters long.')).not.toBeInTheDocument()
+        )
+    })
+
+    it('validates email live on blur', async () => {
+        render(<Register />)
+        const email = screen.getByPlaceholderText('you@example.com')
+        fireEvent.change(email, { target: { value: 'nope' } })
+        fireEvent.blur(email)
+        await waitFor(() =>
+            expect(screen.getByText('Please enter a valid email.')).toBeInTheDocument()
+        )
+    })
+})
+
+describe('Register — typed error surfacing on submit', () => {
+    /** Fills the form with valid values and ticks both required consent boxes. */
+    function fillValidForm() {
+        fireEvent.change(screen.getByPlaceholderText('username'), { target: { value: 'ada' } })
+        fireEvent.change(screen.getByPlaceholderText('First'), { target: { value: 'Ada' } })
+        fireEvent.change(screen.getByPlaceholderText('Last'), { target: { value: 'Lovelace' } })
+        fireEvent.change(screen.getByPlaceholderText('you@example.com'), { target: { value: 'ada@example.com' } })
+        fireEvent.change(screen.getByPlaceholderText('••••••••'), { target: { value: 'Sup3r!secret' } })
+        const [age, terms] = screen.getAllByRole('checkbox')
+        fireEvent.click(age)
+        fireEvent.click(terms)
+    }
+
+    it('renders per-field errors from a FieldValidationError, not a raw JSON string', async () => {
+        register.mockRejectedValueOnce(
+            new FieldValidationError({
+                email: ['Email already taken.'],
+                userName: ['Username already taken.'],
+            })
+        )
+        render(<Register />)
+        fillValidForm()
+
+        fireEvent.click(screen.getByRole('button', { name: 'Create account' }))
+
+        await waitFor(() => expect(register).toHaveBeenCalledTimes(1))
+
+        // Field-level messages render under their inputs.
+        await waitFor(() => {
+            expect(screen.getByText('Email already taken.')).toBeInTheDocument()
+            expect(screen.getByText('Username already taken.')).toBeInTheDocument()
+        })
+
+        // The error must not have leaked as a serialized object/JSON anywhere.
+        expect(screen.queryByText(/fieldErrors/i)).not.toBeInTheDocument()
+        expect(screen.queryByText(/\[object Object\]/)).not.toBeInTheDocument()
+        expect(screen.queryByText(/\{.*email.*\}/)).not.toBeInTheDocument()
+
+        // signIn is not attempted when registration fails.
+        expect(signIn).not.toHaveBeenCalled()
+    })
+
+    it('shows a generic alert message when a plain Error is thrown', async () => {
+        register.mockRejectedValueOnce(new Error('Service unavailable'))
+        render(<Register />)
+        fillValidForm()
+
+        fireEvent.click(screen.getByRole('button', { name: 'Create account' }))
+
+        await waitFor(() =>
+            expect(screen.getByText('Service unavailable')).toBeInTheDocument()
+        )
+    })
+
+    it('signs in after a successful registration', async () => {
+        register.mockResolvedValueOnce({ message: 'ok' })
+        signIn.mockResolvedValueOnce({ ok: true })
+        render(<Register />)
+        fillValidForm()
+
+        fireEvent.click(screen.getByRole('button', { name: 'Create account' }))
+
+        await waitFor(() => expect(register).toHaveBeenCalledTimes(1))
+        await waitFor(() =>
+            expect(signIn).toHaveBeenCalledWith('credentials', {
+                redirect: true,
+                email: 'ada@example.com',
+                password: 'Sup3r!secret',
+            })
+        )
+    })
+})


### PR DESCRIPTION
## Summary

Follow-up test coverage for the merged refactors (#346). Test code only, no production changes.

- AutomationRuleForm: create + edit (field types, price sub-form, timer block, would-trigger-now preview, edit pre-fill, delete)
- Device rename regression: asserts rename flows through onRename with the trimmed value and does NOT mutate the device prop (locks the prop-mutation bug fix); DeviceDashboard updates its devices state immutably
- Register page: live password/email validation before submit via shared registerSchema, and FieldValidationError field-level errors surfaced (not a raw JSON string)

Tests: 236 pass (217 prior + 19), build clean.