### PR TITLE
feat: color voltage readings by configurable thresholds

### DIFF
--- a/src/app/DeviceDashboard.tsx
+++ b/src/app/DeviceDashboard.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { MagnifyingGlassIcon, ChevronDownIcon, PlusIcon, PencilIcon, TrashIcon, XMarkIcon, SignalIcon } from '@heroicons/react/24/outline';
 import { TYPE_CONFIG, DEFAULT_TYPE } from '@/lib/typeConfig';
 import { formatSensorValue, typeEmoji } from '@/lib/typeUtils';
+import { voltageColorClass, thresholdsOrNull } from '@/lib/voltageThresholds';
 import LoadingDots from '@/components/LoadingDots';
 import SensorService, { Sensor, BatteryHealthData } from '@/services/sensorService';
 import SwitchService, { Switch } from '@/services/switchService';
@@ -98,12 +99,19 @@ function formatValue(device: UnifiedDevice): string {
     return formatSensorValue(device.type, device.latestValue);
 }
 
+/** The caller's voltage color thresholds for a device, or null when unset / not a voltage sensor. */
+function deviceVoltageThresholds(device: UnifiedDevice) {
+    if (device.kind !== 'sensor' || device.type !== 'voltage') return null;
+    return thresholdsOrNull(device.rawSensor?.warningVoltage, device.rawSensor?.criticalVoltage);
+}
+
 const DeviceCard: React.FC<{ device: UnifiedDevice; onClick: () => void }> = ({ device, onClick }) => {
     const cfg = TYPE_CONFIG[device.type.toLowerCase()] ?? DEFAULT_TYPE;
     const value = formatValue(device);
     const socketOn  = device.kind === 'socket' && device.latestState === 'ON';
     const socketOff = device.kind === 'socket' && device.latestState === 'OFF';
     const accent = CARD_ACCENT[device.type.toLowerCase()] ?? 'border-t-sky-500/20';
+    const voltageColor = voltageColorClass(device.latestValue, deviceVoltageThresholds(device));
 
     return (
         <button
@@ -141,7 +149,7 @@ const DeviceCard: React.FC<{ device: UnifiedDevice; onClick: () => void }> = ({ 
             {/* Value */}
             <p className={`text-2xl font-bold tabular-nums ${
                 socketOn  ? 'text-green-400' :
-                socketOff ? 'text-red-400'   : 'text-white'
+                socketOff ? 'text-red-400'   : voltageColor
             }`}>
                 {value}
             </p>
@@ -349,6 +357,15 @@ const DeviceDashboard: React.FC = () => {
         setSelected(prev => (prev && prev.id === id ? { ...prev, displayName: name } : prev));
     }, []);
 
+    const handleThresholdsChange = useCallback((id: number, warning: number | null, critical: number | null) => {
+        const apply = (d: UnifiedDevice): UnifiedDevice =>
+            d.kind === 'sensor' && d.id === id && d.rawSensor
+                ? { ...d, rawSensor: { ...d.rawSensor, warningVoltage: warning, criticalVoltage: critical } }
+                : d;
+        setDevices(prev => prev.map(apply));
+        setSelected(prev => (prev ? apply(prev) : prev));
+    }, []);
+
     const filterPills = useMemo(() => {
         const types = [...new Set(devices.map(d => d.type))].sort();
         const labels: Record<string, string> = {
@@ -528,7 +545,11 @@ const DeviceDashboard: React.FC = () => {
                                                     >
                                                         <div className="flex items-center gap-1 leading-tight">
                                                             <span className="text-xs">{typeEmoji(d.type)}</span>
-                                                            <span className="text-sm font-bold text-gray-100 tabular-nums">{formatValue(d)}</span>
+                                                            <span className={`text-sm font-bold tabular-nums ${
+                                                                deviceVoltageThresholds(d)
+                                                                    ? voltageColorClass(d.latestValue, deviceVoltageThresholds(d))
+                                                                    : 'text-gray-100'
+                                                            }`}>{formatValue(d)}</span>
                                                         </div>
                                                         <span className="text-[10px] text-gray-500 leading-tight mt-0.5 truncate max-w-[80px]">{d.displayName}</span>
                                                     </button>
@@ -647,6 +668,7 @@ const DeviceDashboard: React.FC = () => {
                     device={selected}
                     onClose={() => setSelected(null)}
                     onRename={handleRename}
+                    onThresholdsChange={handleThresholdsChange}
                 />
             )}
 

--- a/src/app/DeviceDrawer.tsx
+++ b/src/app/DeviceDrawer.tsx
@@ -26,6 +26,8 @@ interface DeviceDrawerProps {
     onClose: () => void;
     /** Notifies the parent that the device was renamed so it can update its state. */
     onRename: (id: number, name: string) => void;
+    /** Notifies the parent that the sensor's voltage color thresholds changed (null when cleared). */
+    onThresholdsChange?: (sensorId: number, warning: number | null, critical: number | null) => void;
 }
 
 function InfoLabel({ children, tooltip }: { children: React.ReactNode; tooltip: string }) {
@@ -130,9 +132,132 @@ const TimelineBar: React.FC<{ segments: Segment[]; rangeStart: number; rangeEnd:
     );
 };
 
+// ── Voltage color thresholds ──────────────────────────────────────────────────
+
+const inputClass = 'w-full px-3 py-2 bg-gray-900/60 border border-gray-700/40 rounded-xl text-sm text-gray-200 tabular-nums focus:outline-none focus:border-sky-600/50 transition-colors';
+
+const VoltageThresholdConfig: React.FC<{
+    sensorId: number;
+    warning: number | null;
+    critical: number | null;
+    onChange: (sensorId: number, warning: number | null, critical: number | null) => void;
+}> = ({ sensorId, warning, critical, onChange }) => {
+    const [warnInput, setWarnInput] = useState(warning !== null ? String(warning) : '');
+    const [critInput, setCritInput] = useState(critical !== null ? String(critical) : '');
+    const [saving, setSaving] = useState(false);
+
+    const isSet = warning !== null && critical !== null;
+    const warnNum = parseFloat(warnInput);
+    const critNum = parseFloat(critInput);
+    const filled = warnInput.trim() !== '' && critInput.trim() !== '';
+    const valid = Number.isFinite(warnNum) && Number.isFinite(critNum)
+        && critNum >= 0 && warnNum <= 100 && warnNum > critNum;
+    const dirty = warnInput !== (warning !== null ? String(warning) : '')
+        || critInput !== (critical !== null ? String(critical) : '');
+
+    const save = async () => {
+        if (!valid || saving) return;
+        setSaving(true);
+        try {
+            await SensorService.updateVoltageThresholds(sensorId, warnNum, critNum);
+            onChange(sensorId, warnNum, critNum);
+            toast.success('Voltage thresholds saved');
+        } catch {
+            toast.error('Failed to save voltage thresholds');
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const clear = async () => {
+        if (saving) return;
+        setSaving(true);
+        try {
+            await SensorService.clearVoltageThresholds(sensorId);
+            onChange(sensorId, null, null);
+            setWarnInput('');
+            setCritInput('');
+            toast.success('Voltage coloring turned off');
+        } catch {
+            toast.error('Failed to clear voltage thresholds');
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    return (
+        <div className="bg-gray-800/60 border border-gray-700/40 rounded-2xl p-4 space-y-4">
+            <div>
+                <h3 className="text-sm font-semibold text-gray-300">Voltage color thresholds</h3>
+                <p className="text-xs text-gray-500 mt-1 leading-snug">
+                    Color this reading by voltage. Leave off to show it plain.
+                </p>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+                <label className="space-y-1.5">
+                    <span className="text-xs text-gray-500 flex items-center gap-1.5">
+                        <span className="w-2 h-2 rounded-full bg-yellow-400" /> Warning below (V)
+                    </span>
+                    <input
+                        type="number"
+                        inputMode="decimal"
+                        step="0.1"
+                        value={warnInput}
+                        onChange={e => setWarnInput(e.target.value)}
+                        placeholder="12.4"
+                        aria-label="Warning voltage"
+                        className={inputClass}
+                    />
+                </label>
+                <label className="space-y-1.5">
+                    <span className="text-xs text-gray-500 flex items-center gap-1.5">
+                        <span className="w-2 h-2 rounded-full bg-red-400" /> Critical below (V)
+                    </span>
+                    <input
+                        type="number"
+                        inputMode="decimal"
+                        step="0.1"
+                        value={critInput}
+                        onChange={e => setCritInput(e.target.value)}
+                        placeholder="12.0"
+                        aria-label="Critical voltage"
+                        className={inputClass}
+                    />
+                </label>
+            </div>
+
+            {filled && !valid && (
+                <p className="text-xs text-red-400">Warning must be higher than critical, between 0 and 100 V.</p>
+            )}
+
+            <div className="flex items-center gap-2">
+                <button
+                    type="button"
+                    onClick={save}
+                    disabled={!valid || !dirty || saving}
+                    className="flex-1 py-2 rounded-xl text-sm font-medium bg-sky-600 text-white hover:bg-sky-500 active:bg-sky-700 disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+                >
+                    {saving ? 'Saving…' : 'Save'}
+                </button>
+                {isSet && (
+                    <button
+                        type="button"
+                        onClick={clear}
+                        disabled={saving}
+                        className="px-3 py-2 rounded-xl text-sm font-medium text-gray-400 hover:text-gray-200 hover:bg-gray-700/60 disabled:opacity-40 transition-colors"
+                    >
+                        Turn off
+                    </button>
+                )}
+            </div>
+        </div>
+    );
+};
+
 // ─────────────────────────────────────────────────────────────────────────────
 
-const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose, onRename }) => {
+const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose, onRename, onThresholdsChange }) => {
     const [chartData, setChartData] = useState<{ x: number; y: number }[]>([]);
     const [loadingChart, setLoadingChart] = useState(false);
     const [activeRange, setActiveRange] = useState<RangeIndex>(0);
@@ -234,6 +359,8 @@ const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose, onRename }
     const latestValueStr = device.kind === 'sensor' && device.latestValue !== undefined
         ? `${Number(device.latestValue).toFixed(device.type === 'voltage' ? 2 : 1)} ${unitForType(device.type)}`
         : null;
+
+    const isVoltage = device.kind === 'sensor' && device.type === 'voltage';
 
     // Socket computed values
     const now = Date.now();
@@ -562,6 +689,17 @@ const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose, onRename }
                                 )}
                             </div>
                         </div>
+                    )}
+
+                    {/* Voltage color thresholds (voltage sensors only) */}
+                    {isVoltage && (
+                        <VoltageThresholdConfig
+                            key={device.id}
+                            sensorId={device.id}
+                            warning={device.rawSensor?.warningVoltage ?? null}
+                            critical={device.rawSensor?.criticalVoltage ?? null}
+                            onChange={(id, warning, critical) => onThresholdsChange?.(id, warning, critical)}
+                        />
                     )}
 
                     {/* Activities (sensors only — e.g. log motorcycle activities for a voltmeter) */}

--- a/src/lib/voltageThresholds.ts
+++ b/src/lib/voltageThresholds.ts
@@ -1,0 +1,30 @@
+export interface VoltageThresholds {
+    warning: number;
+    critical: number;
+}
+
+export type VoltageStatus = 'normal' | 'warning' | 'critical';
+
+export const VOLTAGE_STATUS_COLOR: Record<VoltageStatus, string> = {
+    normal: 'text-white',
+    warning: 'text-yellow-400',
+    critical: 'text-red-400',
+};
+
+export function voltageStatus(value: number | null | undefined, thresholds: VoltageThresholds): VoltageStatus {
+    if (value === null || value === undefined || !Number.isFinite(value)) return 'normal';
+    if (value < thresholds.critical) return 'critical';
+    if (value < thresholds.warning) return 'warning';
+    return 'normal';
+}
+
+export function voltageColorClass(value: number | null | undefined, thresholds: VoltageThresholds | null | undefined): string {
+    if (!thresholds) return 'text-white';
+    return VOLTAGE_STATUS_COLOR[voltageStatus(value, thresholds)];
+}
+
+/** Builds thresholds from a sensor's stored bounds, or null when either is unset (coloring is opt-in). */
+export function thresholdsOrNull(warning: number | null | undefined, critical: number | null | undefined): VoltageThresholds | null {
+    if (warning === null || warning === undefined || critical === null || critical === undefined) return null;
+    return { warning, critical };
+}

--- a/src/services/sensorService.ts
+++ b/src/services/sensorService.ts
@@ -15,6 +15,18 @@ export interface Sensor {
     suspended?: boolean;
     /** The caller's relationship to this sensor. When absent, as returned by older API builds, it is treated as 'owner'. */
     access?: SensorAccess;
+    /** Voltage color thresholds the caller set for this sensor. Both null when unset — the reading is then left uncolored. */
+    warningVoltage?: number | null;
+    criticalVoltage?: number | null;
+}
+
+/** Stored voltage color thresholds returned by the thresholds endpoint. */
+export interface VoltageThreshold {
+    userId: string;
+    sensorId: number;
+    warningVoltage: number;
+    criticalVoltage: number;
+    createdAt: string;
 }
 
 /** What the caller may do with a sensor: full owner, editor, or read-only viewer. */
@@ -206,6 +218,23 @@ const SensorService = {
             return response.data;
         } catch (error: unknown) {
             throw new Error(formatApiError(error, 'Failed to update custom name'));
+        }
+    },
+
+    async updateVoltageThresholds(id: number, warningVoltage: number, criticalVoltage: number): Promise<VoltageThreshold> {
+        try {
+            const response = await axiosInstance.patch<VoltageThreshold>(`/sensors/${id}/voltage-thresholds`, { warningVoltage, criticalVoltage });
+            return response.data;
+        } catch (error: unknown) {
+            throw new Error(formatApiError(error, 'Failed to save voltage thresholds'));
+        }
+    },
+
+    async clearVoltageThresholds(id: number): Promise<void> {
+        try {
+            await axiosInstance.delete(`/sensors/${id}/voltage-thresholds`);
+        } catch (error: unknown) {
+            throw new Error(formatApiError(error, 'Failed to clear voltage thresholds'));
         }
     },
 

--- a/src/tests/components/DeviceDrawerVoltage.test.tsx
+++ b/src/tests/components/DeviceDrawerVoltage.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+const { updateVoltageThresholds, clearVoltageThresholds, getMultipleSensorsData, toastSuccess, toastError } = vi.hoisted(() => ({
+    updateVoltageThresholds: vi.fn(() => Promise.resolve({})),
+    clearVoltageThresholds: vi.fn(() => Promise.resolve()),
+    getMultipleSensorsData: vi.fn(() => Promise.resolve({ data: [], totalCount: 0 })),
+    toastSuccess: vi.fn(),
+    toastError: vi.fn(),
+}))
+
+vi.mock('@/services/sensorService', () => ({
+    default: {
+        getMultipleSensorsData,
+        updateCustomName: vi.fn(() => Promise.resolve({})),
+        updateVoltageThresholds,
+        clearVoltageThresholds,
+    },
+}))
+vi.mock('@/services/sensorPhotoService', () => ({
+    default: { get: vi.fn(() => Promise.resolve(null)) },
+}))
+vi.mock('@/components/ActivitiesSection', () => ({ default: () => null }))
+vi.mock('sonner', () => ({ toast: { success: toastSuccess, error: toastError } }))
+vi.mock('next/dynamic', () => ({ default: () => () => null }))
+
+import DeviceDrawer from '@/app/DeviceDrawer'
+import type { UnifiedDevice } from '@/app/DeviceDashboard'
+import type { Sensor } from '@/services/sensorService'
+
+function makeVoltage(overrides: Partial<Sensor> = {}): UnifiedDevice {
+    return {
+        kind: 'sensor',
+        id: 7,
+        displayName: 'Bike battery',
+        type: 'voltage',
+        latestValue: 12.3,
+        isActive: true,
+        rawSensor: {
+            id: 7,
+            name: 'garge_b43a4536a89c_voltage',
+            type: 'voltage',
+            role: 'voltage',
+            customName: 'Bike battery',
+            defaultName: 'Voltage',
+            registrationCode: 'x',
+            parentName: 'garge_b43a4536a89c',
+            warningVoltage: null,
+            criticalVoltage: null,
+            ...overrides,
+        },
+    }
+}
+
+beforeEach(() => vi.clearAllMocks())
+
+describe('DeviceDrawer voltage thresholds', () => {
+    it('saves warning + critical thresholds and notifies the parent', async () => {
+        const onThresholdsChange = vi.fn()
+        render(<DeviceDrawer device={makeVoltage()} onClose={() => {}} onRename={() => {}} onThresholdsChange={onThresholdsChange} />)
+
+        const saveBtn = await screen.findByRole('button', { name: 'Save' })
+        fireEvent.change(screen.getByLabelText('Warning voltage'), { target: { value: '12.4' } })
+        fireEvent.change(screen.getByLabelText('Critical voltage'), { target: { value: '12.0' } })
+
+        fireEvent.click(saveBtn)
+
+        await waitFor(() => expect(updateVoltageThresholds).toHaveBeenCalledWith(7, 12.4, 12.0))
+        expect(onThresholdsChange).toHaveBeenCalledWith(7, 12.4, 12.0)
+        await waitFor(() => expect(toastSuccess).toHaveBeenCalledWith('Voltage thresholds saved'))
+    })
+
+    it('blocks saving when warning is not above critical', async () => {
+        render(<DeviceDrawer device={makeVoltage()} onClose={() => {}} onRename={() => {}} />)
+
+        const saveBtn = await screen.findByRole('button', { name: 'Save' })
+        fireEvent.change(screen.getByLabelText('Warning voltage'), { target: { value: '11.0' } })
+        fireEvent.change(screen.getByLabelText('Critical voltage'), { target: { value: '12.0' } })
+
+        expect(saveBtn).toBeDisabled()
+        expect(updateVoltageThresholds).not.toHaveBeenCalled()
+    })
+
+    it('clears thresholds via Turn off when already set', async () => {
+        const onThresholdsChange = vi.fn()
+        render(
+            <DeviceDrawer
+                device={makeVoltage({ warningVoltage: 12.4, criticalVoltage: 12.0 })}
+                onClose={() => {}}
+                onRename={() => {}}
+                onThresholdsChange={onThresholdsChange}
+            />,
+        )
+
+        fireEvent.click(await screen.findByRole('button', { name: 'Turn off' }))
+
+        await waitFor(() => expect(clearVoltageThresholds).toHaveBeenCalledWith(7))
+        expect(onThresholdsChange).toHaveBeenCalledWith(7, null, null)
+    })
+})

--- a/src/tests/lib/voltageThresholds.test.ts
+++ b/src/tests/lib/voltageThresholds.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import {
+    voltageStatus,
+    voltageColorClass,
+    thresholdsOrNull,
+    VOLTAGE_STATUS_COLOR,
+} from '@/lib/voltageThresholds'
+
+const thresholds = { warning: 12.4, critical: 12.0 }
+
+describe('voltageStatus', () => {
+    it('is normal at or above the warning threshold', () => {
+        expect(voltageStatus(12.4, thresholds)).toBe('normal')
+        expect(voltageStatus(13.8, thresholds)).toBe('normal')
+    })
+
+    it('is warning between critical and warning', () => {
+        expect(voltageStatus(12.39, thresholds)).toBe('warning')
+        expect(voltageStatus(12.0, thresholds)).toBe('warning')
+    })
+
+    it('is critical below the critical threshold', () => {
+        expect(voltageStatus(11.99, thresholds)).toBe('critical')
+        expect(voltageStatus(0, thresholds)).toBe('critical')
+    })
+
+    it('treats missing or non-finite values as normal', () => {
+        expect(voltageStatus(null, thresholds)).toBe('normal')
+        expect(voltageStatus(undefined, thresholds)).toBe('normal')
+        expect(voltageStatus(NaN, thresholds)).toBe('normal')
+    })
+
+    it('lets critical win when thresholds are misconfigured (warning <= critical)', () => {
+        expect(voltageStatus(12.2, { warning: 12.0, critical: 12.4 })).toBe('critical')
+    })
+})
+
+describe('voltageColorClass', () => {
+    it('returns white when thresholds are unset (opt-in coloring)', () => {
+        expect(voltageColorClass(11.0, null)).toBe('text-white')
+        expect(voltageColorClass(11.0, undefined)).toBe('text-white')
+    })
+
+    it('maps each status to its color', () => {
+        expect(voltageColorClass(12.6, thresholds)).toBe(VOLTAGE_STATUS_COLOR.normal)
+        expect(voltageColorClass(12.2, thresholds)).toBe(VOLTAGE_STATUS_COLOR.warning)
+        expect(voltageColorClass(11.5, thresholds)).toBe(VOLTAGE_STATUS_COLOR.critical)
+    })
+})
+
+describe('thresholdsOrNull', () => {
+    it('builds thresholds when both bounds are present', () => {
+        expect(thresholdsOrNull(12.4, 12.0)).toEqual({ warning: 12.4, critical: 12.0 })
+    })
+
+    it('returns null when either bound is missing', () => {
+        expect(thresholdsOrNull(12.4, null)).toBeNull()
+        expect(thresholdsOrNull(null, 12.0)).toBeNull()
+        expect(thresholdsOrNull(undefined, undefined)).toBeNull()
+    })
+})


### PR DESCRIPTION
## Summary

Adds opt-in per-sensor voltage coloring on the My Devices page. A voltage reading shows green/yellow/red based on warning and critical thresholds the user sets in the device side panel; readings stay uncolored until configured.

- `voltageThresholds` lib (status + Tailwind color mapping) with unit tests.
- `sensorService`: `warningVoltage`/`criticalVoltage` fields plus update/clear calls.
- Color the device card and group-chip values from the sensor thresholds.
- Threshold editor in the device drawer (save / turn off), persisted via the API.

Depends on garge-api PR `feat: per-user voltage color thresholds` for the fields and endpoints.
