### PR TITLE
fix: make chart toolbar visible on dark UI

### DIFF
--- a/src/app/DeviceDrawer.tsx
+++ b/src/app/DeviceDrawer.tsx
@@ -408,7 +408,7 @@ const DeviceDrawer: React.FC<DeviceDrawerProps> = ({ device, onClose, onRename, 
             >
 
                 {/* Sticky header */}
-                <div className="sticky top-0 bg-gray-950/95 backdrop-blur-xl border-b border-gray-800/60 px-5 py-4 flex items-center gap-3 z-10">
+                <div className="sticky top-0 bg-gray-950/95 backdrop-blur-xl border-b border-gray-800/60 px-5 py-4 flex items-center gap-3 z-20">
                     <div className={`w-10 h-10 rounded-xl flex items-center justify-center flex-shrink-0 ${iconBg}`}>
                         <Icon className={`h-5 w-5 ${iconColor}`} />
                     </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -112,3 +112,8 @@ body {
     background-color: #0284c7 !important;
     color: #fff !important;
 }
+
+/* ApexCharts toolbar background */
+.apexcharts-toolbar {
+    background: #131b29 !important;
+}

--- a/src/components/TimeSeriesChart.tsx
+++ b/src/components/TimeSeriesChart.tsx
@@ -33,8 +33,15 @@ const TimeSeriesChart: React.FC<TimeSeriesChartProps> = ({ title, data, chartTyp
     const xMax = data.length > 0 ? Math.max(...data.map(d => d.x)) : undefined;
 
     const options: ApexOptions = useMemo(() => ({
+        // Dark mode so the toolbar icons (zoom/pan/reset) render light against the dark UI.
+        theme: {
+            mode: 'dark'
+        },
+        // Pin the series color; dark mode otherwise swaps in a different default palette.
+        colors: ['#008ffb'],
         chart: {
             type: effectiveType,
+            background: 'transparent',
             height: 350,
             animations: {
                 enabled: false


### PR DESCRIPTION
- Set the time series chart to ApexCharts dark theme, pin the series color to `#008ffb`, and set `chart.background` to `transparent`.
- Set the toolbar background to the garge surface color `#131b29` in CSS (ApexCharts has no chart option for it).
- Raise the device drawer header above the chart toolbar (`z-20`) so the toolbar no longer overlaps the sticky header when scrolling.
